### PR TITLE
ClosingSubFS

### DIFF
--- a/fs/base.py
+++ b/fs/base.py
@@ -869,15 +869,14 @@ class FS(object):
         )
         return io_stream
 
-    def opendir(self, path, fs_class=None):
+    def opendir(self, path, factory=None):
         """Get a filesystem object for a sub-directory.
 
         :param str path: Path to a directory on the filesystem.
-        :param fs_class: The FS class to map on to the given directory.
-            This will be :class:`~fs.subfs.SubFS` by default, but it is
-            possible to return an instance of the class given here, as
-            long as it has the same signature as
-            :class:`~fs.subfs.SubFS`
+        :param factory: A callable that when invoked with an FS instance
+            and `path` will return a new FS object representing the sub-
+            directory contents. If no `factory` is supplied then
+            :meth:`~fs.subfs.SubFS` will be used.
         :returns: A filesystem object representing a sub-directory.
         :rtype: :class:`~fs.subfs.SubFS`
         :raises fs.errors.DirectoryExpected: If ``dst_path`` does not
@@ -885,13 +884,13 @@ class FS(object):
 
         """
         from .subfs import SubFS
-        fs_class = fs_class or SubFS
+        factory = factory or SubFS
 
         if not self.getbasic(path).is_dir:
             raise errors.DirectoryExpected(
                 path=path
             )
-        return fs_class(self, path)
+        return factory(self, path)
 
     def removetree(self, dir_path):
         """

--- a/fs/base.py
+++ b/fs/base.py
@@ -869,10 +869,15 @@ class FS(object):
         )
         return io_stream
 
-    def opendir(self, path):
+    def opendir(self, path, fs_class=None):
         """Get a filesystem object for a sub-directory.
 
         :param str path: Path to a directory on the filesystem.
+        :param fs_class: The FS class to map on to the given directory.
+            This will be :class:`~fs.subfs.SubFS` by default, but it is
+            possible to return an instance of the class given here, as
+            long as it has the same signature as
+            :class:`~fs.subfs.SubFS`
         :returns: A filesystem object representing a sub-directory.
         :rtype: :class:`~fs.subfs.SubFS`
         :raises fs.errors.DirectoryExpected: If ``dst_path`` does not
@@ -880,12 +885,13 @@ class FS(object):
 
         """
         from .subfs import SubFS
+        fs_class = fs_class or SubFS
 
         if not self.getbasic(path).is_dir:
             raise errors.DirectoryExpected(
                 path=path
             )
-        return SubFS(self, path)
+        return fs_class(self, path)
 
     def removetree(self, dir_path):
         """

--- a/fs/opener/ftpfs.py
+++ b/fs/opener/ftpfs.py
@@ -3,6 +3,7 @@
 
 from ._base import Opener
 from ._registry import registry
+from ..subfs import ClosingSubFS
 
 @registry.install
 class FTPOpener(Opener):
@@ -20,7 +21,7 @@ class FTPOpener(Opener):
             passwd=parse_result.password,
         )
         ftp_fs = (
-            ftp_fs.opendir(dir_path)
+            ftp_fs.opendir(dir_path, fs_class=ClosingSubFS)
             if dir_path else
             ftp_fs
         )

--- a/fs/opener/ftpfs.py
+++ b/fs/opener/ftpfs.py
@@ -21,7 +21,7 @@ class FTPOpener(Opener):
             passwd=parse_result.password,
         )
         ftp_fs = (
-            ftp_fs.opendir(dir_path, fs_class=ClosingSubFS)
+            ftp_fs.opendir(dir_path, factory=ClosingSubFS)
             if dir_path else
             ftp_fs
         )

--- a/fs/subfs.py
+++ b/fs/subfs.py
@@ -29,7 +29,8 @@ class SubFS(WrapFS):
         self._sub_dir = abspath(normpath(path))
 
     def __repr__(self):
-        return "SubFS({!r}, {!r})".format(
+        return "{}({!r}, {!r})".format(
+            self.__class__.__name__,
             self._wrap_fs,
             self._sub_dir
         )
@@ -46,3 +47,14 @@ class SubFS(WrapFS):
     def delegate_path(self, path):
         _path = join(self._sub_dir, relpath(normpath(path)))
         return self._wrap_fs, _path
+
+
+class ClosingSubFS(SubFS):
+    """
+    A version of SubFS which will close its parent automatically.
+
+    """
+
+    def close(self):
+        self.delegate_fs().close()
+        super(ClosingSubFS, self).close()

--- a/fs/test.py
+++ b/fs/test.py
@@ -24,7 +24,7 @@ from fs import ResourceType, Seek
 from fs import errors
 from fs import walk
 from fs.opener import open_fs
-from fs.subfs import SubFS
+from fs.subfs import ClosingSubFS, SubFS
 
 import pytz
 import six
@@ -864,11 +864,15 @@ class FSTestCases(object):
 
         # Open a sub directory
         with self.fs.opendir('foo') as foo_fs:
+            repr(foo_fs)
+            text_type(foo_fs)
             six.assertCountEqual(self, foo_fs.listdir('/'), ['bar', 'egg'])
             self.assertTrue(foo_fs.isfile('bar'))
             self.assertTrue(foo_fs.isfile('egg'))
             self.assertEqual(foo_fs.getbytes('bar'), b'barbar')
             self.assertEqual(foo_fs.getbytes('egg'), b'eggegg')
+
+        self.assertFalse(self.fs.isclosed())
 
         # Attempt to open a non-existent directory
         with self.assertRaises(errors.ResourceNotFound):
@@ -881,6 +885,16 @@ class FSTestCases(object):
         # These should work, and will essentially return a 'clone' of sorts
         self.fs.opendir('')
         self.fs.opendir('/')
+
+        # Check ClosingSubFS closes 'parent'
+        with self.fs.opendir('foo', fs_class=ClosingSubFS) as foo_fs:
+            six.assertCountEqual(self, foo_fs.listdir('/'), ['bar', 'egg'])
+            self.assertTrue(foo_fs.isfile('bar'))
+            self.assertTrue(foo_fs.isfile('egg'))
+            self.assertEqual(foo_fs.getbytes('bar'), b'barbar')
+            self.assertEqual(foo_fs.getbytes('egg'), b'eggegg')
+
+        self.assertTrue(self.fs.isclosed())
 
     def test_remove(self):
 

--- a/fs/test.py
+++ b/fs/test.py
@@ -887,7 +887,7 @@ class FSTestCases(object):
         self.fs.opendir('/')
 
         # Check ClosingSubFS closes 'parent'
-        with self.fs.opendir('foo', fs_class=ClosingSubFS) as foo_fs:
+        with self.fs.opendir('foo', factory=ClosingSubFS) as foo_fs:
             six.assertCountEqual(self, foo_fs.listdir('/'), ['bar', 'egg'])
             self.assertTrue(foo_fs.isfile('bar'))
             self.assertTrue(foo_fs.isfile('egg'))

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -88,6 +88,7 @@ class WrapFS(FS):
                                   errors=errors,
                                   newline=newline)
 
+
     def getinfo(self, path, namespaces=None):
         self.check()
         _fs, _path = self.delegate_path(path)
@@ -344,14 +345,15 @@ class WrapFS(FS):
             )
         return open_file
 
-    def opendir(self, path):
+    def opendir(self, path, fs_class=None):
         from .subfs import SubFS
+        fs_class = fs_class or SubFS
         if not self.getinfo(path).is_dir:
             raise errors.DirectoryExpected(
                 path=path
             )
         with unwrap_errors(path):
-            return SubFS(self, path)
+            return fs_class(self, path)
 
     def setbytes(self, path, contents):
         self.check()

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -345,15 +345,15 @@ class WrapFS(FS):
             )
         return open_file
 
-    def opendir(self, path, fs_class=None):
+    def opendir(self, path, factory=None):
         from .subfs import SubFS
-        fs_class = fs_class or SubFS
+        factory = factory or SubFS
         if not self.getinfo(path).is_dir:
             raise errors.DirectoryExpected(
                 path=path
             )
         with unwrap_errors(path):
-            return fs_class(self, path)
+            return factory(self, path)
 
     def setbytes(self, path, contents):
         self.check()


### PR DESCRIPTION
Implements `ClosingSubFS` which is identical to `SubFS` but will close its parent automatically.

This was a work-around to https://github.com/PyFilesystem/pyfilesystem2/issues/51