### PR TITLE
Relax six dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ REQUIREMENTS = [
     "appdirs~=1.4.3",
     "pytz",
     "setuptools",
-    "six~=1.10",
+    "six>=1.10,<2.0",
 ]
 
 setup(


### PR DESCRIPTION
The `six` dependency prevents other software from work - https://github.com/Metatab/metapack/issues/4#issuecomment-336496954