### PR TITLE
Fix documentation for "Moving and Copying"

### DIFF
--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -219,6 +219,6 @@ The :func:`~fs.copy.copy_fs` and :func:`~fs.copy.copy_dir` functions also accept
 
     >>> from fs.copy import copy_fs
     >>> from fs.walk import Walker
-    >>> copy_fs('~/projects', 'zip://projects.zip', walker=Walker(files=['*.py']))
+    >>> copy_fs('~/projects', 'zip://projects.zip', walker=Walker(filter=['*.py']))
 
 


### PR DESCRIPTION
In ab15ba72d885cf8b02ed14009d551a9a9aa61957 the code for Walker() was [changed](https://github.com/PyFilesystem/pyfilesystem2/commit/ab15ba72d885cf8b02ed14009d551a9a9aa61957#diff-edbf11fed744b9aee494554ab2d36c74L119) to accept "filter" instead of "wildcards". The documentation was also [changed](https://github.com/PyFilesystem/pyfilesystem2/commit/ab15ba72d885cf8b02ed14009d551a9a9aa61957#diff-edd835f0f9f7dac8265dec2cc5776a67L131) but from "wildcards" to "files" which is wrong, obviously.