### PR TITLE
Add time based update for caching in fs.wrap.WrapCachedDir

### DIFF
--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -12,10 +12,11 @@ Here's an example that opens a filesystem then makes it *read only*::
     fs.errors.ResourceReadOnly: resource '__init__.py' is read only
 
 """
-from time import time
+
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from time import time
 from .wrapfs import WrapFS
 from .path import abspath, normpath, split
 from .errors import ResourceReadOnly, ResourceNotFound

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -16,7 +16,7 @@ Here's an example that opens a filesystem then makes it *read only*::
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import time
+import time as gettime
 from .wrapfs import WrapFS
 from .path import abspath, normpath, split
 from .errors import ResourceReadOnly, ResourceNotFound
@@ -84,19 +84,20 @@ class WrapCachedDir(WrapFS):
                 page=page
             )
             _dir = {info.name: info for info in _scan_result}
-            self._cache[cache_key] = {'time':time.time(),'data':_dir}
+            #help(time)
+            self._cache[cache_key] = {'time':gettime.time(),'data':_dir}
         else:
-            if self._cache[cache_key]['time'] + self.livetime < time.time():
+            if self._cache[cache_key]['time'] + self.livetime < gettime.time():
                 _scan_result = self._wrap_fs.scandir(
                     path,
                     namespaces=namespaces,
                     page=page
                 )
                 _dir = {info.name: info for info in _scan_result}
-                self._cache[cache_key] = {'time':time.time(),'data':_dir}
+                self._cache[cache_key] = {'time':gettime.time(),'data':_dir}
             else:
                 if self.speedup:
-                    self._cache[cache_key]['time'] = time.time()
+                    self._cache[cache_key]['time'] = gettime.time()
 
         gen_scandir = iter(self._cache[cache_key].values())
         return gen_scandir

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -16,7 +16,7 @@ Here's an example that opens a filesystem then makes it *read only*::
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from time import time
+import time
 from .wrapfs import WrapFS
 from .path import abspath, normpath, split
 from .errors import ResourceReadOnly, ResourceNotFound
@@ -84,16 +84,16 @@ class WrapCachedDir(WrapFS):
                 page=page
             )
             _dir = {info.name: info for info in _scan_result}
-            self._cache[cache_key] = {'time':time(),'data':_dir}
+            self._cache[cache_key] = {'time':time.time(),'data':_dir}
         else:
-            if self._cache[cache_key]['time'] + self.livetime < time():
+            if self._cache[cache_key]['time'] + self.livetime < time.time():
                 _scan_result = self._wrap_fs.scandir(
                     path,
                     namespaces=namespaces,
                     page=page
                 )
                 _dir = {info.name: info for info in _scan_result}
-                self._cache[cache_key] = {'time':time(),'data':_dir}
+                self._cache[cache_key] = {'time':time.time(),'data':_dir}
             else:
                 if self.speedup:
                     self._cache[cache_key]['time'] = time.time()

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -15,7 +15,7 @@ Here's an example that opens a filesystem then makes it *read only*::
 
 from __future__ import print_function
 from __future__ import unicode_literals
-
+import time
 from time import time as gettime
 from .wrapfs import WrapFS
 from .path import abspath, normpath, split

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -15,8 +15,9 @@ Here's an example that opens a filesystem then makes it *read only*::
 
 from __future__ import print_function
 from __future__ import unicode_literals
+from __future__ import absolute_import
 
-from ..time import time as gettime
+from time import time as gettime
 from .wrapfs import WrapFS
 from .path import abspath, normpath, split
 from .errors import ResourceReadOnly, ResourceNotFound

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -16,7 +16,7 @@ Here's an example that opens a filesystem then makes it *read only*::
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import time as gettime
+from time import time as gettime
 from .wrapfs import WrapFS
 from .path import abspath, normpath, split
 from .errors import ResourceReadOnly, ResourceNotFound
@@ -85,19 +85,19 @@ class WrapCachedDir(WrapFS):
             )
             _dir = {info.name: info for info in _scan_result}
             #help(time)
-            self._cache[cache_key] = {'time':gettime.time(),'data':_dir}
+            self._cache[cache_key] = {'time':gettime(),'data':_dir}
         else:
-            if self._cache[cache_key]['time'] + self.livetime < gettime.time():
+            if self._cache[cache_key]['time'] + self.livetime < gettime():
                 _scan_result = self._wrap_fs.scandir(
                     path,
                     namespaces=namespaces,
                     page=page
                 )
                 _dir = {info.name: info for info in _scan_result}
-                self._cache[cache_key] = {'time':gettime.time(),'data':_dir}
+                self._cache[cache_key] = {'time':gettime(),'data':_dir}
             else:
                 if self.speedup:
-                    self._cache[cache_key]['time'] = gettime.time()
+                    self._cache[cache_key]['time'] = gettime()
 
         gen_scandir = iter(self._cache[cache_key].values())
         return gen_scandir

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -15,8 +15,8 @@ Here's an example that opens a filesystem then makes it *read only*::
 
 from __future__ import print_function
 from __future__ import unicode_literals
-import time
-from time import time as gettime
+
+from ..time import time as gettime
 from .wrapfs import WrapFS
 from .path import abspath, normpath, split
 from .errors import ResourceReadOnly, ResourceNotFound

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -151,31 +151,6 @@ class TestWrap(unittest.TestCase):
         mem_fs.removedir('foo/bar/baz')
         mem_fs.touch('foo/bar/baz')
         self.assertTrue(fs.isdir('foo/bar/baz'))
-        sleep(0.5)
-        self.assertTrue(fs.isdir('foo/bar/baz'))
-        sleep(0.5)
-        self.assertTrue(fs.isdir('foo/bar/baz'))
-        sleep(3)
-        self.assertFalse(fs.isdir('foo/bar/baz'))    def test_cachedir_time(self):
-        mem_fs = open_fs('mem://')
-        mem_fs.makedirs('foo/bar/baz')
-        mem_fs.touch('egg')
-
-        fs = wrap.cache_directory(mem_fs,livetime=3)
-        self.assertEqual(
-            sorted(fs.listdir('/')),
-            ['egg', 'foo']
-        )
-        self.assertEqual(
-            sorted(fs.listdir('/')),
-            ['egg', 'foo']
-        )
-
-        #caching dir
-        self.assertTrue(fs.isdir('foo/bar/baz'))
-        mem_fs.removedir('foo/bar/baz')
-        mem_fs.touch('foo/bar/baz')
-        self.assertTrue(fs.isdir('foo/bar/baz'))
         sleep(2)
         self.assertTrue(fs.isdir('foo/bar/baz'))
         sleep(2)

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import unittest
 
+from time import sleep
 from fs import errors
 from fs import open_fs
 from fs import wrap
@@ -80,7 +81,7 @@ class TestWrap(unittest.TestCase):
         mem_fs.makedirs('foo/bar/baz')
         mem_fs.touch('egg')
 
-        fs = wrap.cache_directory(mem_fs)
+        fs = wrap.cache_directory(mem_fs,livetime=-1)
         self.assertEqual(
             sorted(fs.listdir('/')),
             ['egg', 'foo']
@@ -102,4 +103,115 @@ class TestWrap(unittest.TestCase):
 
         with self.assertRaises(errors.ResourceNotFound):
             fs.getinfo('/foofoo')
+
+    def test_cachedir_time(self):
+        mem_fs = open_fs('mem://')
+        mem_fs.makedirs('foo/bar/baz')
+        mem_fs.touch('egg')
+
+        fs = wrap.cache_directory(mem_fs,livetime=3)
+        self.assertEqual(
+            sorted(fs.listdir('/')),
+            ['egg', 'foo']
+        )
+        self.assertEqual(
+            sorted(fs.listdir('/')),
+            ['egg', 'foo']
+        )
+
+        #caching dir
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        mem_fs.removedir('foo/bar/baz')
+        mem_fs.touch('foo/bar/baz')
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(0.5)
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(0.5)
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(3)
+        self.assertFalse(fs.isdir('foo/bar/baz'))    def test_cachedir_time(self):
+        mem_fs = open_fs('mem://')
+        mem_fs.makedirs('foo/bar/baz')
+        mem_fs.touch('egg')
+
+        fs = wrap.cache_directory(mem_fs,livetime=3)
+        self.assertEqual(
+            sorted(fs.listdir('/')),
+            ['egg', 'foo']
+        )
+        self.assertEqual(
+            sorted(fs.listdir('/')),
+            ['egg', 'foo']
+        )
+
+        #caching dir
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        mem_fs.removedir('foo/bar/baz')
+        mem_fs.touch('foo/bar/baz')
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(0.5)
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(0.5)
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(3)
+        self.assertFalse(fs.isdir('foo/bar/baz'))
+
+
+
+    def test_cachedir_speedup(self):
+        mem_fs = open_fs('mem://')
+        mem_fs.makedirs('foo/bar/baz')
+        mem_fs.touch('egg')
+
+        fs = wrap.cache_directory(mem_fs,livetime=3,speedup=True)
+        self.assertEqual(
+            sorted(fs.listdir('/')),
+            ['egg', 'foo']
+        )
+        self.assertEqual(
+            sorted(fs.listdir('/')),
+            ['egg', 'foo']
+        )
+
+        #caching dir
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        mem_fs.removedir('foo/bar/baz')
+        mem_fs.touch('foo/bar/baz')
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(0.5)
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(0.5)
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(3)
+        self.assertFalse(fs.isdir('foo/bar/baz'))    def test_cachedir_time(self):
+        mem_fs = open_fs('mem://')
+        mem_fs.makedirs('foo/bar/baz')
+        mem_fs.touch('egg')
+
+        fs = wrap.cache_directory(mem_fs,livetime=3)
+        self.assertEqual(
+            sorted(fs.listdir('/')),
+            ['egg', 'foo']
+        )
+        self.assertEqual(
+            sorted(fs.listdir('/')),
+            ['egg', 'foo']
+        )
+
+        #caching dir
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        mem_fs.removedir('foo/bar/baz')
+        mem_fs.touch('foo/bar/baz')
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(2)
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(2)
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(2)
+        self.assertTrue(fs.isdir('foo/bar/baz'))
+        sleep(4)
+        self.assertFalse(fs.isdir('foo/bar/baz'))
+
+
+
 

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -129,34 +129,7 @@ class TestWrap(unittest.TestCase):
         sleep(0.5)
         self.assertTrue(fs.isdir('foo/bar/baz'))
         sleep(3)
-        self.assertFalse(fs.isdir('foo/bar/baz'))    def test_cachedir_time(self):
-        mem_fs = open_fs('mem://')
-        mem_fs.makedirs('foo/bar/baz')
-        mem_fs.touch('egg')
-
-        fs = wrap.cache_directory(mem_fs,livetime=3)
-        self.assertEqual(
-            sorted(fs.listdir('/')),
-            ['egg', 'foo']
-        )
-        self.assertEqual(
-            sorted(fs.listdir('/')),
-            ['egg', 'foo']
-        )
-
-        #caching dir
-        self.assertTrue(fs.isdir('foo/bar/baz'))
-        mem_fs.removedir('foo/bar/baz')
-        mem_fs.touch('foo/bar/baz')
-        self.assertTrue(fs.isdir('foo/bar/baz'))
-        sleep(0.5)
-        self.assertTrue(fs.isdir('foo/bar/baz'))
-        sleep(0.5)
-        self.assertTrue(fs.isdir('foo/bar/baz'))
-        sleep(3)
         self.assertFalse(fs.isdir('foo/bar/baz'))
-
-
 
     def test_cachedir_speedup(self):
         mem_fs = open_fs('mem://')


### PR DESCRIPTION
A new feature for WrapCachedDir:
livetime: after this time a cached entry is too old and will be recached
speedup: the cache time of uptodate entries will be renewed, so cached entries with many accesses will be delivered from cache more often.

Todo:
cleanup old entries from time to time

Question:
The scandir implementation does not use the page parameter for cache_key, so I think there will bethe same result if you call scandir with page=1 first and page=None secondly.
An Idea is to generate cache_key like:
cache_key = (_path, frozenset(namespaces or ()), path)
Am I right?