### PR TITLE
Use PEP-496 syntax to resolve #41

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 appdirs==1.4.0
 enum34==1.1.6 ; python_version < '3.4'
 pytz
-scandir==1.3
+scandir==1.3 ; python_version < '3.5'
 setuptools
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.0
-enum34==1.1.6
+enum34==1.1.6 ; python_version < '3.4'
 pytz
 scandir==1.3
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('README.rst', 'rt') as f:
 
 REQUIREMENTS = [
     "appdirs~=1.4.0",
-    "enum34~=1.1.6",
+    "enum34~=1.1.6 ; python_version < '3.4'",
     "pytz",
     "setuptools",
     "six~=1.10.0",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ with open('README.rst', 'rt') as f:
 
 REQUIREMENTS = [
     "appdirs~=1.4.0",
-    "enum34~=1.1.6 ; python_version < '3.4'",
     "pytz",
     "setuptools",
     "six~=1.10.0",
@@ -37,7 +36,8 @@ setup(
     description="Python's filesystem abstraction layer",
     install_requires=REQUIREMENTS,
     extras_require={
-        ":python_version<'3.5'": ['scandir~=1.5'],
+        ":python_version < '3.5'": ['scandir~=1.5'],
+        ":python_version < '3.4'": ['enum34~=1.1.6']
     },
     license="BSD",
     long_description=DESCRIPTION,


### PR DESCRIPTION
I just made the `enum32` a conditional requirement depending on the python version ;  this should be enough to fix #41.