### PR TITLE
Use UTC timezone on _parse_time

### DIFF
--- a/fs/_ftp_parse.py
+++ b/fs/_ftp_parse.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import re
 import time
+import calendar
 
 from .enums import ResourceType
 from .permissions import Permissions
@@ -70,9 +71,9 @@ def _parse_time(t):
         # Unknown time format
         return None
 
-    epoch_time = time.mktime((
+    epoch_time = calendar.timegm((
         _t.tm_year if _t.tm_year != 1900 else time.localtime().tm_year,
-        _t.tm_mon, _t.tm_mday - 1, _t.tm_hour, _t.tm_min, 0, 0, 0, 0
+        _t.tm_mon, _t.tm_mday - 1, _t.tm_hour, _t.tm_min, 0, 0, 0, 0, 'UTC'
     ))
 
     return epoch_time

--- a/tests/test_ftp_parse.py
+++ b/tests/test_ftp_parse.py
@@ -106,5 +106,3 @@ drwxr-xr-x   12 0        0            4096 Sep 29 13:13 pub
 
         parsed = ftp_parse.parse(directory.splitlines())
         self.assertEqual(parsed, expected)
-
-


### PR DESCRIPTION
Fixes test error on non-UTC timezone system like mine (AST which is UTC+3:00). Here the output of the ./runtests.sh before this patch:
```
.....
======================================================================
FAIL: test_decode_linux (tests.test_ftp_parse.TestFTPParse)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/xxx/Code/pyfilesystem2/tests/test_ftp_parse.py", line 108, in test_decode_linux
    self.assertEqual(parsed, expected)
AssertionError: Lists differ: [{'basic': {'is_dir': True, 'name': 'debian'[1530 chars]t'}}] != [{'access': {'permissions': ['g_r', 'g_w', '[1530 chars]t'}}]

First differing element 0:
{'basic': {'is_dir': True, 'name': 'debian'[282 chars]an'}}
{'access': {'permissions': ['g_r', 'g_w', '[282 chars]an'}}

Diff is 3098 characters long. Set self.maxDiff to None to see it.

======================================================================
FAIL: test_parse_time (tests.test_ftp_parse.TestFTPParse)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/xxx/Code/pyfilesystem2/tests/test_ftp_parse.py", line 15, in test_parse_time
    142128000.0
AssertionError: 142117200.0 != 142128000.0
.....
Ran 651 tests in 1.248s

FAILED (failures=2)
```
Note that 142128000.0 - 142117200.0 = 3hours.