### PR TITLE
Use rst syntax for link in install instructions

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -21,5 +21,4 @@ Or to upgrade to the most recent version::
     pip install fs --upgrade
 
 Alternatively, if you would like to install from source, you can check
-out [the code from
-Github](https://github.com/PyFilesystem/pyfilesystem2).
+out `the code from Github <https://github.com/PyFilesystem/pyfilesystem2>`_.


### PR DESCRIPTION
not a markdown file after all