### PR TITLE
Feat iobase (PR for #50)

### DIFF
--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -132,8 +132,8 @@ class FTPFile(io.IOBase):
         return _repr.format(self.fs.ftp_url, self.path, self.mode)
 
     def close(self):
-        with self._lock:
-            if not self.closed:
+        if not self.closed:
+            with self._lock:
                 try:
                     if self._write_conn is not None:
                         self._write_conn.close()
@@ -252,7 +252,6 @@ class FTPFile(io.IOBase):
             if self._write_conn:
                 self._write_conn.close()
                 self._write_conn = None
-
 
 
 class FTPFS(FS):

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -131,26 +131,6 @@ class FTPFile(io.IOBase):
         _repr = "<ftpfile {!r} {!r} {!r}>"
         return _repr.format(self.fs.ftp_url, self.path, self.mode)
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
-
-    def __iter__(self):
-        return line_iterator(self)
-
-    def __del__(self):
-        self.close()
-
-    def flush(self):
-        pass
-
-    def next(self):
-        return self.readline()
-
-    __next__ = next
-
     def close(self):
         with self._lock:
             if not self.closed:

--- a/fs/iotools.py
+++ b/fs/iotools.py
@@ -19,9 +19,12 @@ class RawWrapper(io.IOBase):
         super(RawWrapper, self).__init__()
 
     def close(self):
-        if not self._f.closed:
+        if not self.closed:
+            # Close self first since it will
+            # flush itself, so we can't close
+            # self._f before that
             super(RawWrapper, self).close()
-        self._f.close()
+            self._f.close()
 
     def fileno(self):
         return self._f.fileno()
@@ -112,7 +115,6 @@ class RawWrapper(io.IOBase):
 
     def __iter__(self):
         return iter(self._f)
-
 
 
 

--- a/fs/iotools.py
+++ b/fs/iotools.py
@@ -9,19 +9,21 @@ from io import SEEK_SET, SEEK_CUR
 from .mode import Mode
 
 
-class RawWrapper(object):
+class RawWrapper(io.IOBase):
     """Convert a Python 2 style file-like object in to a IO object."""
 
     def __init__(self, f, mode=None, name=None):
         self._f = f
         self.mode = mode or getattr(f, 'mode', None)
         self.name = name
-        self.closed = False
         super(RawWrapper, self).__init__()
 
     def close(self):
+        if not self._f.closed:
+            super(RawWrapper, self).close()
         self._f.close()
-        self.closed = True
+            # self._f.close()
+            # self._closed = True
 
     def fileno(self):
         return self._f.fileno()

--- a/fs/iotools.py
+++ b/fs/iotools.py
@@ -22,8 +22,6 @@ class RawWrapper(io.IOBase):
         if not self._f.closed:
             super(RawWrapper, self).close()
         self._f.close()
-            # self._f.close()
-            # self._closed = True
 
     def fileno(self):
         return self._f.fileno()

--- a/fs/iotools.py
+++ b/fs/iotools.py
@@ -112,17 +112,10 @@ class RawWrapper(io.IOBase):
     def writelines(self, sequence):
         return self._f.writelines(sequence)
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        self.close()
-
     def __iter__(self):
         return iter(self._f)
 
-    def __del__(self):
-        self.close()
+
 
 
 def make_stream(name,

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -92,11 +92,10 @@ class _MemoryFile(io.IOBase):
             return self._bytes_io.readline(*args, **kwargs)
 
     def close(self):
-        with self._lock:
-            if not self.closed:
+        if not self.closed:
+            with self._lock:
                 self._memory_fs._on_close_file(self, self._path)
-            super(_MemoryFile, self).close()
-            #self.closed = True
+                super(_MemoryFile, self).close()
 
     def read(self, size=None):
         if not self._mode.reading:

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -34,7 +34,6 @@ class _MemoryFile(io.IOBase):
 
         self.accessed_time = time.time()
         self.modified_time = time.time()
-        #self.closed = False
         self.pos = 0
 
         if self._mode.truncate:
@@ -149,12 +148,6 @@ class _MemoryFile(io.IOBase):
         with self._seek_lock():
             self.on_modify()
             self._bytes_io.writelines(sequence)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
 
 
 class _DirEntry(object):

--- a/fs/test.py
+++ b/fs/test.py
@@ -665,6 +665,9 @@ class FSTestCases(object):
 
         with self.fs.open('foo/hello', 'wt') as f:
             repr(f)
+            self.assertIsInstance(f, io.IOBase)
+            self.assertTrue(f.writable())
+            self.assertFalse(f.readable())
             f.write(text)
 
         with self.assertRaises(errors.FileExists):
@@ -673,6 +676,9 @@ class FSTestCases(object):
 
         # Read it back
         with self.fs.open('foo/hello', 'rt') as f:
+            self.assertIsInstance(f, io.IOBase)
+            self.assertTrue(f.readable())
+            self.assertFalse(f.writable())
             hello = f.read()
         self.assertEqual(hello, text)
         self.assert_text('foo/hello', text)
@@ -708,6 +714,9 @@ class FSTestCases(object):
 
         with self.fs.openbin('foo/hello', 'w') as f:
             repr(f)
+            self.assertIsInstance(f, io.IOBase)
+            self.assertTrue(f.writable())
+            self.assertFalse(f.readable())
             f.write(text)
 
         with self.assertRaises(errors.FileExists):
@@ -716,6 +725,9 @@ class FSTestCases(object):
 
         # Read it back
         with self.fs.openbin('foo/hello', 'r') as f:
+            self.assertIsInstance(f, io.IOBase)
+            self.assertTrue(f.readable())
+            self.assertFalse(f.writable())
             hello = f.read()
         self.assertEqual(hello, text)
         self.assert_bytes('foo/hello', text)
@@ -749,6 +761,9 @@ class FSTestCases(object):
         with self.fs.open('text', 'w') as f:
             repr(f)
             text_type(f)
+            self.assertIsInstance(f, io.IOBase)
+            self.assertTrue(f.writable())
+            self.assertFalse(f.readable())
             self.assertEqual(f.tell(), 0)
             f.write('Hello\nWorld\n')
             self.assertEqual(f.tell(), 12)
@@ -763,6 +778,9 @@ class FSTestCases(object):
         with self.fs.open('text', 'r') as f:
             repr(f)
             text_type(f)
+            self.assertIsInstance(f, io.IOBase)
+            self.assertFalse(f.writable())
+            self.assertTrue(f.readable())
             self.assertEqual(
                 f.readlines(),
                 ['Hello\n', 'World\n', 'foo\n', 'bar\n', 'baz\n']
@@ -771,6 +789,9 @@ class FSTestCases(object):
                 f.write('no')
 
         with self.fs.open('text', 'rb') as f:
+            self.assertIsInstance(f, io.IOBase)
+            self.assertFalse(f.writable())
+            self.assertTrue(f.readable())
             self.assertEqual(
                 f.readlines(8),
                 [b'Hello\n', b'World\n']
@@ -788,6 +809,10 @@ class FSTestCases(object):
         self.assertEqual(next(iter_lines), 'Hello\n')
 
         with self.fs.open('text', 'rb') as f:
+            self.assertIsInstance(f, io.IOBase)
+            self.assertFalse(f.writable())
+            self.assertTrue(f.readable())
+            self.assertTrue(f.seekable())
             self.assertEqual(f.read(1), b'H')
             f.seek(3, Seek.set)
             self.assertEqual(f.read(1), b'l')
@@ -799,6 +824,9 @@ class FSTestCases(object):
                 f.seek(10, 77)
 
         with self.fs.open('text', 'r+b') as f:
+            self.assertIsInstance(f, io.IOBase)
+            self.assertTrue(f.readable())
+            self.assertTrue(f.writable())
             f.seek(5)
             f.truncate()
             f.seek(0)
@@ -818,11 +846,15 @@ class FSTestCases(object):
         with self.fs.openbin('file.bin', 'wb') as write_file:
             repr(write_file)
             text_type(write_file)
+            self.assertIsInstance(write_file, io.IOBase)
+            self.assertTrue(write_file.writable())
             write_file.write(b'\0\1\2')
         # Read a binary file
         with self.fs.openbin('file.bin', 'rb') as read_file:
             repr(write_file)
             text_type(write_file)
+            self.assertIsInstance(read_file, io.IOBase)
+            self.assertTrue(read_file.readable())
             data = read_file.read()
         self.assertEqual(data, b'\0\1\2')
 

--- a/fs/test.py
+++ b/fs/test.py
@@ -668,7 +668,9 @@ class FSTestCases(object):
             self.assertIsInstance(f, io.IOBase)
             self.assertTrue(f.writable())
             self.assertFalse(f.readable())
+            self.assertFalse(f.closed)
             f.write(text)
+        self.assertTrue(f.closed)
 
         with self.assertRaises(errors.FileExists):
             with self.fs.open('foo/hello', 'xt') as f:
@@ -679,7 +681,9 @@ class FSTestCases(object):
             self.assertIsInstance(f, io.IOBase)
             self.assertTrue(f.readable())
             self.assertFalse(f.writable())
+            self.assertFalse(f.closed)
             hello = f.read()
+        self.assertTrue(f.closed)
         self.assertEqual(hello, text)
         self.assert_text('foo/hello', text)
 
@@ -697,10 +701,17 @@ class FSTestCases(object):
         with self.fs.open('foo/hello') as f:
             try:
                 fn = f.fileno()
-            except AttributeError:
+            except io.UnsupportedOperation:
                 pass
             else:
                 self.assertEqual(os.read(fn, 7), b'Goodbye')
+
+        # Test text files are proper iterators over themselves
+        lines = os.linesep.join(["Line 1", "Line 2", "Line 3"])
+        self.fs.settext("iter.txt", lines)
+        with self.fs.open("iter.txt") as f:
+            for actual, expected in zip(f, lines.splitlines(1)):
+                self.assertEqual(actual, expected)
 
     def test_openbin_rw(self):
         # Open a file that doesn't exist
@@ -710,7 +721,7 @@ class FSTestCases(object):
         self.fs.makedir('foo')
 
         # Create a new text file
-        text = b'Hello, World'
+        text = b'Hello, World\n'
 
         with self.fs.openbin('foo/hello', 'w') as f:
             repr(f)
@@ -718,6 +729,8 @@ class FSTestCases(object):
             self.assertTrue(f.writable())
             self.assertFalse(f.readable())
             f.write(text)
+            self.assertFalse(f.closed)
+        self.assertTrue(f.closed)
 
         with self.assertRaises(errors.FileExists):
             with self.fs.openbin('foo/hello', 'x') as f:
@@ -729,6 +742,8 @@ class FSTestCases(object):
             self.assertTrue(f.readable())
             self.assertFalse(f.writable())
             hello = f.read()
+            self.assertFalse(f.closed)
+        self.assertTrue(f.closed)
         self.assertEqual(hello, text)
         self.assert_bytes('foo/hello', text)
 
@@ -750,10 +765,18 @@ class FSTestCases(object):
         with self.fs.openbin('foo/hello') as f:
             try:
                 fn = f.fileno()
-            except AttributeError:
+            except io.UnsupportedOperation:
                 pass
             else:
                 self.assertEqual(os.read(fn, 7), b'Goodbye')
+
+        # Test binary files are proper iterators over themselves
+        lines = b"\n".join([b"Line 1", b"Line 2", b"Line 3"])
+        self.fs.setbytes("iter.bin", lines)
+        with self.fs.openbin("iter.bin") as f:
+            for actual, expected in zip(f, lines.splitlines(1)):
+                self.assertEqual(actual, expected)
+
 
     def test_open_files(self):
         # Test file-like objects work as expected.
@@ -764,12 +787,14 @@ class FSTestCases(object):
             self.assertIsInstance(f, io.IOBase)
             self.assertTrue(f.writable())
             self.assertFalse(f.readable())
+            self.assertFalse(f.closed)
             self.assertEqual(f.tell(), 0)
             f.write('Hello\nWorld\n')
             self.assertEqual(f.tell(), 12)
             f.writelines(['foo\n', 'bar\n', 'baz\n'])
             with self.assertRaises(IOError):
                 f.read(1)
+        self.assertTrue(f.closed)
 
         with self.fs.open('bin', 'wb') as f:
             with self.assertRaises(IOError):
@@ -781,29 +806,35 @@ class FSTestCases(object):
             self.assertIsInstance(f, io.IOBase)
             self.assertFalse(f.writable())
             self.assertTrue(f.readable())
+            self.assertFalse(f.closed)
             self.assertEqual(
                 f.readlines(),
                 ['Hello\n', 'World\n', 'foo\n', 'bar\n', 'baz\n']
             )
             with self.assertRaises(IOError):
                 f.write('no')
+        self.assertTrue(f.closed)
 
         with self.fs.open('text', 'rb') as f:
             self.assertIsInstance(f, io.IOBase)
             self.assertFalse(f.writable())
             self.assertTrue(f.readable())
+            self.assertFalse(f.closed)
             self.assertEqual(
                 f.readlines(8),
                 [b'Hello\n', b'World\n']
             )
             with self.assertRaises(IOError):
                 f.write('no')
+        self.assertTrue(f.closed)
 
         with self.fs.open('text', 'r') as f:
             self.assertEqual(
                 list(f),
                 ['Hello\n', 'World\n', 'foo\n', 'bar\n', 'baz\n']
             )
+            self.assertFalse(f.closed)
+        self.assertTrue(f.closed)
 
         iter_lines = iter(self.fs.open('text'))
         self.assertEqual(next(iter_lines), 'Hello\n')
@@ -813,6 +844,7 @@ class FSTestCases(object):
             self.assertFalse(f.writable())
             self.assertTrue(f.readable())
             self.assertTrue(f.seekable())
+            self.assertFalse(f.closed)
             self.assertEqual(f.read(1), b'H')
             f.seek(3, Seek.set)
             self.assertEqual(f.read(1), b'l')
@@ -822,11 +854,14 @@ class FSTestCases(object):
             self.assertEqual(f.read(1), b'z')
             with self.assertRaises(ValueError):
                 f.seek(10, 77)
+        self.assertTrue(f.closed)
 
         with self.fs.open('text', 'r+b') as f:
             self.assertIsInstance(f, io.IOBase)
             self.assertTrue(f.readable())
             self.assertTrue(f.writable())
+            self.assertTrue(f.seekable())
+            self.assertFalse(f.closed)
             f.seek(5)
             f.truncate()
             f.seek(0)
@@ -840,6 +875,7 @@ class FSTestCases(object):
             f.write(b'O')
             f.seek(4)
             self.assertEqual(f.read(1), b'O')
+        self.assertTrue(f.closed)
 
     def test_openbin(self):
         # Write a binary file
@@ -848,15 +884,22 @@ class FSTestCases(object):
             text_type(write_file)
             self.assertIsInstance(write_file, io.IOBase)
             self.assertTrue(write_file.writable())
+            self.assertFalse(write_file.readable())
+            self.assertFalse(write_file.closed)
             write_file.write(b'\0\1\2')
+        self.assertTrue(write_file.closed)
+
         # Read a binary file
         with self.fs.openbin('file.bin', 'rb') as read_file:
             repr(write_file)
             text_type(write_file)
             self.assertIsInstance(read_file, io.IOBase)
             self.assertTrue(read_file.readable())
+            self.assertFalse(read_file.writable())
+            self.assertFalse(read_file.closed)
             data = read_file.read()
         self.assertEqual(data, b'\0\1\2')
+        self.assertTrue(read_file.closed)
 
         # Check disallow text mode
         with self.assertRaises(ValueError):


### PR DESCRIPTION
#### Lib
* made `FTPFile`, `_MemoryFile` and `RawWrapper` derive from `io.IOBase`
* removed `__enter__`, `_del__` and `__exit__` implementation as the base `io.IOBase` implementation returns `self` in `__enter__` and closes `self` in `__exit__` and `__del__` already.
* removed `RawWrapper` `next` and `__next__` as they only copied the base `io.IOBase` implementation
* implemented `writable` and `readable` depending on the mode of `FS.open` for `FTPFile` and `_MemoryFile`
* implemented `seekable` (always returning `True`) for all three classes

#### Tests
* Check file objects returned by `FS.open` and `FS.openbin` are instances of `io.IOBase`
* Check that `readable` and `writable` return the right value depending on the opening mode
* Check that file objects are not closed within a context block, then closed after
* Check that file objects are iterable over lines
* Fixed test as `f.fileno()` does not raise an `AttributeError` now (since it is implemented by `io.IOBase`) but an `io.UnsupportedOperation` if the subclass didn't reimplement that method.