### PR TITLE
walker_class attribute for filesystem

### DIFF
--- a/fs/base.py
+++ b/fs/base.py
@@ -43,6 +43,9 @@ class FS(object):
 
     # This is the "standard" meta namespace.
     _meta = {}
+    
+    # most FS will use default walking algorithms
+    walker_class=Walker
 
     def __init__(self):
         """Create a filesystem. See help(type(self)) for accurate signature.
@@ -65,7 +68,7 @@ class FS(object):
     def walk(self):
         """`~fs.walk.BoundWalker`: a walker bound to this filesystem.
         """
-        return Walker.bind(self)
+        return self.walker_class.bind(self)
 
     # ---------------------------------------------------------------- #
     # Required methods                                                 #

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -397,3 +397,8 @@ class WrapFS(FS):
             _fs.validatepath(_path)
         path = abspath(normpath(path))
         return path
+
+    @property
+    def walk(self):
+        return self._wrap_fs.walker_class.bind(self)
+

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -5,6 +5,7 @@ import unittest
 from fs.errors import FSError
 from fs.memoryfs import MemoryFS
 from fs import walk
+from fs.wrap import read_only
 
 
 class TestWalkerBase(unittest.TestCase):
@@ -196,3 +197,46 @@ class TestWalk(unittest.TestCase):
     def test_on_error_invalid(self):
         with self.assertRaises(TypeError):
             walk.Walker(on_error='nope')
+    
+    def test_subdir_uses_same_walker(self):
+        class CustomWalker(walk.Walker):
+
+            @classmethod
+            def bind(cls, fs):
+                return walk.BoundWalker(fs, walker_class=CustomWalker)
+
+        class CustomizedMemoryFS(MemoryFS):
+            walker_class=CustomWalker
+
+        base_fs=CustomizedMemoryFS()
+        base_fs.settext("a", "a")
+        base_fs.makedirs("b")
+        base_fs.settext("b/c", "c")
+        base_fs.settext("b/d", "d")
+        base_walker=base_fs.walk
+        self.assertEqual(base_walker.walker_class, CustomWalker)
+        self.assertCountEqual(["/a", "/b/c", "/b/d"], base_walker.files())
+
+        sub_fs=base_fs.opendir("b")
+        sub_walker=sub_fs.walk
+        self.assertEqual(sub_walker.walker_class, CustomWalker)
+        self.assertCountEqual(["/c", "/d"], sub_walker.files())
+
+    def test_readonly_wrapper_uses_same_walker(self):
+        class CustomWalker(walk.Walker):
+
+            @classmethod
+            def bind(cls, fs):
+                return walk.BoundWalker(fs, walker_class=CustomWalker)
+
+        class CustomizedMemoryFS(MemoryFS):
+            walker_class=CustomWalker
+
+        base_fs=CustomizedMemoryFS()
+        base_walker=base_fs.walk
+        self.assertEqual(base_walker.walker_class, CustomWalker)
+
+        readonly_fs=read_only(CustomizedMemoryFS())
+        readonly_walker=readonly_fs.walk
+        self.assertEqual(readonly_walker.walker_class, CustomWalker)
+

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -6,6 +6,7 @@ from fs.errors import FSError
 from fs.memoryfs import MemoryFS
 from fs import walk
 from fs.wrap import read_only
+import six
 
 
 class TestWalkerBase(unittest.TestCase):
@@ -215,12 +216,12 @@ class TestWalk(unittest.TestCase):
         base_fs.settext("b/d", "d")
         base_walker=base_fs.walk
         self.assertEqual(base_walker.walker_class, CustomWalker)
-        self.assertCountEqual(["/a", "/b/c", "/b/d"], base_walker.files())
+        six.assertCountEqual(self, ["/a", "/b/c", "/b/d"], base_walker.files())
 
         sub_fs=base_fs.opendir("b")
         sub_walker=sub_fs.walk
         self.assertEqual(sub_walker.walker_class, CustomWalker)
-        self.assertCountEqual(["/c", "/d"], sub_walker.files())
+        six.assertCountEqual(self, ["/c", "/d"], sub_walker.files())
 
     def test_readonly_wrapper_uses_same_walker(self):
         class CustomWalker(walk.Walker):


### PR DESCRIPTION
I needed to write custom walker for my custom fs. It was done via override of 'walk' property. Everything was fine until I opened subdir. It turned out that WrapFS inherits 'walk' property from base FS, which always uses default Walker class. 
I propose introduction of 'walker_class' fs class-level attribute which is used in 'walk' propery instead of hard-coded Walker class. With this, custom fs will only need to redefine it to use another walker.