### PR TITLE
Make scandir an optional dependency

### DIFF
--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -367,73 +367,68 @@ class OSFS(FS):
                         os.utime(sys_path, (accessed, modified))
 
 
-
-    def _scandir_c(self, path, namespaces=None):
-        self.check()
-        namespaces = namespaces or ()
-        _path = self.validatepath(path)
-        sys_path = self._to_sys_path(_path)
-        with convert_os_errors('scandir', path, directory=True):
-            for dir_entry in scandir(sys_path):
-                info = {
-                    "basic": {
-                        "name": dir_entry.name,
-                        "is_dir": dir_entry.is_dir()
+    if scandir:
+        def _scandir(self, path, namespaces=None):
+            self.check()
+            namespaces = namespaces or ()
+            _path = self.validatepath(path)
+            sys_path = self._to_sys_path(_path)
+            with convert_os_errors('scandir', path, directory=True):
+                for dir_entry in scandir(sys_path):
+                    info = {
+                        "basic": {
+                            "name": dir_entry.name,
+                            "is_dir": dir_entry.is_dir()
+                        }
                     }
-                }
-                if 'details' in namespaces:
-                    stat_result = dir_entry.stat()
-                    info['details'] = \
-                        self._make_details_from_stat(stat_result)
-                if 'stat' in namespaces:
-                    stat_result = dir_entry.stat()
-                    info['stat'] = {
-                        k: getattr(stat, k)
-                        for k in dir(stat) if k.startswith('st_')
-                    }
-                if 'access' in namespaces:
-                    stat_result = dir_entry.stat()
-                    info['access'] =\
-                        self._make_access_from_stat(stat_result)
+                    if 'details' in namespaces:
+                        stat_result = dir_entry.stat()
+                        info['details'] = \
+                            self._make_details_from_stat(stat_result)
+                    if 'stat' in namespaces:
+                        stat_result = dir_entry.stat()
+                        info['stat'] = {
+                            k: getattr(stat, k)
+                            for k in dir(stat) if k.startswith('st_')
+                        }
+                    if 'access' in namespaces:
+                        stat_result = dir_entry.stat()
+                        info['access'] =\
+                            self._make_access_from_stat(stat_result)
 
-                yield Info(info)
+                    yield Info(info)
 
-    def _scandir_py(self, path, namespaces=None):
-        self.check()
-        namespaces = namespaces or ()
-        _path = self.validatepath(path)
-        sys_path = self._to_sys_path(_path)
-        with convert_os_errors('scandir', path, directory=True):
-            for entry_name in os.listdir(sys_path):
-                entry_path = os.path.join(sys_path, entry_name)
-                info = {
-                    "basic": {
-                        "name": entry_name,
-                        "is_dir": os.path.isdir(entry_path),
-                    }
-                }
-                if 'details' in namespaces:
-                    stat_result = os.stat(entry_path)
-                    info['details'] = \
-                        self._make_details_from_stat(stat_result)
-                if 'stat' in namespaces:
-                    stat_result = os.stat(entry_path)
-                    info['stat'] = {
-                        k: getattr(stat, k)
-                        for k in dir(stat) if k.startswith('st_')
-                    }
-                if 'access' in namespaces:
-                    stat_result = os.stat(entry_path)
-                    info['access'] =\
-                        self._make_access_from_stat(stat_result)
-
-                yield Info(info)
-
-    # Set the method used by OSFS.scandir
-    if scandir is None:
-        _scandir = _scandir_py
     else:
-        _scandir = _scandir_c
+
+        def _scandir(self, path, namespaces=None):
+            self.check()
+            namespaces = namespaces or ()
+            _path = self.validatepath(path)
+            sys_path = self._to_sys_path(_path)
+            with convert_os_errors('scandir', path, directory=True):
+                for entry_name in os.listdir(sys_path):
+                    entry_path = os.path.join(sys_path, entry_name)
+                    stat_result = os.stat(entry_path)
+                    info = {
+                        "basic": {
+                            "name": entry_name,
+                            "is_dir": stat.S_ISDIR(stat_result.st_mode),
+                        }
+                    }
+                    if 'details' in namespaces:
+                        info['details'] = \
+                            self._make_details_from_stat(stat_result)
+                    if 'stat' in namespaces:
+                        info['stat'] = {
+                            k: getattr(stat, k)
+                            for k in dir(stat) if k.startswith('st_')
+                        }
+                    if 'access' in namespaces:
+                        info['access'] =\
+                            self._make_access_from_stat(stat_result)
+
+                    yield Info(info)
+
 
     def scandir(self, path, namespaces=None, page=None):
         iter_info = self._scandir(path, namespaces=namespaces)

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -13,13 +13,13 @@ import sys
 
 import six
 
-# try:
-#     from os import scandir
-# except ImportError:
-#     try:
-#         from scandir import scandir
-#     except ImportError:
-scandir = None
+try:
+    from os import scandir
+except ImportError:
+    try:
+        from scandir import scandir
+    except ImportError:
+        scandir = None
 
 from . import errors
 from .errors import FileExists
@@ -366,71 +366,74 @@ class OSFS(FS):
                     with convert_os_errors('setinfo', path):
                         os.utime(sys_path, (accessed, modified))
 
-    if scandir is not None:
 
-        def _scandir(self, path, namespaces=None):
-            self.check()
-            namespaces = namespaces or ()
-            _path = self.validatepath(path)
-            sys_path = self._to_sys_path(_path)
-            with convert_os_errors('scandir', path, directory=True):
-                for dir_entry in scandir(sys_path):
-                    info = {
-                        "basic": {
-                            "name": dir_entry.name,
-                            "is_dir": dir_entry.is_dir()
-                        }
+
+    def _scandir_c(self, path, namespaces=None):
+        self.check()
+        namespaces = namespaces or ()
+        _path = self.validatepath(path)
+        sys_path = self._to_sys_path(_path)
+        with convert_os_errors('scandir', path, directory=True):
+            for dir_entry in scandir(sys_path):
+                info = {
+                    "basic": {
+                        "name": dir_entry.name,
+                        "is_dir": dir_entry.is_dir()
                     }
-                    if 'details' in namespaces:
-                        stat_result = dir_entry.stat()
-                        info['details'] = \
-                            self._make_details_from_stat(stat_result)
-                    if 'stat' in namespaces:
-                        stat_result = dir_entry.stat()
-                        info['stat'] = {
-                            k: getattr(stat, k)
-                            for k in dir(stat) if k.startswith('st_')
-                        }
-                    if 'access' in namespaces:
-                        stat_result = dir_entry.stat()
-                        info['access'] =\
-                            self._make_access_from_stat(stat_result)
+                }
+                if 'details' in namespaces:
+                    stat_result = dir_entry.stat()
+                    info['details'] = \
+                        self._make_details_from_stat(stat_result)
+                if 'stat' in namespaces:
+                    stat_result = dir_entry.stat()
+                    info['stat'] = {
+                        k: getattr(stat, k)
+                        for k in dir(stat) if k.startswith('st_')
+                    }
+                if 'access' in namespaces:
+                    stat_result = dir_entry.stat()
+                    info['access'] =\
+                        self._make_access_from_stat(stat_result)
 
-                    yield Info(info)
+                yield Info(info)
 
+    def _scandir_py(self, path, namespaces=None):
+        self.check()
+        namespaces = namespaces or ()
+        _path = self.validatepath(path)
+        sys_path = self._to_sys_path(_path)
+        with convert_os_errors('scandir', path, directory=True):
+            for entry_name in os.listdir(sys_path):
+                entry_path = os.path.join(sys_path, entry_name)
+                info = {
+                    "basic": {
+                        "name": entry_name,
+                        "is_dir": os.path.isdir(entry_path),
+                    }
+                }
+                if 'details' in namespaces:
+                    stat_result = os.stat(entry_path)
+                    info['details'] = \
+                        self._make_details_from_stat(stat_result)
+                if 'stat' in namespaces:
+                    stat_result = os.stat(entry_path)
+                    info['stat'] = {
+                        k: getattr(stat, k)
+                        for k in dir(stat) if k.startswith('st_')
+                    }
+                if 'access' in namespaces:
+                    stat_result = os.stat(entry_path)
+                    info['access'] =\
+                        self._make_access_from_stat(stat_result)
+
+                yield Info(info)
+
+    # Set the method used by OSFS.scandir
+    if scandir is None:
+        _scandir = _scandir_py
     else:
-
-        def _scandir(self, path, namespaces=None):
-            self.check()
-            namespaces = namespaces or ()
-            _path = self.validatepath(path)
-            sys_path = self._to_sys_path(_path)
-            with convert_os_errors('scandir', path, directory=True):
-                for entry_name in os.listdir(sys_path):
-                    entry_path = os.path.join(sys_path, entry_name)
-                    info = {
-                        "basic": {
-                            "name": entry_name,
-                            "is_dir": os.path.isdir(entry_path),
-                        }
-                    }
-                    if 'details' in namespaces:
-                        stat_result = os.stat(entry_path)
-                        info['details'] = \
-                            self._make_details_from_stat(stat_result)
-                    if 'stat' in namespaces:
-                        stat_result = os.stat(entry_path)
-                        info['stat'] = {
-                            k: getattr(stat, k)
-                            for k in dir(stat) if k.startswith('st_')
-                        }
-                    if 'access' in namespaces:
-                        stat_result = os.stat(entry_path)
-                        info['access'] =\
-                            self._make_access_from_stat(stat_result)
-
-                    yield Info(info)
-
+        _scandir = _scandir_c
 
     def scandir(self, path, namespaces=None, page=None):
         iter_info = self._scandir(path, namespaces=namespaces)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 appdirs==1.4.0
 enum34==1.1.6
 pytz
-scandir==1.3
 setuptools
 six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     description="Python's filesystem abstraction layer",
     install_requires=REQUIREMENTS,
     extras_require={
-        ":python_version<'3.5'": ['scandir~=1.5'],
+        "scandir : python_version < '3.5'": ['scandir~=1.5'],
     },
     license="BSD",
     long_description=DESCRIPTION,

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -17,7 +17,7 @@ from fs.test import FSTestCases
 from six import text_type
 
 
-class OSFSTestBase(FSTestCases, unittest.TestCase):
+class TestOSFS(FSTestCases, unittest.TestCase):
     """Test OSFS implementation."""
 
     def make_fs(self):
@@ -94,19 +94,3 @@ class OSFSTestBase(FSTestCases, unittest.TestCase):
                 self.assertTrue(os.path.isdir(fs_dir))
         finally:
             shutil.rmtree(dir_path)
-
-
-class TestOSFS(OSFSTestBase, unittest.TestCase):
-    pass
-
-
-class TestOSFSScandir(OSFSTestBase, unittest.TestCase):
-
-    def test_scandir_purepython(self):
-        with mock.patch.object(self.fs, '_scandir', self.fs._scandir_py):
-            self.test_scandir()
-
-    @unittest.skipIf(osfs.scandir is None, "scandir not available.")
-    def test_scandir_c_extension(self):
-        with mock.patch.object(self.fs, '_scandir', self.fs._scandir_c):
-            self.test_scandir()

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -17,7 +17,7 @@ from fs.test import FSTestCases
 from six import text_type
 
 
-class TestOSFS(FSTestCases, unittest.TestCase):
+class OSFSTestBase(FSTestCases, unittest.TestCase):
     """Test OSFS implementation."""
 
     def make_fs(self):
@@ -96,7 +96,11 @@ class TestOSFS(FSTestCases, unittest.TestCase):
             shutil.rmtree(dir_path)
 
 
-class TestOSFSScandir(TestOSFS):
+class TestOSFS(OSFSTestBase, unittest.TestCase):
+    pass
+
+
+class TestOSFSScandir(OSFSTestBase, unittest.TestCase):
 
     def test_scandir_purepython(self):
         with mock.patch.object(self.fs, '_scandir', self.fs._scandir_py):

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -94,3 +94,15 @@ class TestOSFS(FSTestCases, unittest.TestCase):
                 self.assertTrue(os.path.isdir(fs_dir))
         finally:
             shutil.rmtree(dir_path)
+
+
+class TestOSFSScandir(TestOSFS):
+
+    def test_scandir_purepython(self):
+        with mock.patch.object(self.fs, '_scandir', self.fs._scandir_py):
+            self.test_scandir()
+
+    @unittest.skipIf(osfs.scandir is None, "scandir not available.")
+    def test_scandir_c_extension(self):
+        with mock.patch.object(self.fs, '_scandir', self.fs._scandir_c):
+            self.test_scandir()

--- a/tox.ini
+++ b/tox.ini
@@ -13,3 +13,11 @@ deps = appdirs
 commands = nosetests tests -v \
 	[]
 
+[testenv:pure-python]
+deps = appdirs
+    nose
+    mock
+    pyftpdlib
+    pytz
+commands = nosetests tests -v \
+        []


### PR DESCRIPTION
Hi,
I just noticed while trying to install `fs` on the `alpine-python` Docker image that it had `scandir` as a hard requirement. Since `scandir` is a C extension, this meant that **1.** implementations other than CPython couldn't use *Pyfilesystem2*, and that **2.** it required C compilation, so minimal builds needed to have both a C compiler and Python headers installed, both of which can weigh a lot. 

With the edits in that PR, the `scandir` module will be used if it can be found (either `scandir` is installed or the version is superior to **3.5**). In other cases, plain `os.listdir` module will be used.