### PR TITLE
Walk iterators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ python:
 
 os:
   - linux
-  - osx
 
 before_install:
   - pip install setuptools pip -U

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - fs.getfile function
 
+### Changed
+
+- Modified walk to use iterators internally (for more efficient walking)
+
 ## [2.0.17] - 2017-11-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Modified walk to use iterators internally (for more efficient walking)
+- Modified fs.copy to use getfile
 
 ## [2.0.17] - 2017-11-20
 

--- a/fs/compress.py
+++ b/fs/compress.py
@@ -102,7 +102,6 @@ def write_zip(src_fs,
                     _zip.write(sys_path, zip_name)
 
 
-
 def write_tar(src_fs,
               file,
               compression=None,

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -103,10 +103,12 @@ def copy_file(src_fs, src_path, dst_fs, dst_path):
             else:
                 # Standard copy
                 with src_fs.lock(), dst_fs.lock():
-                    with src_fs.openbin(src_path) as read_file:
-                        # There may be an optimized copy available on
-                        # dst_fs
-                        dst_fs.setbinfile(dst_path, read_file)
+                    if src_fs.getmeta().get('network', False):
+                        with dst_fs.openbin(dst_path, 'w') as write_file:
+                            src_fs.getfile(src_path, write_file)
+                    else:
+                        with src_fs.openbin(src_path) as read_file:
+                            dst_fs.setbinfile(dst_path, read_file)
 
 
 def copy_file_if_newer(src_fs, src_path, dst_fs, dst_path):

--- a/fs/mirror.py
+++ b/fs/mirror.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-from .copy import copy_file
+from .copy import copy_file_internal
 from .errors import ResourceNotFound
 from .walk import Walker
 from .opener import manage_fs
@@ -92,7 +92,7 @@ def _mirror(src_fs, dst_fs, walker=None, copy_if_newer=True):
                     # Compare file info
                     if copy_if_newer and not _compare(_file, dst_file):
                         continue
-            copy_file(src_fs, _path, dst_fs, _path)
+            copy_file_internal(src_fs, _path, dst_fs, _path)
 
         # Make directories
         for _dir in dirs:

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -159,6 +159,10 @@ class MountFS(FS):
         fs, _path = self._delegate(path)
         return fs.getbytes(_path)
 
+    def getfile(self, path, file, chunk_size=None, **options):
+        fs, _path = self._delegate(path)
+        return fs.getfile(_path, file, chunk_size=chunk_size, **options)
+
     def gettext(self, path, encoding=None, errors=None, newline=None):
         self.check()
         fs, _path = self._delegate(path)

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -291,13 +291,13 @@ class MultiFS(FS):
 
     def hassyspath(self, path):
         self.check()
-        fs = self._delegate_required(path)
-        return fs.hassyspath(path)
+        fs = self._delegate(path)
+        return fs is not None and fs.hassyspath(path)
 
     def hasurl(self, path, purpose='download'):
         self.check()
-        fs = self._delegate_required(path)
-        return fs.hasurl(path, purpose=purpose)
+        fs = self._delegate(path)
+        return fs is not None and fs.hasurl(path, purpose=purpose)
 
     def isdir(self, path):
         self.check()

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -259,6 +259,10 @@ class MultiFS(FS):
             raise errors.ResourceNotFound(path)
         return fs.getbytes(path)
 
+    def getfile(self, path, file, chunk_size=None, **options):
+        fs = self._delegate_required(path)
+        return fs.getfile(path, file, chunk_size=chunk_size, **options)
+
     def gettext(self, path, encoding=None, errors=None, newline=''):
         self.check()
         fs = self._delegate_required(path)

--- a/fs/test.py
+++ b/fs/test.py
@@ -401,6 +401,8 @@ class FSTestCases(object):
             self.assertFalse(self.fs.hassyspath('foo'))
         else:
             self.assertTrue(self.fs.hassyspath('foo'))
+        # Should not throw an error
+        self.fs.hassyspath('a/b/c/foo/bar')
 
     def test_geturl(self):
         self.fs.create('foo')
@@ -410,6 +412,8 @@ class FSTestCases(object):
             self.assertFalse(self.fs.hasurl('foo'))
         else:
             self.assertTrue(self.fs.hasurl('foo'))
+        # Should not throw an error
+        self.fs.hasurl('a/b/c/foo/bar')
 
     def test_geturl_purpose(self):
         """Check an unknown purpose raises a NoURL error.

--- a/fs/test.py
+++ b/fs/test.py
@@ -1075,8 +1075,14 @@ class FSTestCases(object):
 
     def test_removetree(self):
         self.fs.makedirs('foo/bar/baz')
+        self.fs.makedirs('foo/egg')
+        self.fs.makedirs('foo/a/b/c/d/e')
         self.fs.create('foo/egg.txt')
         self.fs.create('foo/bar/egg.bin')
+        self.fs.create('foo/bar/baz/egg.txt')
+        self.fs.create('foo/a/b/c/1.txt')
+        self.fs.create('foo/a/b/c/2.txt')
+        self.fs.create('foo/a/b/c/3.txt')
 
         self.assert_exists('foo/egg.txt')
         self.assert_exists('foo/bar/egg.bin')

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -419,7 +419,7 @@ class Walker(WalkerBase):
                 if info is None:
                     for _info in dir_info[dir_path]:
                         yield dir_path, _info
-                    dir_info.pop(dir_path)
+                    del dir_info[dir_path]
                 else:
                     dir_info[dir_path].append(info)
 

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -42,7 +42,8 @@ class Walker(object):
             list of filename patterns, e.g. ``['*.py']``. Files will only
             be returned if the final component matches one of the patterns.
         exclude_dirs (list, optional): A list of patterns that will be used
-            to filter out directories from the walk. e.g. ``['*.svn', '*.git']``.
+            to filter out directories from the walk. e.g.
+            ``['*.svn', '*.git']``.
         max_depth (int, optional): Maximum directory depth to walk.
 
     """
@@ -322,7 +323,6 @@ class Walker(object):
         for _path, info in self.walk_info(fs, path=path):
             if not info.is_dir:
                 yield join(_path, info.name)
-
 
     def dirs(self, fs, path='/'):
         """Walk a filesystem, yielding absolute paths to directories.

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -375,10 +375,11 @@ class Walker(object):
             elif info.is_dir:
                 _depth = self._calculate_depth(dir_path) - depth + 1
                 if self._check_open_dir(fs, dir_path, info):
-                    defered.append((dir_path, info))
                     if self._check_scan_dir(fs, dir_path, info, _depth):
                         _path = join(dir_path, info.name)
-                        push((_path, scan(_path), []))
+                        push((_path, scan(_path), [(dir_path, info)]))
+                    else:
+                        yield dir_path, info
             else:
                 if self.check_file(fs, info):
                     yield dir_path, info

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -407,15 +407,15 @@ class Walker(WalkerBase):
         _path = abspath(normpath(path))
 
         if self.search == 'breadth':
-            walk = self._walk_breadth(fs, _path, namespaces=namespaces)
-            for dir_path, info in walk:
+            _walk = self._walk_breadth(fs, _path, namespaces=namespaces)
+            for dir_path, info in _walk:
                 if info is not None:
                     yield dir_path, info
 
         elif self.search == 'depth':
             dir_info = defaultdict(list)
-            walk = self._walk_depth(fs, _path, namespaces=namespaces)
-            for dir_path, info in walk:
+            _walk = self._walk_depth(fs, _path, namespaces=namespaces)
+            for dir_path, info in _walk:
                 if info is None:
                     for _info in dir_info[dir_path]:
                         yield dir_path, _info

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -144,14 +144,12 @@ class Walker(object):
             max_depth=(self.max_depth, None)
         )
 
-    @property
-    def _iter_walk(self):
+    def _iter_walk(self, fs, path, namespaces=None):
         """Get the walk generator."""
-        return (
-            self._walk_breadth
-            if self.search == 'breadth' else
-            self._walk_depth
-        )
+        if self.search == 'breadth':
+            return self._walk_breadth(fs, path, namespaces=namespaces)
+        else:
+            return self._walk_depth(fs, path, namespaces=namespaces)
 
     def _check_open_dir(self, fs, path, info):
         """Check if a directory should be considered in the walk.

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -361,15 +361,15 @@ class Walker(object):
             return self._scan(fs, path, namespaces=namespaces)
 
         depth = self._calculate_depth(path)
-        stack = [(path, scan(path), [])]
+        stack = [(path, scan(path), None)]
         push = stack.append
 
         while stack:
-            dir_path, iter_files, defered = stack[-1]
+            dir_path, iter_files, parent = stack[-1]
             info = next(iter_files, None)
             if info is None:
-                for item in defered:
-                    yield item
+                if parent is not None:
+                    yield parent
                 yield dir_path, None
                 del stack[-1]
             elif info.is_dir:
@@ -377,7 +377,7 @@ class Walker(object):
                 if self._check_open_dir(fs, dir_path, info):
                     if self._check_scan_dir(fs, dir_path, info, _depth):
                         _path = join(dir_path, info.name)
-                        push((_path, scan(_path), [(dir_path, info)]))
+                        push((_path, scan(_path), (dir_path, info)))
                     else:
                         yield dir_path, info
             else:

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -115,8 +115,8 @@ class WalkerBase(object):
             (str, Info): a tuple of ``(<absolute path>, <resource info>)``.
 
         """
-        walk = self.walk_info(fs, path=path, namespaces=namespaces)
-        for _path, info in walk:
+        _walk = self.walk_info(fs, path=path, namespaces=namespaces)
+        for _path, info in _walk:
             yield join(_path, info.name), info
 
 

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -249,8 +249,8 @@ class Walker(WalkerBase):
             infos (list): A list of `~fs.info.Info` instances.
 
         Returns:
-            list: An iterator of `Info` objects passing the ``check_file``
-            validation.
+            ~collections.Iterator: An iterator of `Info` objects passing
+            the ``check_file`` validation.
 
         """
         _check_file = self.check_file

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -279,27 +279,6 @@ class Walker(object):
             else:
                 dir_info[dir_path].append(info)
 
-    def walk_info(self, fs, path='/', namespaces=None):
-        """Walk the directory structure of a filesystem, yielding
-        tuples of an absolute paths to he current directory and a
-        `~fs.info.Info` object.
-
-        Arguments:
-            fs (FS): A filesystem instance.
-            path (str, optional): A path to a directory on the filesystem.
-            namespaces(list, optional): A list of additional namespaces
-                to add to the `~fs.info.Info` objects.
-
-        Returns: ~collections.Iterator: iterator of (path,
-            `~fs.info.Info`) tuples.
-
-        """
-        _path = abspath(normpath(path))
-        _walk = self._iter_walk(fs, _path, namespaces=namespaces)
-        for dir_path, info in _walk:
-            if info is not None:
-                yield dir_path, info
-
     def files(self, fs, path='/'):
         """Walk a filesystem, yielding absolute paths to files.
 
@@ -312,8 +291,8 @@ class Walker(object):
             recursively within the given directory.
 
         """
-        for _path, info in self.walk_info(fs, path=path):
-            if not info.is_dir:
+        for _path, info in self._iter_walk(fs, path=path):
+            if info is not None and not info.is_dir:
                 yield join(_path, info.name)
 
     def dirs(self, fs, path='/'):
@@ -328,8 +307,8 @@ class Walker(object):
             recursively within the given directory.
 
         """
-        for _path, info in self.walk_info(fs, path=path):
-            if info.is_dir:
+        for _path, info in self._iter_walk(fs, path=path):
+            if info is not None and info.is_dir:
                 yield join(_path, info.name)
 
     def info(self, fs, path='/', namespaces=None):
@@ -345,9 +324,10 @@ class Walker(object):
             (str, Info): a tuple of ``(<absolute path>, <resource info>)``.
 
         """
-        _walk = self.walk_info(fs, path=path, namespaces=namespaces)
+        _walk = self._iter_walk(fs, path=path, namespaces=namespaces)
         for _path, info in _walk:
-            yield join(_path, info.name), info
+            if info is not None:
+                yield join(_path, info.name), info
 
     def _walk_breadth(self, fs, path, namespaces=None):
         """Walk files using a *breadth first* search.

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -457,9 +457,7 @@ class Walker(WalkerBase):
             return self._scan(fs, path, namespaces=namespaces)
 
         depth = self._calculate_depth(path)
-        stack = [(
-            path, scan(path)
-        )]
+        stack = [(path, scan(path))]
         push = stack.append
 
         while stack:
@@ -476,9 +474,7 @@ class Walker(WalkerBase):
                         yield dir_path, info
                         if self._check_scan_dir(fs, dir_path, info, _depth):
                             _path = join(dir_path, info.name)
-                            push((
-                                _path, scan(_path)
-                            ))
+                            push((_path, scan(_path)))
                 else:
                     yield dir_path, info
 

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -380,14 +380,13 @@ class Walker(WalkerBase):
 
         dir_info = defaultdict(list)
         for dir_path, info in do_walk(fs, _path, namespaces=namespaces):
-
             if info is None:
                 dirs = []
                 files = []
                 for _info in dir_info[dir_path]:
                     (dirs if _info.is_dir else files).append(_info)
                 yield Step(dir_path, dirs, files)
-                dir_info.pop(dir_path)
+                del dir_info[dir_path]
             else:
                 dir_info[dir_path].append(info)
 

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -155,7 +155,7 @@ class Walker(object):
         """Check if a directory should be considered in the walk.
         """
         if (self.exclude_dirs is not None and
-            fs.match(self.exclude_dirs, info.name)):
+                fs.match(self.exclude_dirs, info.name)):
             return False
         return self.check_open_dir(fs, path, info)
 

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -458,34 +458,29 @@ class Walker(WalkerBase):
 
         depth = self._calculate_depth(path)
         stack = [(
-            path, scan(path), [], []
+            path, scan(path)
         )]
         push = stack.append
 
         while stack:
-            dir_path, iter_files, dirs, files = stack[-1]
+            dir_path, iter_files = stack[-1]
             try:
                 info = next(iter_files)
             except StopIteration:
-                for info in dirs:
-                    yield dir_path, info
-                for info in self.filter_files(fs, files):
-                    yield dir_path, info
                 yield dir_path, None
-
                 del stack[-1]
             else:
                 if info.is_dir:
                     _depth = self._calculate_depth(dir_path) - depth + 1
                     if self._check_open_dir(fs, dir_path, info):
-                        dirs.append(info)
+                        yield dir_path, info
                         if self._check_scan_dir(fs, dir_path, info, _depth):
                             _path = join(dir_path, info.name)
                             push((
-                                _path, scan(_path), [], []
+                                _path, scan(_path)
                             ))
                 else:
-                    files.append(info)
+                    yield dir_path, info
 
 
 class BoundWalker(object):

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -93,6 +93,15 @@ class TestWalk(unittest.TestCase):
         files = sorted(info.name for info in results[0].files)
         self.assertEqual(files, [])
 
+    def test_walk_levels_1_depth(self):
+        results = list(self.fs.walk(max_depth=1, search='depth'))
+        self.assertEqual(len(results), 1)
+        dirs = sorted(info.name for info in results[0].dirs)
+        self.assertEqual(dirs, ['foo1', 'foo2', 'foo3'])
+        files = sorted(info.name for info in results[0].files)
+        self.assertEqual(files, [])
+
+
     def test_walk_levels_2(self):
         _walk = []
         for step in self.fs.walk(max_depth=2):

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -149,9 +149,9 @@ class TestWalk(unittest.TestCase):
             dirs,
             [
                 '/foo1/bar1',
+                '/foo1',
                 '/foo2/bar2/bar3',
                 '/foo2/bar2',
-                '/foo1',
                 '/foo2',
                 '/foo3'
             ]

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -9,14 +9,6 @@ from fs.wrap import read_only
 import six
 
 
-class TestWalkerBase(unittest.TestCase):
-
-    def test_not_implemented(self):
-        walker = walk.WalkerBase()
-        with self.assertRaises(NotImplementedError):
-            walker.walk(None, path='/')
-
-
 class TestWalker(unittest.TestCase):
 
     def setUp(self):
@@ -45,7 +37,7 @@ class TestWalk(unittest.TestCase):
         self.fs.makedir('foo2/bar2')
         self.fs.makedir('foo2/bar2/bar3')
         self.fs.create('foo2/bar2/bar3/test.txt')
-        self.fs.create('foo2/top3.txt')
+        self.fs.create('foo2/top3.bin')
 
     def test_invalid(self):
         with self.assertRaises(ValueError):
@@ -64,7 +56,20 @@ class TestWalk(unittest.TestCase):
                 [info.name for info in dirs],
                 [info.name for info in files]
             ))
-        expected = [(u'/', [u'foo1', u'foo2', u'foo3'], []), (u'/foo1', [u'bar1'], [u'top1.txt', u'top2.txt']), (u'/foo2', [u'bar2'], [u'top3.txt']), (u'/foo3', [], []), (u'/foo1/bar1', [], []), (u'/foo2/bar2', [u'bar3'], []), (u'/foo2/bar2/bar3', [], [u'test.txt'])]
+        expected = [(u'/', [u'foo1', u'foo2', u'foo3'], []), (u'/foo1', [u'bar1'], [u'top1.txt', u'top2.txt']), (u'/foo2', [u'bar2'], [u'top3.bin']), (u'/foo3', [], []), (u'/foo1/bar1', [], []), (u'/foo2/bar2', [u'bar3'], []), (u'/foo2/bar2/bar3', [], [u'test.txt'])]
+        self.assertEqual(_walk, expected)
+
+    def test_walk_depth(self):
+        _walk = []
+        for step in self.fs.walk(search='depth'):
+            self.assertIsInstance(step, walk.Step)
+            path, dirs, files = step
+            _walk.append((
+                path,
+                [info.name for info in dirs],
+                [info.name for info in files]
+            ))
+        expected = [(u'/foo1/bar1', [], []), (u'/foo1', [u'bar1'], [u'top1.txt', u'top2.txt']), (u'/foo2/bar2/bar3', [], [u'test.txt']), (u'/foo2/bar2', [u'bar3'], []), (u'/foo2', [u'bar2'], [u'top3.bin']), (u'/foo3', [], []), (u'/', [u'foo1', u'foo2', u'foo3'], [])]
         self.assertEqual(_walk, expected)
 
     def test_walk_directory(self):
@@ -77,7 +82,7 @@ class TestWalk(unittest.TestCase):
                 [info.name for info in dirs],
                 [info.name for info in files]
             ))
-        expected = [(u'/foo2', [u'bar2'], [u'top3.txt']), (u'/foo2/bar2', [u'bar3'], []), (u'/foo2/bar2/bar3', [], [u'test.txt'])]
+        expected = [(u'/foo2', [u'bar2'], [u'top3.bin']), (u'/foo2/bar2', [u'bar3'], []), (u'/foo2/bar2/bar3', [], [u'test.txt'])]
         self.assertEqual(_walk, expected)
 
     def test_walk_levels_1(self):
@@ -98,7 +103,7 @@ class TestWalk(unittest.TestCase):
                 sorted(info.name for info in dirs),
                 sorted(info.name for info in files)
             ))
-        expected = [(u'/', [u'foo1', u'foo2', u'foo3'], []), (u'/foo1', [u'bar1'], [u'top1.txt', u'top2.txt']), (u'/foo2', [u'bar2'], [u'top3.txt']), (u'/foo3', [], [])]
+        expected = [(u'/', [u'foo1', u'foo2', u'foo3'], []), (u'/foo1', [u'bar1'], [u'top1.txt', u'top2.txt']), (u'/foo2', [u'bar2'], [u'top3.bin']), (u'/foo3', [], [])]
         self.assertEqual(_walk, expected)
 
     def test_walk_files(self):
@@ -109,7 +114,7 @@ class TestWalk(unittest.TestCase):
             [
                 '/foo1/top1.txt',
                 '/foo1/top2.txt',
-                '/foo2/top3.txt',
+                '/foo2/top3.bin',
                 '/foo2/bar2/bar3/test.txt',
             ]
         )
@@ -121,7 +126,7 @@ class TestWalk(unittest.TestCase):
                 '/foo1/top1.txt',
                 '/foo1/top2.txt',
                 '/foo2/bar2/bar3/test.txt',
-                '/foo2/top3.txt',
+                '/foo2/top3.bin',
             ]
         )
 
@@ -162,12 +167,49 @@ class TestWalk(unittest.TestCase):
             ]
         )
 
+    def test_walk_files_filter(self):
+        files = list(self.fs.walk.files(filter=['*.txt']))
+
+        self.assertEqual(
+            files,
+            [
+                '/foo1/top1.txt',
+                '/foo1/top2.txt',
+                '/foo2/bar2/bar3/test.txt',
+            ]
+        )
+
+        files = list(self.fs.walk.files(search="depth", filter=['*.txt']))
+        self.assertEqual(
+            files,
+            [
+                '/foo1/top1.txt',
+                '/foo1/top2.txt',
+                '/foo2/bar2/bar3/test.txt',
+            ]
+        )
+
+        files = list(self.fs.walk.files(filter=['*.bin']))
+
+        self.assertEqual(
+            files,
+            [
+                '/foo2/top3.bin'
+            ]
+        )
+
+        files = list(self.fs.walk.files(filter=['*.nope']))
+
+        self.assertEqual(
+            files, []
+        )
+
     def test_walk_info(self):
         walk = []
         for path, info in self.fs.walk.info():
             walk.append((path, info.is_dir, info.name))
 
-        expected = [(u'/foo1', True, u'foo1'), (u'/foo2', True, u'foo2'), (u'/foo3', True, u'foo3'), (u'/foo1/top1.txt', False, u'top1.txt'), (u'/foo1/top2.txt', False, u'top2.txt'), (u'/foo1/bar1', True, u'bar1'), (u'/foo2/bar2', True, u'bar2'), (u'/foo2/top3.txt', False, u'top3.txt'), (u'/foo2/bar2/bar3', True, u'bar3'), (u'/foo2/bar2/bar3/test.txt', False, u'test.txt')]
+        expected = [(u'/foo1', True, u'foo1'), (u'/foo2', True, u'foo2'), (u'/foo3', True, u'foo3'), (u'/foo1/top1.txt', False, u'top1.txt'), (u'/foo1/top2.txt', False, u'top2.txt'), (u'/foo1/bar1', True, u'bar1'), (u'/foo2/bar2', True, u'bar2'), (u'/foo2/top3.bin', False, u'top3.bin'), (u'/foo2/bar2/bar3', True, u'bar3'), (u'/foo2/bar2/bar3/test.txt', False, u'test.txt')]
         self.assertEqual(walk, expected)
 
     def test_broken(self):

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -166,7 +166,8 @@ class TestWalk(unittest.TestCase):
         walk = []
         for path, info in self.fs.walk.info():
             walk.append((path, info.is_dir, info.name))
-        expected = [(u'/foo1', True, u'foo1'), (u'/foo2', True, u'foo2'), (u'/foo3', True, u'foo3'), (u'/foo1/bar1', True, u'bar1'), (u'/foo1/top1.txt', False, u'top1.txt'), (u'/foo1/top2.txt', False, u'top2.txt'), (u'/foo2/bar2', True, u'bar2'), (u'/foo2/top3.txt', False, u'top3.txt'), (u'/foo2/bar2/bar3', True, u'bar3'), (u'/foo2/bar2/bar3/test.txt', False, u'test.txt')]
+
+        expected = [(u'/foo1', True, u'foo1'), (u'/foo2', True, u'foo2'), (u'/foo3', True, u'foo3'), (u'/foo1/top1.txt', False, u'top1.txt'), (u'/foo1/top2.txt', False, u'top2.txt'), (u'/foo1/bar1', True, u'bar1'), (u'/foo2/bar2', True, u'bar2'), (u'/foo2/top3.txt', False, u'top3.txt'), (u'/foo2/bar2/bar3', True, u'bar3'), (u'/foo2/bar2/bar3/test.txt', False, u'test.txt')]
         self.assertEqual(walk, expected)
 
     def test_broken(self):
@@ -198,7 +199,7 @@ class TestWalk(unittest.TestCase):
     def test_on_error_invalid(self):
         with self.assertRaises(TypeError):
             walk.Walker(on_error='nope')
-    
+
     def test_subdir_uses_same_walker(self):
         class CustomWalker(walk.Walker):
 


### PR DESCRIPTION
This modifies the walk code to use iterators over lists where possible.

This is so that the `info`, `files` and `dirs` methods don't need to load an entire directory worth before they start yielding results--which should also be more memory efficient.

See https://github.com/PyFilesystem/pyfilesystem2/issues/112

Also includes some optimisations for file copying which will benefit S3FS and potentially other network filesystems that implement `getfile`.