### PR TITLE
Allow wrapping exceptions in `CreateFailed`

### DIFF
--- a/fs/errors.py
+++ b/fs/errors.py
@@ -11,6 +11,8 @@ which may be used as a catch-all filesystem exception.
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import functools
+
 import six
 from six import text_type
 
@@ -92,6 +94,21 @@ class CreateFailed(FSError):
 
     default_message = "unable to create filesystem"
 
+    @classmethod
+    def catch_all(cls, func):
+        @functools.wraps(func)
+        def new_func(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except cls:
+                raise
+            except Exception as e:
+                six.raise_from(cls(exc=e), None)
+        return new_func
+
+    def __init__(self, msg=None, exc=None):
+        self._msg = msg or self.default_message
+        self.exc = exc
 
 class PathError(FSError):
     """Base exception for errors to do with a path string.

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -103,7 +103,7 @@ class CreateFailed(FSError):
             except cls:
                 raise
             except Exception as e:
-                six.raise_from(cls(exc=e), None)
+                raise cls(exc=e)
         return new_func
 
     def __init__(self, msg=None, exc=None):

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -92,7 +92,7 @@ class CreateFailed(FSError):
     """Filesystem could not be created.
     """
 
-    default_message = "unable to create filesystem"
+    default_message = "unable to create filesystem, {details}"
 
     @classmethod
     def catch_all(cls, func):
@@ -108,6 +108,7 @@ class CreateFailed(FSError):
 
     def __init__(self, msg=None, exc=None):
         self._msg = msg or self.default_message
+        self.details = '' if exc is None else text_type(exc)
         self.exc = exc
 
 class PathError(FSError):

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -87,14 +87,16 @@ class OSFS(FS):
                 if not os.path.isdir(_root_path):
                     os.makedirs(_root_path, mode=create_mode)
             except OSError as error:
-                raise errors.CreateFailed(
-                    'unable to create {} ({})'.format(root_path, error)
+                six.raise_from(
+                    errors.CreateFailed(
+                        'unable to create {} ({})'.format(root_path, error),
+                        error,
+                    ),
+                    None,
                 )
         else:
             if not os.path.isdir(_root_path):
-                raise errors.CreateFailed(
-                    'root path does not exist'
-                )
+                raise errors.CreateFailed('root path does not exist')
 
         _meta = self._meta = {
             'case_insensitive': os.path.normcase('Aa') != 'aa',

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -87,12 +87,9 @@ class OSFS(FS):
                 if not os.path.isdir(_root_path):
                     os.makedirs(_root_path, mode=create_mode)
             except OSError as error:
-                six.raise_from(
-                    errors.CreateFailed(
-                        'unable to create {} ({})'.format(root_path, error),
-                        error,
-                    ),
-                    None,
+                raise errors.CreateFailed(
+                    'unable to create {} ({})'.format(root_path, error),
+                    error,
                 )
         else:
             if not os.path.isdir(_root_path):

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -198,6 +198,7 @@ class ReadTarFS(FS):
         tarfile.LNKTYPE: ResourceType.symlink,
     }
 
+    @errors.CreateFailed.catch_all
     def __init__(self, file, encoding='utf-8'):
         super(ReadTarFS, self).__init__()
         self._file = file

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -241,6 +241,7 @@ class ReadZipFS(FS):
         'virtual': False,
     }
 
+    @errors.CreateFailed.catch_all
     def __init__(self, file, encoding='utf-8'):
         super(ReadZipFS, self).__init__()
         self._file = file

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -5,6 +5,7 @@ import unittest
 from six import text_type
 
 from fs import errors
+from fs.errors import CreateFailed
 
 
 class TestErrors(unittest.TestCase):
@@ -24,3 +25,22 @@ class TestErrors(unittest.TestCase):
             text_type(err),
             "not supported"
         )
+
+
+class TestCreateFailed(unittest.TestCase):
+
+    def test_catch_all(self):
+
+        errors = (ZeroDivisionError, ValueError, CreateFailed)
+
+        @CreateFailed.catch_all
+        def test(x):
+            raise errors[x]
+
+        for index, exc in enumerate(errors):
+            try:
+                test(index)
+            except Exception as e:
+                self.assertIsInstance(e, CreateFailed)
+                if e.exc is not None:
+                    self.assertNotIsInstance(e.exc, CreateFailed)


### PR DESCRIPTION
Hi Will,
I made it so `CreateFailed` accepts an additional `exc` argument, as discussed in #144.

I also added a decorator classmethod to `CreateFailed`, so that it is easier to wrap any errors occuring in a filesystem `__init__` method into a `CreateFailed` exception.