### PR TITLE
Fix units in `fs.filesize`

### DIFF
--- a/fs/filesize.py
+++ b/fs/filesize.py
@@ -9,7 +9,7 @@ Functions for reporting filesizes
 from __future__ import division
 from __future__ import unicode_literals
 
-__all__ = ['traditional', 'decimal']
+__all__ = ['traditional', 'decimal', 'binary']
 
 
 
@@ -17,7 +17,7 @@ def _to_str(size, suffixes, base):
     try:
         size = int(size)
     except ValueError:
-        raise ValueError(
+        raise TypeError(
             "filesize requires a numeric value, not {!r}".format(size)
         )
     if size == 1:
@@ -35,7 +35,7 @@ def _to_str(size, suffixes, base):
 def traditional(size):
     """
     Convert a filesize in to a string representation with traditional
-    (base 2) units.
+    (base 2) units and JDEC prefixes.
 
     :param int size: A file size.
     :returns: A string containing a abbreviated file size and units.
@@ -49,18 +49,35 @@ def traditional(size):
     )
 
 
+def binary(size):
+    """
+    Convert a filesize in to a string representation with binary units
+    and SI binary prefixes.
+
+    :param int size: A file size.
+    :param bool si: True to use SI prefixes, False to use JDEC prefixes.
+    :returns: A string containing a abbreviated file size and units.
+    :rtype str:
+
+    """
+    return _to_str(
+        size,
+        ('KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'),
+        1024
+    )
+
+
 def decimal(size):
     """
     Convert a filesize in to a string representation with decimal
-    units.
+    units and SI decimal prefixes.
 
     :param int size: A file size.
     :returns: A string containing a abbreviated file size and units.
     :rtype str:
     """
-
     return _to_str(
         size,
-        ('kbit', 'Mbit', 'Gbit', 'Tbit', 'Pbit', 'Ebit', 'Zbit', 'Ybit'),
+        ('kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'),
         1000
     )

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -41,6 +41,42 @@ class TestFilesize(unittest.TestCase):
             '1.5 MB'
         )
 
+    def test_binary(self):
+
+        self.assertEqual(
+            filesize.binary(0),
+            '0 bytes'
+        )
+        self.assertEqual(
+            filesize.binary(1),
+            '1 byte'
+        )
+        self.assertEqual(
+            filesize.binary(2),
+            '2 bytes'
+        )
+        self.assertEqual(
+            filesize.binary(1024),
+            '1.0 KiB'
+        )
+
+        self.assertEqual(
+            filesize.binary(1024 * 1024),
+            '1.0 MiB'
+        )
+
+        self.assertEqual(
+            filesize.binary(1024 * 1024 + 1),
+            '1.0 MiB'
+        )
+
+        self.assertEqual(
+            filesize.binary(1.5 * 1024 * 1024),
+            '1.5 MiB'
+        )
+
+
+
     def test_decimal(self):
 
         self.assertEqual(
@@ -57,25 +93,25 @@ class TestFilesize(unittest.TestCase):
         )
         self.assertEqual(
             filesize.decimal(1000),
-            '1.0 kbit'
+            '1.0 kB'
         )
 
         self.assertEqual(
             filesize.decimal(1000 * 1000),
-            '1.0 Mbit'
+            '1.0 MB'
         )
 
         self.assertEqual(
             filesize.decimal(1000 * 1000 + 1),
-            '1.0 Mbit'
+            '1.0 MB'
         )
 
         self.assertEqual(
             filesize.decimal(1200 * 1000),
-            '1.2 Mbit'
+            '1.2 MB'
         )
 
     def test_errors(self):
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             filesize.traditional('foo')


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Byte), the binary filesize units should be `KiB`, `MiB`, ..., and the decimal units should be `kB`, `MB`, ...

Previously, `traditional` would use the SI prefixes, and `decimal` would display bits instead of bytes.

Also, I'm not sure about this, but once again functions should probably be raising `TypeError` when given an argument that cannot be coerced to a numerical value.