### PR TITLE
Update tests, and fix discovered bugs

### DIFF
--- a/fs/base.py
+++ b/fs/base.py
@@ -820,6 +820,8 @@ class FS(object):
 
         if not overwrite and self.exists(dst_path):
             raise errors.DestinationExists(dst_path)
+        if self.getinfo(src_path).is_dir:
+            raise errors.FileExpected(src_path)
         if self.getmeta().get('supports_rename', False):
             try:
                 src_sys_path = self.getsyspath(src_path)

--- a/fs/base.py
+++ b/fs/base.py
@@ -318,6 +318,8 @@ class FS(object):
         with self._lock:
             if not create and not self.exists(dst_path):
                 raise errors.ResourceNotFound(dst_path)
+            if not self.getinfo(src_path).is_dir:
+                raise errors.DirectoryExpected(src_path)
             copy.copy_dir(
                 self,
                 src_path,

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -212,6 +212,8 @@ class FTPFile(io.IOBase):
                 remaining_data -= sent_size
                 self.pos += sent_size
 
+        return data_pos
+
     def writelines(self, lines):
         self.write(b''.join(lines))
 
@@ -226,6 +228,9 @@ class FTPFile(io.IOBase):
                 f.write(data)
                 if len(data) < size:
                     f.write(b'\0' * (size - len(data)))
+
+        self.pos = size or self.tell()
+        return self.pos
 
     def seekable(self):
         return True
@@ -252,6 +257,7 @@ class FTPFile(io.IOBase):
             if self._write_conn:
                 self._write_conn.close()
                 self._write_conn = None
+        return self.tell()
 
 
 class FTPFS(FS):

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -15,7 +15,7 @@ from ftplib import error_perm
 from ftplib import error_temp
 
 from six import PY2
-from six import text_type, binary_type
+from six import text_type
 
 from . import errors
 from .base import FS
@@ -87,7 +87,7 @@ if PY2:
     def _encode(st, encoding):
         return st.encode(encoding) if isinstance(st, text_type) else st
     def _decode(st, encoding):
-        return st.decode(encoding) if isinstance(st, binary_type) else st
+        return st.decode(encoding) if isinstance(st, bytes) else st
 else:
     def _encode(st, _):
         return st

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -107,9 +107,6 @@ class FTPFile(io.IOBase):
         self._read_conn = None
         self._write_conn = None
 
-    def __length_hint__(self):
-        return self.fs.getsize(self.path)
-
     def _open_ftp(self):
         ftp = self.fs._open_ftp(self.fs.ftp.encoding)
         ftp.voidcmd(str('TYPE I'))

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -87,7 +87,7 @@ if PY2:
     def _encode(st, encoding):
         return st.encode(encoding) if isinstance(st, text_type) else st
     def _decode(st, encoding):
-        return st.decode(encoding) if isinstance(st, bytes) else st
+        return st.decode(encoding, 'replace') if isinstance(st, bytes) else st
 else:
     def _encode(st, _):
         return st

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -230,7 +230,8 @@ class FTPFile(io.IOBase):
     def truncate(self, size=None):
         # Inefficient, but I don't know if truncate is possible with ftp
         with self._lock:
-            size = size or self.tell()
+            if size is None:
+                size = self.tell()
             with self.fs.openbin(self.path) as f:
                 data = f.read(size)
             with self.fs.openbin(self.path, 'w') as f:

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -83,8 +83,12 @@ def parse_ftp_error(e):
     return code, message
 
 
-def _encode(s):
-    return s.encode() if PY2 and isinstance(s, text_type) else s
+if PY2:
+    def _encode(s):
+        return s.encode("utf-8") if isinstance(s, text_type) else s
+else:
+    def _encode(s):
+        return s
 
 
 class FTPFile(io.IOBase):
@@ -345,12 +349,8 @@ class FTPFS(FS):
     @property
     def encoding(self):
         if self._ftp is None:
-            if self._features is None:
-                _ftp = self._open_ftp('latin-1')
-                has_utf8 = "UTF8" in _ftp.sendcmd('FEAT')
-            else:
-                has_utf8 = "UTF8" in self._features
-            return "utf-8" if has_utf8 else "latin-1"
+            _ftp = self._open_ftp('latin-1')
+            return "utf-8" if "UTF8" in _ftp.sendcmd('FEAT') else "latin-1"
         else:
             return self._ftp.encoding
 

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -116,14 +116,15 @@ class _MemoryFile(io.IOBase):
     def tell(self):
         return self.pos
 
-    def truncate(self, size):
+    def truncate(self, size=None):
         with self._seek_lock():
             self.on_modify()
-            self._bytes_io.truncate(size)
+            new_size = self._bytes_io.truncate(size)
             if size is not None and self._bytes_io.tell() < size:
                 self._bytes_io.seek(0, os.SEEK_END)
                 file_size = self._bytes_io.tell()
                 self._bytes_io.write(b'\0' * (size - file_size))
+            return new_size
 
     def writable(self):
         return self._mode.writing
@@ -133,7 +134,7 @@ class _MemoryFile(io.IOBase):
             raise IOError('File not open for writing')
         with self._seek_lock():
             self.on_modify()
-            self._bytes_io.write(data)
+            return self._bytes_io.write(data)
 
     def writelines(self, sequence):
         with self._seek_lock():

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -121,10 +121,10 @@ class _MemoryFile(io.IOBase):
             self.on_modify()
             new_size = self._bytes_io.truncate(size)
             if size is not None and self._bytes_io.tell() < size:
-                self._bytes_io.seek(0, os.SEEK_END)
-                file_size = self._bytes_io.tell()
+                file_size = self._bytes_io.seek(0, os.SEEK_END)
                 self._bytes_io.write(b'\0' * (size - file_size))
-            return new_size
+                self._bytes_io.seek(-size+file_size, os.SEEK_END)
+            return size or new_size
 
     def writable(self):
         return self._mode.writing

--- a/fs/test.py
+++ b/fs/test.py
@@ -884,6 +884,7 @@ class FSTestCases(object):
             self.assertEqual(0, f.seek(0))
             self.assertEqual(f.read(), b'Hello')
             self.assertEqual(10, f.truncate(10))
+            self.assertEqual(5, f.tell())
             self.assertEqual(0, f.seek(0))
             print(repr(self.fs))
             print(repr(f))

--- a/fs/test.py
+++ b/fs/test.py
@@ -1125,6 +1125,15 @@ class FSTestCases(object):
         with self.assertRaises(errors.ResourceNotFound):
             self.fs.copy('baz', 'a/b/c/baz')
 
+        # Test copying a source that doesn't exist
+        with self.assertRaises(errors.ResourceNotFound):
+            self.fs.copy('egg', 'spam')
+
+        # Test copying a directory
+        self.fs.makedir('dir')
+        with self.assertRaises(errors.FileExpected):
+            self.fs.copy('dir', 'folder')
+
     def test_create(self):
         # Test create new file
         self.assertFalse(self.fs.exists('foo'))
@@ -1642,6 +1651,10 @@ class FSTestCases(object):
 
         with self.assertRaises(errors.ResourceNotFound):
             self.fs.copydir('foo', 'foofoo')
+        with self.assertRaises(errors.ResourceNotFound):
+            self.fs.copydir('spam', 'egg', create=True)
+        with self.assertRaises(errors.DirectoryExpected):
+            self.fs.copydir('foo2/foofoo.txt', 'foofoo.txt', create=True)
 
     def test_movedir(self):
         self.fs.makedirs('foo/bar/baz/egg')

--- a/fs/test.py
+++ b/fs/test.py
@@ -329,7 +329,6 @@ class FSTestCases(object):
         self.assertEqual(data, contents)
         self.assertIsInstance(data, text_type)
 
-
     def test_appendbytes(self):
         with self.assertRaises(ValueError):
             self.fs.appendbytes('foo', 'bar')
@@ -1698,3 +1697,22 @@ class FSTestCases(object):
         written = write_tree.getvalue()
         expected = u'|-- foo\n|   `-- bar\n`-- test.txt\n'
         self.assertEqual(expected, written)
+
+    def test_unicode_path(self):
+        if not self.fs.getmeta().get('unicode_paths', False):
+            self.skipTest('the filesystem does not support unicode paths.')
+
+        self.fs.makedir('földér')
+        self.fs.settext('☭.txt', 'Smells like communism.')
+        self.fs.setbytes('földér/☣.txt', b'Smells like an old syringe.')
+
+        self.assert_isdir('földér')
+        self.assertEqual(['☣.txt'], self.fs.listdir('földér'))
+        self.assertEqual('☣.txt', self.fs.getinfo('földér/☣.txt').name)
+        self.assert_text('☭.txt', 'Smells like communism.')
+        self.assert_bytes('földér/☣.txt', b'Smells like an old syringe.')
+
+        self.fs.remove('földér/☣.txt')
+        self.assert_not_exists('földér/☣.txt')
+        self.fs.removedir('földér')
+        self.assert_not_exists('földér')

--- a/fs/test.py
+++ b/fs/test.py
@@ -1713,10 +1713,14 @@ class FSTestCases(object):
         self.assert_text('☭.txt', 'Smells like communism.')
         self.assert_bytes('földér/☣.txt', b'Smells like an old syringe.')
 
+        if self.fs.hassyspath('földér/☣.txt'):
+            self.assertTrue(os.path.exists(self.fs.getsyspath('földér/☣.txt')))
+
         self.fs.remove('földér/☣.txt')
         self.assert_not_exists('földér/☣.txt')
         self.fs.removedir('földér')
         self.assert_not_exists('földér')
+
 
     def test_case_sensitive(self):
         if self.fs.getmeta().get('case_insensitive', False):

--- a/fs/test.py
+++ b/fs/test.py
@@ -595,6 +595,10 @@ class FSTestCases(object):
         with self.assertRaises(errors.ResourceNotFound):
             self.fs.move('bar', 'egg/bar')
 
+        # Check moving an unexisting source
+        with self.assertRaises(errors.ResourceNotFound):
+            self.fs.move('egg', 'spam')
+
         # Check moving between different directories
         self.fs.makedir('baz')
         self.fs.setbytes('baz/bazbaz', b'bazbaz')
@@ -602,6 +606,12 @@ class FSTestCases(object):
         self.fs.move('baz/bazbaz', 'baz2/bazbaz')
         self.assert_not_exists('baz/bazbaz')
         self.assert_bytes('baz2/bazbaz', b'bazbaz')
+
+        # Check moving a directory raises an error
+        self.assert_isdir('baz2')
+        self.assert_not_exists('yolk')
+        with self.assertRaises(errors.FileExpected):
+            self.fs.move('baz2', 'yolk')
 
     def test_makedir(self):
         # Check edge case of root
@@ -782,7 +792,6 @@ class FSTestCases(object):
         with self.fs.openbin("iter.bin") as f:
             for actual, expected in zip(f, lines.splitlines(1)):
                 self.assertEqual(actual, expected)
-
 
     def test_open_files(self):
         # Test file-like objects work as expected.
@@ -1666,8 +1675,17 @@ class FSTestCases(object):
         self.assert_not_exists('foo/bar/foofoo.txt')
         self.assert_not_exists('foo/bar/baz/egg')
 
+        # Check moving to an unexisting directory
         with self.assertRaises(errors.ResourceNotFound):
             self.fs.movedir('foo', 'foofoo')
+
+        # Check moving an unexisting directory
+        with self.assertRaises(errors.ResourceNotFound):
+            self.fs.movedir('spam', 'egg', create=True)
+
+        # Check moving a file
+        with self.assertRaises(errors.DirectoryExpected):
+            self.fs.movedir('foo2/foofoo.txt', 'foo2/baz/egg')
 
     def test_match(self):
         self.assertTrue(self.fs.match(['*.py'], 'foo.py'))

--- a/fs/test.py
+++ b/fs/test.py
@@ -1716,3 +1716,20 @@ class FSTestCases(object):
         self.assert_not_exists('földér/☣.txt')
         self.fs.removedir('földér')
         self.assert_not_exists('földér')
+
+    def test_case_sensitive(self):
+        if self.fs.getmeta().get('case_insensitive', False):
+            self.skipTest('the filesystem is not case sensitive.')
+
+        self.fs.makedir('foo')
+        self.fs.makedir('Foo')
+        self.fs.touch('fOO')
+
+        self.assert_exists('foo')
+        self.assert_exists('Foo')
+        self.assert_exists('fOO')
+        self.assert_not_exists('FoO')
+
+        self.assert_isdir('foo')
+        self.assert_isdir('Foo')
+        self.assert_isfile('fOO')

--- a/fs/test.py
+++ b/fs/test.py
@@ -734,7 +734,7 @@ class FSTestCases(object):
             self.assertIsInstance(f, io.IOBase)
             self.assertTrue(f.writable())
             self.assertFalse(f.readable())
-            f.write(text)
+            self.assertEqual(len(text), f.write(text))
             self.assertFalse(f.closed)
         self.assertTrue(f.closed)
 
@@ -756,7 +756,7 @@ class FSTestCases(object):
         # Test overwrite
         text = b'Goodbye, World'
         with self.fs.openbin('foo/hello', 'w') as f:
-            f.write(text)
+            self.assertEqual(len(text), f.write(text))
         self.assert_bytes('foo/hello', text)
 
         # Test FileExpected raised
@@ -845,6 +845,9 @@ class FSTestCases(object):
         iter_lines = iter(self.fs.open('text'))
         self.assertEqual(next(iter_lines), 'Hello\n')
 
+        with self.fs.open('unicode', 'w') as f:
+            self.assertEqual(12, f.write('Héllo\nWörld\n'))
+
         with self.fs.open('text', 'rb') as f:
             self.assertIsInstance(f, io.IOBase)
             self.assertFalse(f.writable())
@@ -852,11 +855,11 @@ class FSTestCases(object):
             self.assertTrue(f.seekable())
             self.assertFalse(f.closed)
             self.assertEqual(f.read(1), b'H')
-            f.seek(3, Seek.set)
+            self.assertEqual(3, f.seek(3, Seek.set))
             self.assertEqual(f.read(1), b'l')
-            f.seek(2, Seek.current)
+            self.assertEqual(6, f.seek(2, Seek.current))
             self.assertEqual(f.read(1), b'W')
-            f.seek(-2, Seek.end)
+            self.assertEqual(22, f.seek(-2, Seek.end))
             self.assertEqual(f.read(1), b'z')
             with self.assertRaises(ValueError):
                 f.seek(10, 77)
@@ -868,18 +871,18 @@ class FSTestCases(object):
             self.assertTrue(f.writable())
             self.assertTrue(f.seekable())
             self.assertFalse(f.closed)
-            f.seek(5)
-            f.truncate()
-            f.seek(0)
+            self.assertEqual(5, f.seek(5))
+            self.assertEqual(5, f.truncate())
+            self.assertEqual(0, f.seek(0))
             self.assertEqual(f.read(), b'Hello')
-            f.truncate(10)
-            f.seek(0)
+            self.assertEqual(10, f.truncate(10))
+            self.assertEqual(0, f.seek(0))
             print(repr(self.fs))
             print(repr(f))
             self.assertEqual(f.read(), b'Hello\0\0\0\0\0')
-            f.seek(4)
+            self.assertEqual(4, f.seek(4))
             f.write(b'O')
-            f.seek(4)
+            self.assertEqual(4, f.seek(4))
             self.assertEqual(f.read(1), b'O')
         self.assertTrue(f.closed)
 
@@ -892,7 +895,7 @@ class FSTestCases(object):
             self.assertTrue(write_file.writable())
             self.assertFalse(write_file.readable())
             self.assertFalse(write_file.closed)
-            write_file.write(b'\0\1\2')
+            self.assertEqual(3, write_file.write(b'\0\1\2'))
         self.assertTrue(write_file.closed)
 
         # Read a binary file

--- a/testrequirements.txt
+++ b/testrequirements.txt
@@ -1,7 +1,7 @@
 appdirs~=1.4.0
 coverage
 mock
-pyftpdlib==1.5.1
+pyftpdlib~=1.5.2
 python-coveralls
 pytz==2016.7
 nose

--- a/testrequirements.txt
+++ b/testrequirements.txt
@@ -1,7 +1,7 @@
 appdirs~=1.4.0
 coverage
 mock
-pyftpdlib~=1.5.2
+pyftpdlib==1.5.2
 python-coveralls
 pytz==2016.7
 nose

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import threading
 import ftplib
 import os
 import platform
@@ -21,53 +22,24 @@ from ftplib import error_temp
 
 from pyftpdlib.authorizers import DummyAuthorizer
 from pyftpdlib.handlers import FTPHandler
-from pyftpdlib.servers import FTPServer
+from pyftpdlib.test import FTPd
 
 from fs import errors
 from fs.opener import open_fs
-from fs.ftpfs import ftp_errors
-
-from nose.plugins.attrib import attr
-
-
-_WINDOWS_PLATFORM = platform.system() == 'Windows'
-
-
-if __name__ == "__main__":
-    # Run an ftp server that exposes a given directory
-    import sys
-    authorizer = DummyAuthorizer()
-    authorizer.add_user("user", "12345", sys.argv[1], perm="elradfmw")
-    authorizer.add_anonymous(sys.argv[1])
-
-    handler = FTPHandler
-    handler.authorizer = authorizer
-    address = ("127.0.0.1", int(sys.argv[2]))
-
-    ftpd = FTPServer(address, handler)
-
-    sys.stdout.write('serving\n')
-    sys.stdout.flush()
-    ftpd.serve_forever()
-    sys.exit(0)
-
-
+from fs.ftpfs import FTPFS, ftp_errors
 from fs.test import FSTestCases
 
-ftp_port_offset = 0
-ftp_port = 30000 + (os.getpid() % 8)
+from nose.plugins.attrib import attr
 
 
 class TestFTPFSClass(unittest.TestCase):
 
     def test_parse_ftp_time(self):
-        from fs.ftpfs import FTPFS
         self.assertIsNone(FTPFS._parse_ftp_time('notreallyatime'))
         t = FTPFS._parse_ftp_time('19740705000000')
         self.assertEqual(t, 142214400)
 
     def test_parse_mlsx(self):
-        from fs.ftpfs import FTPFS
         info = list(
             FTPFS._parse_mlsx(['create=19740705000000;modify=19740705000000; /foo'])
         )[0]
@@ -78,7 +50,6 @@ class TestFTPFSClass(unittest.TestCase):
         self.assertEqual(info, [])
 
     def test_opener(self):
-        from fs.ftpfs import FTPFS
         ftp_fs = open_fs('ftp://will:wfc@ftp.example.org')
         self.assertIsInstance(ftp_fs, FTPFS)
         self.assertEqual(ftp_fs.host, 'ftp.example.org')
@@ -111,82 +82,58 @@ class TestFTPErrors(unittest.TestCase):
                 raise error_perm('999 foo')
 
 
-@attr('slow')
 class TestFTPFS(FSTestCases, unittest.TestCase):
 
-    def make_fs(self):
-        from fs.ftpfs import FTPFS
-        global ftp_port_offset
-        temp_path = os.path.join(self._temp_dir, text_type(uuid.uuid4()))
-        _ftp_port = ftp_port + ftp_port_offset
-        ftp_port_offset += 1
+    user='user'
+    pasw='1234'
 
-        os.mkdir(temp_path)
-        env = os.environ.copy()
+    @classmethod
+    def setUpClass(cls):
+        super(TestFTPFS, cls).setUpClass()
 
-        server = subprocess.Popen(
-            [
-                sys.executable,
-                os.path.abspath(__file__),
-                temp_path,
-                text_type(_ftp_port)
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=env
-        )
-        server.stdout.readline()
+        cls._temp_dir = tempfile.mkdtemp('ftpfs2tests')
+        cls._temp_path = os.path.join(cls._temp_dir, text_type(uuid.uuid4()))
+        os.mkdir(cls._temp_path)
 
-        if _WINDOWS_PLATFORM:
-            # Don't know why this is necessary on Windows
+        cls.server = FTPd()
+        cls.server.shutdown_after = -1
+        cls.server.handler.authorizer = DummyAuthorizer()
+        cls.server.handler.authorizer.add_user(
+            cls.user, cls.pasw, cls._temp_path, perm="elradfmw")
+        cls.server.handler.authorizer.add_anonymous(cls._temp_path)
+        cls.server.start()
+
+        # Don't know why this is necessary on Windows
+        if platform.system() == 'Windows':
             time.sleep(0.1)
-
         # Poll until a connection can be made
-        start_time = time.time()
-        while time.time() - start_time < 5:
-            try:
-                ftpurl = urlopen('ftp://127.0.0.1:{}'.format(_ftp_port))
-            except IOError:
-                time.sleep(0)
-            else:
-                ftpurl.read()
-                ftpurl.close()
-                break
-        else:
-            raise Exception("unable to start ftp server")
-        self.servers.append(server)
+        if not cls.server.is_alive():
+            raise RuntimeError("could not start FTP server.")
 
-        fs = FTPFS(
-            '127.0.0.1',
-            user='user',
-            passwd='12345',
-            port=_ftp_port,
-            timeout=5.0
-        )
-        return fs
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+        shutil.rmtree(cls._temp_dir)
+        super(TestFTPFS, cls).tearDownClass()
 
-    def setUp(self):
-        self.servers = []
-        self._temp_dir = tempfile.mkdtemp('ftpfs2tests')
-        super(TestFTPFS, self).setUp()
+    def make_fs(self):
+        return open_fs('ftp://{}:{}@{}:{}'.format(
+            self.user, self.pasw, self.server.host, self.server.port
+        ))
 
     def tearDown(self):
-        while self.servers:
-            server = self.servers.pop(0)
-            if sys.platform == 'win32':
-                os.popen('TASKKILL /PID {} /F'.format(server.pid))
-            else:
-                server.terminate()
-                server.wait()
-                #os.system('kill {}'.format(server.pid))
-        shutil.rmtree(self._temp_dir)
+        shutil.rmtree(self._temp_path)
+        os.mkdir(self._temp_path)
         super(TestFTPFS, self).tearDown()
 
     def test_ftp_url(self):
         self.assertTrue(self.fs.ftp_url.startswith('ftp://127.0.0.1'))
 
+    def test_host(self):
+        self.assertEqual(self.fs.host, self.server.host)
+
+    @attr('slow')
     def test_connection_error(self):
-        from fs.ftpfs import FTPFS
         fs = FTPFS('ftp.not.a.chance', timeout=1)
         with self.assertRaises(errors.RemoteConnectionError):
             fs.listdir('/')

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -22,7 +22,7 @@ from ftplib import error_temp
 
 from pyftpdlib.authorizers import DummyAuthorizer
 from pyftpdlib.handlers import FTPHandler
-from pyftpdlib.test import FTPd
+from pyftpdlib.test import ThreadedTestFTPd
 
 from fs import errors
 from fs.opener import open_fs
@@ -95,7 +95,7 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
         cls._temp_path = os.path.join(cls._temp_dir, text_type(uuid.uuid4()))
         os.mkdir(cls._temp_path)
 
-        cls.server = FTPd()
+        cls.server = ThreadedTestFTPd()
         cls.server.shutdown_after = -1
         cls.server.handler.authorizer = DummyAuthorizer()
         cls.server.handler.authorizer.add_user(

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
@@ -22,7 +23,6 @@ from ftplib import error_temp
 
 from pyftpdlib.authorizers import DummyAuthorizer
 from pyftpdlib.handlers import FTPHandler
-from pyftpdlib.test import ThreadedTestFTPd
 
 from fs import errors
 from fs.opener import open_fs
@@ -89,6 +89,7 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        from pyftpdlib.test import ThreadedTestFTPd
         super(TestFTPFS, cls).setUpClass()
 
         cls._temp_dir = tempfile.mkdtemp('ftpfs2tests')

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -203,6 +203,12 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
         self.fs.ftp.sendcmd = broken_sendcmd
         self.assertEqual(self.fs.features, {})
 
+    def test_getmeta_unicode_path(self):
+        self.assertTrue(self.fs.getmeta().get('unicode_paths'))
+        self.fs.features
+        del self.fs.features['UTF8']
+        self.assertFalse(self.fs.getmeta().get('unicode_paths'))
+
 
 class TestFTPFSNoMLSD(TestFTPFS):
 


### PR DESCRIPTION
Hi Will, I updated the tests in `fs.test` with some missing checks, and discovered some new bugs I will fix gradually in this PR.

### New tests
1. `FS.copy`, `FS.move`, `FS.copydir` and `FS.movedir` should raise `ResourceNotFound` when the source is nowhere to be found
2. `FS.copy` and `FS.move` should probably raise `FileExpected` when the source is a directory (not listed in the documentation, but makes sense I guess ?...)
3. `FS.movedir` and `FS.copydir` should raise `DirectoryExpected` when the source is a file
4. If a filesystem is advertising itself as *case insensitive*, check that's true
5. If a filesystem is advertising itself as supporting *unicode paths*, check that's true
6. Check that *file-like* objects returned by `FS.openbin`:
    * have a `seek` method that returns the new absolute position when called
    * have a `write` method that returns the number of bytes (in binary mode) / characters (in text mode) written
    * have a `truncate` method that returns the new length of the file

### Discovered bugs
* ~`FTPFile.seek`, `FTPFile.truncate` and `FTPFile.write` do not return anything~ *fixed*
* ~`FTPFS` crashes on unicode paths (`/földér`)~ *fixed, see below*
* ~`MemoryFile.write` and `MemoryFile.truncate` do not return anything~ *fixed*
* ~many filesystem's `move` and `copy` do not raise `FileExpected` when given a directory~ *fixed by fixing `FS.copy` and `FS.move`*

### About FTPFS
FTP servers supporting UTF-8 encoded paths display the feature `UTF8`. But the `ftplib.FTP` objects require to set the encoding *before* connecting to the server, or else the server and the client encoding will not be synchronised (client will send *utf-8* paths but server will treat them as *latin-1*). 

To fix this, the encoding is checked when accessing the `FTPFS.ftp` property for the first time. A mock connection is established to check for the `UTF8` feature ; then, a proper connection is established, with *utf-8* as the encoding if available, and *latin-1* otherwise. Then, any new ftp connection will use the previous encoding, so the overhead is limited.


### About test_ftpfs
I rewrote the class so that a new server is created once by class instead of before each test, which was a lot longer for nothing. I also made use of `pyftpdlib.test.FTPd` instead of externally calling the file and then *task-killing* the thread, which was a lot hackier. 

I still think there is an issue with the timeout of `FTPFS` objects, since the `test_connection_error` tests take a really long time, longer than what they should take given the timeout.