### PR TITLE
Add support for FTP-Proxy

### DIFF
--- a/fs/opener/ftpfs.py
+++ b/fs/opener/ftpfs.py
@@ -20,10 +20,17 @@ class FTPOpener(Opener):
         ftp_host, _, dir_path = parse_result.resource.partition('/')
         ftp_host, _, ftp_port = ftp_host.partition(':')
         ftp_port = int(ftp_port) if ftp_port.isdigit() else 21
+
+        try:
+            username = '{}@{}'.format(parse_result.username, ftp_host)
+            ftp_host = parse_result.params['proxy']
+        except KeyError:
+            username = parse_result.username
+
         ftp_fs = FTPFS(
             ftp_host,
             port=ftp_port,
-            user=parse_result.username,
+            user=username,
             passwd=parse_result.password,
         )
         ftp_fs = (

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -306,3 +306,12 @@ class TestOpeners(unittest.TestCase):
         user_data_fs_foo_dir = open_fs('userdata://fstest:willmcgugan:1.0/foo/')
         self.assertEqual(user_data_fs_foo_dir.gettext('bar.txt'), 'baz')
 
+    @mock.patch("fs.ftpfs.FTPFS")
+    def test_open_ftp(self, mock_FTPFS):
+        open_fs('ftp://foo:bar@ftp.example.org')
+        mock_FTPFS.assert_called_once_with('ftp.example.org', passwd='bar', port=21, user='foo')
+
+    @mock.patch("fs.ftpfs.FTPFS")
+    def test_open_ftp_proxy(self, mock_FTPFS):
+        open_fs('ftp://foo:bar@ftp.example.org?proxy=ftp.proxy.org')
+        mock_FTPFS.assert_called_once_with('ftp.proxy.org', passwd='bar', port=21, user='foo@ftp.example.org')


### PR DESCRIPTION
As a followup to #75 and #82 I'd like to contribute the code I added locally for using our FTP-Proxy.
I added tests as good as it was possible. Would love to write an integration test someday, but I didn't succeed yet.