### PR TITLE
Add `ResourceReadOnly` to `__all__` in `fs.errors`

### DIFF
--- a/fs/errors.py
+++ b/fs/errors.py
@@ -43,6 +43,7 @@ __all__ = [
     'ResourceInvalid',
     'ResourceLocked',
     'ResourceNotFound',
+    'ResourceReadOnly',
     'Unsupported',
 ]
 


### PR DESCRIPTION
`ResourceReadOnly` was missing from `fs.errors.__all__`, hence not documented by automodule.