### PR TITLE
Fixed UnicodeEncodeError when creating OSFS from non-ascii path

### DIFF
--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -110,9 +110,12 @@ class OSFS(FS):
             _meta["invalid_path_chars"] = '\0'
 
             if 'PC_PATH_MAX' in os.pathconf_names:
+                root_path_safe = _root_path.encode(self.encoding) \
+                    if six.PY2 and isinstance(_root_path, six.text_type) \
+                    else _root_path
                 _meta['max_sys_path_length'] = (
                     os.pathconf(
-                        _root_path,
+                        root_path_safe,
                         os.pathconf_names['PC_PATH_MAX']
                     )
                 )

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -84,3 +84,13 @@ class TestOSFS(FSTestCases, unittest.TestCase):
             with self.assertRaises(errors.CreateFailed):
                 # Trying to create a dir that exists as a file
                 osfs.OSFS(tmp_file.name, create=True)
+
+    def test_unicode_paths(self):
+        dir_path = tempfile.mkdtemp()
+        try:
+            fs_dir = os.path.join(dir_path, u'te\u0161t_\u00fanicod\u0113')
+            os.mkdir(fs_dir)
+            with osfs.OSFS(fs_dir):
+                self.assertTrue(os.path.isdir(fs_dir))
+        finally:
+            shutil.rmtree(dir_path)


### PR DESCRIPTION
It seems that os.pathconf has issues with unicode paths in Python 2 as it tries to decode to ascii despite locale settings. It string is encoded to bytes first, then everything works fine.

Tested on linux-3.13.0-110-generic/Python 2.7.6.