### PR TITLE
Seek files and extract permissions from `ZipFS`

### DIFF
--- a/fs/compress.py
+++ b/fs/compress.py
@@ -18,7 +18,7 @@ import six
 from .enums import ResourceType
 from .path import relpath
 from .time import datetime_to_epoch
-from .errors import NoSysPath
+from .errors import NoSysPath, MissingInfoNamespace
 from .walk import Walker
 
 
@@ -51,7 +51,8 @@ def write_zip(src_fs,
     )
     walker = walker or Walker()
     with _zip:
-        gen_walk = walker.info(src_fs, namespaces=["details", "stat"])
+        gen_walk = walker.info(
+            src_fs, namespaces=["details", "stat", "access"])
         for path, info in gen_walk:
             # Zip names must be relative, directory names must end
             # with a slash.
@@ -76,7 +77,13 @@ def write_zip(src_fs,
                 )
             zip_info = zipfile.ZipInfo(zip_name, zip_time)
 
+            try:
+                zip_info.external_attr = info.permissions.mode << 16
+            except MissingInfoNamespace:
+                zip_info.external_attr = 0o600
+
             if info.is_dir:
+                zip_info.external_attr |= 0x10
                 # This is how to record directories with zipfile
                 _zip.writestr(zip_info, b'')
             else:

--- a/fs/compress.py
+++ b/fs/compress.py
@@ -80,7 +80,7 @@ def write_zip(src_fs,
             try:
                 zip_info.external_attr = info.permissions.mode << 16
             except MissingInfoNamespace:
-                zip_info.external_attr = 0o600
+                pass
 
             if info.is_dir:
                 zip_info.external_attr |= 0x10

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -18,6 +18,16 @@ from .path import dirname, normpath, relpath, basename
 from .wrapfs import WrapFS
 from .permissions import Permissions
 
+__all__ = ['TarFS', 'WriteTarFS', 'ReadTarFS']
+
+
+if six.PY2:
+    def _get_member_info(member, encoding):
+        return member.get_info(encoding, None)
+else:
+    def _get_member_info(member, encoding):
+        return member.get_info()
+
 
 class TarFS(WrapFS):
     """Read and write tar files.
@@ -208,7 +218,7 @@ class ReadTarFS(FS):
         namespaces = namespaces or ()
         raw_info = {}
 
-        if _path in '/':
+        if not _path:
             raw_info['basic'] = {
                 "name": "",
                 "is_dir": True,
@@ -244,9 +254,7 @@ class ReadTarFS(FS):
                     "user": member.uname,
                 }
             if "tar" in namespaces:
-                raw_info["tar"] = raw_tar_info = member.get_info(*(
-                    [self.encoding, None] if six.PY2 else []
-                ))
+                raw_info["tar"] = _get_member_info(member, self.encoding)
                 raw_info["tar"].update({
                     k.replace('is', 'is_'):getattr(member, k)()
                     for k in dir(member)

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -204,59 +204,55 @@ class ReadTarFS(FS):
         return "<TarFS '{}'>".format(self._file)
 
     def getinfo(self, path, namespaces=None):
-        self.check()
+        _path = relpath(self.validatepath(path))
         namespaces = namespaces or ()
-        path = relpath(normpath(path))
-        if not path:
-            raw_info = {
-                "basic":
-                {
-                    "name": "",
-                    "is_dir": True,
-                },
-                "details":
-                {
+        raw_info = {}
+
+        if _path in '/':
+            raw_info['basic'] = {
+                "name": "",
+                "is_dir": True,
+            }
+            if 'details' in namespaces:
+                raw_info['details'] = {
                     "type": int(ResourceType.directory)
                 }
-            }
+
         else:
             try:
-                member = self._tar.getmember(path)
+                member = self._tar.getmember(_path)
             except KeyError:
                 raise errors.ResourceNotFound(path)
 
+            raw_info["basic"] = {
+                "name": basename(member.name),
+                "is_dir": member.isdir(),
+            }
 
-            raw_tar_info = member.get_info(*(
-                [self.encoding, None] if six.PY2 else []
-            ))
-
-            raw_tar_info.update({
-                k.replace('is', 'is_'):getattr(member, k)()
-                for k in dir(member)
-                if k.startswith('is')
-            })
-            raw_info = {
-                "basic":
-                {
-                    "name": basename(member.name),
-                    "is_dir": member.isdir(),
-                },
-                "details":
-                {
+            if "details" in namespaces:
+                raw_info["details"] = {
                     "size": member.size,
                     "type": int(self.type_map[member.type]),
                     "modified": member.mtime,
-                },
-                "access":
-                {
+                }
+            if "access" in namespaces:
+                raw_info["access"] = {
                     "gid": member.gid,
                     "group": member.gname,
                     "permissions": Permissions(mode=member.mode).dump(),
                     "uid": member.uid,
                     "user": member.uname,
-                },
-                "tar": raw_tar_info,
-            }
+                }
+            if "tar" in namespaces:
+                raw_info["tar"] = raw_tar_info = member.get_info(*(
+                    [self.encoding, None] if six.PY2 else []
+                ))
+                raw_info["tar"].update({
+                    k.replace('is', 'is_'):getattr(member, k)()
+                    for k in dir(member)
+                    if k.startswith('is')
+                })
+
         return Info(raw_info)
 
     def setinfo(self, path, info):

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -33,6 +33,7 @@ class _ZipExtFile(RawWrapper):
     def read(self, size=-1):
         if size is None or size < 0:
             size = self._end - self._pos
+            # NB(@althonos): do NOT replace by self._f.read() !
             buf = b''.join([self._f.read(size-1), self._f._readbuffer[-1:]])
             self._f._offset += 1
         elif self._f._offset + size <= len(self._f._readbuffer):
@@ -46,9 +47,10 @@ class _ZipExtFile(RawWrapper):
     def read1(self, size=-1):
         if size is None or size < 0:
             size = self._end - self._pos
+            # NB(@althonos): do NOT replace by self._f.read1() !
             buf = b''.join([self._f.read1(size-1), self._f._readbuffer[-1:]])
             self._f._offset += 1
-        if self._f._offset + size <= len(self._f._readbuffer):
+        elif self._f._offset + size <= len(self._f._readbuffer):
             buf = self._f._readbuffer[self._f._offset:size+self._f._offset]
             self._f._offset += size
         else:

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -31,7 +31,9 @@ class _ZipExtFile(RawWrapper):
         super(_ZipExtFile, self).__init__(_zip.open(name), 'r', name)
 
     def read(self, size=-1):
-        if size is None or size < 0:
+        if self._pos >= self._end:
+            return b''
+        elif size is None or size < 0:
             size = self._end - self._pos
             # NB(@althonos): do NOT replace by self._f.read() !
             buf = b''.join([self._f.read(size-1), self._f._readbuffer[-1:]])
@@ -45,6 +47,8 @@ class _ZipExtFile(RawWrapper):
         return buf
 
     def read1(self, size=-1):
+        if self._pos >= self._end:
+            return b''
         if size is None or size < 0:
             size = self._end - self._pos
             # NB(@althonos): do NOT replace by self._f.read1() !

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -31,12 +31,28 @@ class _ZipExtFile(RawWrapper):
         super(_ZipExtFile, self).__init__(_zip.open(name), 'r', name)
 
     def read(self, size=-1):
-        buf = self._f.read(size)
+        if size is None or size < 0:
+            size = self._end - self._pos
+            buf = b''.join([self._f.read(size-1), self._f._readbuffer[-1:]])
+            self._f._offset += 1
+        elif self._f._offset + size <= len(self._f._readbuffer):
+            buf = self._f._readbuffer[self._f._offset:size+self._f._offset]
+            self._f._offset += size
+        else:
+            buf = self._f.read(size)
         self._pos += len(buf)
         return buf
 
     def read1(self, size=-1):
-        buf = self._f.read1(size)
+        if size is None or size < 0:
+            size = self._end - self._pos
+            buf = b''.join([self._f.read1(size-1), self._f._readbuffer[-1:]])
+            self._f._offset += 1
+        if self._f._offset + size <= len(self._f._readbuffer):
+            buf = self._f._readbuffer[self._f._offset:size+self._f._offset]
+            self._f._offset += size
+        else:
+            buf = self._f.read1(size)
         self._pos += len(buf)
         return buf
 

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -347,7 +347,7 @@ class ReadZipFS(FS):
                             raw_info["access"] = {
                                 "permissions": Permissions(
                                     mode=zip_info.external_attr >> 16 & 0xFFF
-                                )
+                                ).dump()
                             }
 
         return Info(raw_info)

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -337,17 +337,16 @@ class ReadZipFS(FS):
                     if "zip" in namespaces:
                         raw_info["zip"] = {
                             k: getattr(zip_info, k)
-                            for k in dir(zip_info)
-                            if (not k.startswith('_') and
-                                not callable(getattr(zip_info, k)))
+                            for k in zip_info.__slots__
+                            if not k.startswith('_')
                         }
                     if "access" in namespaces:
                         # check the zip was created on UNIX to get permissions
-                        if zip_info.create_system == 3:
-                            mode = zip_info.external_attr >> 16 & 0xFFF
+                        if zip_info.external_attr \
+                                and zip_info.create_system == 3:
                             raw_info["access"] = {
                                 "permissions": Permissions(
-                                    mode=mode or 0o600  # default permission
+                                    mode=zip_info.external_attr >> 16 & 0xFFF
                                 ).dump(),
                             }
 

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -344,10 +344,11 @@ class ReadZipFS(FS):
                     if "access" in namespaces:
                         # check the zip was created on UNIX to get permissions
                         if zip_info.create_system == 3:
+                            mode = zip_info.external_attr >> 16 & 0xFFF
                             raw_info["access"] = {
                                 "permissions": Permissions(
-                                    mode=zip_info.external_attr >> 16 & 0xFFF
-                                ).dump()
+                                    mode=mode or 0o600  # default permission
+                                ).dump(),
                             }
 
         return Info(raw_info)

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -81,12 +81,11 @@ class _ZipExtFile(RawWrapper):
                 else:
                     self._f.read(offset)
                 self._pos += offset
+            elif self._f._offset + offset >= 0:
+                self._f._offset += offset
+                self._pos += offset
             else:
-                if self._f._offset + offset >= 0:
-                    self._f._offset += offset
-                    self._pos += offset
-                else:
-                    self.seek(self._pos + offset, Seek.set)
+                self.seek(self._pos + offset, Seek.set)
 
         elif whence == Seek.end:
             if offset > 0:

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -5,6 +5,7 @@ from six import text_type
 from fs.opener import open_fs
 from fs import walk
 from fs import errors
+from fs.memoryfs import MemoryFS
 from fs.test import UNICODE_TEXT
 
 
@@ -68,7 +69,8 @@ class ArchiveTestCases(object):
         top = self.fs.getinfo('top.txt', ['details', 'access'])
         self.assertEqual(top.size, 12)
         self.assertFalse(top.is_dir)
-
+        if not isinstance(self.source_fs, MemoryFS):
+            self.assertEqual(top.permissions.mode, 0o644)
 
     def test_listdir(self):
         self.assertEqual(

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from six import text_type
 
 from fs.opener import open_fs
+from fs.enums import ResourceType
 from fs import walk
 from fs import errors
 from fs.memoryfs import MemoryFS
@@ -62,15 +63,22 @@ class ArchiveTestCases(object):
             self.fs.setinfo('foo.txt', {})
 
     def test_getinfo(self):
-        root = self.fs.getinfo('/')
+        root = self.fs.getinfo('/', ["details"])
         self.assertEqual(root.name, '')
         self.assertTrue(root.is_dir)
+        self.assertEqual(root.get('details', 'type'), ResourceType.directory)
+
+        bar = self.fs.getinfo('foo/bar', ['details'])
+        self.assertEqual(bar.name, 'bar')
+        self.assertTrue(bar.is_dir)
+        self.assertEqual(bar.get('details', 'type'), ResourceType.directory)
 
         top = self.fs.getinfo('top.txt', ['details', 'access'])
         self.assertEqual(top.size, 12)
         self.assertFalse(top.is_dir)
         if not isinstance(self.source_fs, MemoryFS):
             self.assertEqual(top.permissions.mode, 0o644)
+        self.assertEqual(top.get('details', 'type'), ResourceType.file)
 
     def test_listdir(self):
         self.assertEqual(

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -65,9 +65,10 @@ class ArchiveTestCases(object):
         self.assertEqual(root.name, '')
         self.assertTrue(root.is_dir)
 
-        top = self.fs.getinfo('top.txt', 'details')
+        top = self.fs.getinfo('top.txt', ['details', 'access'])
         self.assertEqual(top.size, 12)
         self.assertFalse(top.is_dir)
+
 
     def test_listdir(self):
         self.assertEqual(
@@ -130,4 +131,3 @@ class ArchiveTestCases(object):
     def test_implied_dir(self):
         self.fs.getinfo('foo/bar')
         self.fs.getinfo('foo')
-

--- a/tests/test_tarfs.py
+++ b/tests/test_tarfs.py
@@ -4,6 +4,7 @@ import os
 import six
 import gzip
 import tarfile
+import getpass
 import tempfile
 import unittest
 
@@ -153,7 +154,13 @@ class TestReadTarFS(ArchiveTestCases, unittest.TestCase):
         try:
             tarfs.TarFS(self._temp_path)
         except:
-            self.fail("Couldn't open tarfs from fileobject")
+            self.fail("Couldn't open tarfs from filename")
+
+    def test_getinfo(self):
+        super(TestReadTarFS, self).test_getinfo()
+        top = self.fs.getinfo('top.txt', ['tar'])
+        self.assertTrue(top.get('tar', 'is_file'))
+
 
 class TestReadTarFSMem(TestReadTarFS):
 

--- a/tests/test_zipfs.py
+++ b/tests/test_zipfs.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import os
+import sys
 import tempfile
 import unittest
 import zipfile
@@ -49,6 +50,12 @@ class TestReadZipFS(ArchiveTestCases, unittest.TestCase):
 
     def remove_archive(self):
         os.remove(self._temp_path)
+
+    def test_getinfo(self):
+        super(TestReadZipFS, self).test_getinfo()
+        top = self.fs.getinfo('top.txt', ['zip'])
+        if sys.platform in ('linux', 'darwin'):
+            self.assertEqual(top.get('zip', 'create_system'), 3)
 
     def test_openbin(self):
         with self.fs.openbin('top.txt') as f:
@@ -119,8 +126,6 @@ class TestReadZipFS(ArchiveTestCases, unittest.TestCase):
             self.assertEqual(f.seek(-7, Seek.end), 5)
             self.assertEqual(f.seek(-5, Seek.end), 7)
             self.assertEqual(f.read(), b'World')
-
-
 
 
 class TestReadZipFSMem(TestReadZipFS):

--- a/tests/test_zipfs.py
+++ b/tests/test_zipfs.py
@@ -60,6 +60,24 @@ class TestReadZipFS(ArchiveTestCases, unittest.TestCase):
         with self.fs.openbin('top.txt') as f:
             self.assertRaises(ValueError, f.seek, 0, 5)
 
+    def test_read(self):
+        with self.fs.openbin('top.txt') as f:
+            self.assertEqual(f.read(), b'Hello, World')
+        with self.fs.openbin('top.txt') as f:
+            self.assertEqual(f.read(5), b'Hello')
+            self.assertEqual(f.read(7), b', World')
+        with self.fs.openbin('top.txt') as f:
+            self.assertEqual(f.read(12), b'Hello, World')
+
+    def test_read1(self):
+        with self.fs.openbin('top.txt') as f:
+            self.assertEqual(f.read1(), b'Hello, World')
+        with self.fs.openbin('top.txt') as f:
+            self.assertEqual(f.read1(5), b'Hello')
+            self.assertEqual(f.read1(7), b', World')
+        with self.fs.openbin('top.txt') as f:
+            self.assertEqual(f.read1(12), b'Hello, World')
+
     def test_seek_set(self):
         with self.fs.openbin('top.txt') as f:
             self.assertEqual(f.tell(), 0)
@@ -90,6 +108,8 @@ class TestReadZipFS(ArchiveTestCases, unittest.TestCase):
             self.assertEqual(f.tell(), 12)
             self.assertEqual(f.seek(-1, Seek.current), 11)
             self.assertEqual(f.read(), b'd')
+        with self.fs.openbin('top.txt') as f:
+            self.assertRaises(ValueError, f.seek, -1, Seek.current)
 
     def test_seek_end(self):
         with self.fs.openbin('top.txt') as f:


### PR DESCRIPTION
## About #98

The objects returned by `ZipFile.open` do not support seeking, but since they use an internal buffer we can use that buffer to our advantage. So here's what I did:

* `_ZipExtFile.seek` will try to use the internal zip buffer as much as possible, by manually changing the position of the internal file object in the buffer. If it's not possible, then: 
    - if we're seeking backward, we will have to open the file one more time (like `FTPFile` does)
    - if we're seeking forward, we read and discard until we reach the desired position
* `_ZipExtFile.read` and `_ZipExtFile.read1` were patched to prevent the internal file object from discarding the read buffer on EOF. Without this fudge, we would have to reopen the file each time the EOF is reached, even for a `_ZipExtFile.seek(-1, Seek.end)`.
* `_ZipExtFile.tell` will return the position of the file.

While I was at it, I implemented #60 as well :smile: : 

## About #60 

* When reading a zip file, permissions are extracted (but nothing else, since Zip files do not store owner / group of the archive), **providing that the zip file was created on a Unix system**, and that there are some permissions to extract.
* When writing a zip file, permissions from the `"access"` namespace are written (as well as the directory bit to indicate whether the zip entry is a file or a directory). If there are no permissions to write, `zip_info.external_attr` is left as default (`0`).

I also reorganized `ReadZipFs.getinfo` to only return the required namespaces, meaning the call to `ZipFile.getinfo` will be skipped if possible, and then did the same thing for `ReadTarFs` for the archives filesystems to be more consistent.

## People this may interest
* @willmcgugan 😄 
* @rkhwaja  
* @mashabow 
