### PR TITLE
Add typing comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,8 @@ ENV/
 # Rope project settings
 .ropeproject
 
-
-#PyCharm
-
+# PyCharm
 .idea/
+
+# MyPy cache
+.mypy_cache

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,7 @@ testall:
 docs:
 	cd docs && make html
 	python -c "import os, webbrowser; webbrowser.open('file://' + os.path.abspath('./docs/build/html/index.html'))"
+
+.PHONY: typecheck
+typecheck:
+	mypy -p fs --ignore-missing-imports

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ docs:
 
 .PHONY: typecheck
 typecheck:
-	mypy -p fs --ignore-missing-imports
+	mypy -p fs --config setup.cfg

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ Credits
 -------
 
 -  `Will McGugan <https://github.com/willmcgugan>`__
--  `Martin Larralde <https://github.com/althonos>`__ for TarFS
+-  `Martin Larralde <https://github.com/althonos>`__
 -  `Giampaolo <https://github.com/gpcimino>`__ for ``copy_if_newer`` and
    ftp fixes.
 

--- a/fs/_repr.py
+++ b/fs/_repr.py
@@ -3,13 +3,14 @@
 
 from __future__ import unicode_literals
 
+import typing
 
-if False:
+if typing.TYPE_CHECKING:
     from typing import Text, Tuple
 
 
 def make_repr(class_name, *args, **kwargs):
-    # type: (Text, *object, **Tuple[object, object]) -> Text
+    # type: (Text, *object, **Tuple[Text, Text]) -> Text
     """Generate a repr string.
 
     Positional arguments should be the positional arguments used to

--- a/fs/_repr.py
+++ b/fs/_repr.py
@@ -3,7 +3,13 @@
 
 from __future__ import unicode_literals
 
+
+if False:
+    from typing import Text, Tuple
+
+
 def make_repr(class_name, *args, **kwargs):
+    # type: (Text, *object, **Tuple[object, object]) -> Text
     """Generate a repr string.
 
     Positional arguments should be the positional arguments used to

--- a/fs/_repr.py
+++ b/fs/_repr.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import typing
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Text, Tuple
 
 

--- a/fs/_repr.py
+++ b/fs/_repr.py
@@ -10,7 +10,7 @@ if typing.TYPE_CHECKING:
 
 
 def make_repr(class_name, *args, **kwargs):
-    # type: (Text, *object, **Tuple[Text, Text]) -> Text
+    # type: (Text, *object, **Tuple[object, object]) -> Text
     """Generate a repr string.
 
     Positional arguments should be the positional arguments used to

--- a/fs/appfs.py
+++ b/fs/appfs.py
@@ -9,13 +9,14 @@ subclasses of `~fs.osfs.OSFS`.
 
 # see http://technet.microsoft.com/en-us/library/cc766489(WS.10).aspx
 
+import typing
+
 from .osfs import OSFS
 from ._repr import make_repr
 from appdirs import AppDirs
 
-
-if False:  # typing imports
-    from typing import ClassVar, Optional, Text
+if typing.TYPE_CHECKING:
+    from typing import Optional, Text
 
 
 __all__ = ['UserDataFS',
@@ -51,7 +52,7 @@ class _AppFS(OSFS):
         )
 
     def __repr__(self):
-        return make_repr(
+        return make_repr(       # type: ignore
             self.__class__.__name__,
             self.app_dirs.appname,
             author=(self.app_dirs.appauthor, None),
@@ -65,6 +66,7 @@ class _AppFS(OSFS):
             self.__class__.__name__.lower(),
             self.app_dirs.appname
         )
+
 
 class UserDataFS(_AppFS):
     """A filesystem for per-user application data.

--- a/fs/appfs.py
+++ b/fs/appfs.py
@@ -30,10 +30,10 @@ class _AppFS(OSFS):
     """Abstract base class for an app FS.
     """
 
-    # FIXME(@althonos): replace by ClassVar[Optional[Text]]
-    # once https://github.com/python/mypy/pull/4718 is accepted
+    # FIXME(@althonos): replace by ClassVar[Text] once
+    # https://github.com/python/mypy/pull/4718 is accepted
     # (subclass override will raise errors until then)
-    app_dir = None  # type: Optional[Text]
+    app_dir = None  # type: Text
 
     def __init__(self,
                  appname,          # type: Text

--- a/fs/appfs.py
+++ b/fs/appfs.py
@@ -40,8 +40,8 @@ class _AppFS(OSFS):
                  appname,          # type: Text
                  author=None,      # type: Optional[Text]
                  version=None,     # type: Optional[Text]
-                 roaming=False,
-                 create=True
+                 roaming=False,    # type: bool
+                 create=True       # type: bool
                  ):
         # type: (...) -> None
         self.app_dirs = AppDirs(appname, author, version, roaming)
@@ -52,7 +52,8 @@ class _AppFS(OSFS):
         )
 
     def __repr__(self):
-        return make_repr(       # type: ignore
+        # type: () -> Text
+        return make_repr(
             self.__class__.__name__,
             self.app_dirs.appname,
             author=(self.app_dirs.appauthor, None),
@@ -62,6 +63,7 @@ class _AppFS(OSFS):
         )
 
     def __str__(self):
+        # type: () -> Text
         return "<{} '{}'>".format(
             self.__class__.__name__.lower(),
             self.app_dirs.appname

--- a/fs/appfs.py
+++ b/fs/appfs.py
@@ -45,7 +45,7 @@ class _AppFS(OSFS):
                  ):
         # type: (...) -> None
         self.app_dirs = AppDirs(appname, author, version, roaming)
-        self.create = create
+        self._create = create
         super(_AppFS, self).__init__(
             getattr(self.app_dirs, self.app_dir),
             create=create
@@ -59,7 +59,7 @@ class _AppFS(OSFS):
             author=(self.app_dirs.appauthor, None),
             version=(self.app_dirs.version, None),
             roaming=(self.app_dirs.roaming, False),
-            create=(self.create, True)
+            create=(self._create, True)
         )
 
     def __str__(self):

--- a/fs/appfs.py
+++ b/fs/appfs.py
@@ -13,6 +13,11 @@ from .osfs import OSFS
 from ._repr import make_repr
 from appdirs import AppDirs
 
+
+if False:  # typing imports
+    from typing import ClassVar, Optional, Text
+
+
 __all__ = ['UserDataFS',
            'UserConfigFS',
            'SiteDataFS',
@@ -25,14 +30,19 @@ class _AppFS(OSFS):
     """Abstract base class for an app FS.
     """
 
-    app_dir = None
+    # FIXME(@althonos): replace by ClassVar[Optional[Text]]
+    # once https://github.com/python/mypy/pull/4718 is accepted
+    # (subclass override will raise errors until then)
+    app_dir = None  # type: Optional[Text]
 
     def __init__(self,
-                 appname,
-                 author=None,
-                 version=None,
+                 appname,          # type: Text
+                 author=None,      # type: Optional[Text]
+                 version=None,     # type: Optional[Text]
                  roaming=False,
-                 create=True):
+                 create=True
+                 ):
+        # type: (...) -> None
         self.app_dirs = AppDirs(appname, author, version, roaming)
         self.create = create
         super(_AppFS, self).__init__(

--- a/fs/appfs.py
+++ b/fs/appfs.py
@@ -15,7 +15,7 @@ from .osfs import OSFS
 from ._repr import make_repr
 from appdirs import AppDirs
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Optional, Text
 
 

--- a/fs/base.py
+++ b/fs/base.py
@@ -690,7 +690,7 @@ class FS(object):
         return meta
 
     def getsize(self, path):
-        # type: (Text) -> Optional[int]
+        # type: (Text) -> int
         """Get the size (in bytes) of a resource.
 
         Arguments:

--- a/fs/base.py
+++ b/fs/base.py
@@ -40,12 +40,15 @@ if typing.TYPE_CHECKING:
     from datetime import datetime
     from threading import RLock
     from typing import (
-        Any, BinaryIO, Callable, Collection, Dict, IO, Iterable,
-        Iterator, List, Mapping, Optional, Text, Tuple, Union)
+        Any, BinaryIO, Callable, Collection, Dict, IO,
+        Iterable, Iterator, List, Mapping, Optional, Text,
+        Tuple, Type, Union)
+    from types import TracebackType
     from .enums import ResourceType
     from .info import Info, RawInfo
     from .subfs import SubFS
     from .permissions import Permissions
+    from .walk import BoundWalker
 
 
 __all__ = ["FS"]
@@ -80,7 +83,11 @@ class FS(object):
         """
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self,
+                 exc_type,      # type: Optional[Type[BaseException]]
+                 exc_value,     # type: Optional[BaseException]
+                 traceback      # type: Optional[TracebackType]
+                 ):
         # type: (...) -> None
         """Close filesystem on exit.
         """
@@ -88,6 +95,7 @@ class FS(object):
 
     @property
     def walk(self):
+        # type: (_FS) -> BoundWalker[_FS]
         """`~fs.walk.BoundWalker`: a walker bound to this filesystem.
         """
         return self.walker_class.bind(self)
@@ -1321,7 +1329,7 @@ class FS(object):
                 errors=None,        # type: Optional[Text]
                 newline='',         # type: Text
                 ):
-        # typing:
+        # type: (...) -> None
         """Create or replace a file with text.
 
         Arguments:

--- a/fs/base.py
+++ b/fs/base.py
@@ -55,7 +55,6 @@ if False:  # typing.TYPE_CHECKING
     _OpendirFactory = Callable[[_T, Text], SubFS[_T]]
 
 
-
 __all__ = ["FS"]
 
 

--- a/fs/base.py
+++ b/fs/base.py
@@ -52,7 +52,7 @@ __all__ = ["FS"]
 
 
 # typing.TypeVar: the type variable of a filesystem subclass
-_FS = typing.TypeVar('_FS', bound=FS)
+_FS = typing.TypeVar('_FS', bound='FS')
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/fs/base.py
+++ b/fs/base.py
@@ -50,7 +50,7 @@ class FS(object):
     """
 
     # This is the "standard" meta namespace.
-    _meta = {}
+    _meta = {}      # type: Dict[Text, Union[Text, int, bool, None]]
 
     # most FS will use default walking algorithms
     walker_class = Walker
@@ -88,7 +88,7 @@ class FS(object):
 
     @abc.abstractmethod
     def getinfo(self, path, namespaces=None):
-        # type: (Text, Optional[Container[Text]]) -> Info
+        # type: (Text, Optional[Collection[Text]]) -> Info
         """Get information about a resource on a filesystem.
 
         Arguments:
@@ -437,7 +437,7 @@ class FS(object):
                   dirs=None,            # type: Optional[Iterable[Text]]
                   exclude_dirs=None,    # type: Optional[Iterable[Text]]
                   exclude_files=None,   # type: Optional[Iterable[Text]]
-                  namespaces=None,      # type: Optional[Container[Text]]
+                  namespaces=None,      # type: Optional[Collection[Text]]
                   page=None,            # type: Optional[Tuple[int, int]]
                   ):
         # type: (...) -> Iterator[Info]
@@ -1119,7 +1119,7 @@ class FS(object):
 
     def scandir(self,
                 path,             # type: Text
-                namespaces=None,  # type: Optional[Container[Text]]
+                namespaces=None,  # type: Optional[Collection[Text]]
                 page=None,        # type: Optional[Tuple[int, int]]
                 ):
         # type: (...) -> Iterator[Info]

--- a/fs/base.py
+++ b/fs/base.py
@@ -1443,7 +1443,7 @@ class FS(object):
             raise errors.FilesystemClosed()
 
     def match(self, patterns, name):
-        # type: (Iterable[Text], Text) -> bool
+        # type: (Optional[Iterable[Text]], Text) -> bool
         """Check if a name matches any of a list of wildcards.
 
         Arguments:

--- a/fs/base.py
+++ b/fs/base.py
@@ -14,6 +14,7 @@ import abc
 import os
 import threading
 import time
+import typing
 from functools import partial
 
 from contextlib import closing
@@ -36,12 +37,13 @@ from .time import datetime_to_epoch
 from .walk import Walker
 
 
-if False:  # typing imports
+if typing.TYPE_CHECKING:
     from datetime import datetime
-    from typing import *   # FIXME
+    from typing import (
+        Any, BinaryIO, Callable, Collection, Dict, IO, Iterable,
+        Iterator, List, Optional, Text, Tuple, Union)
     from .enums import ResourceType
-    from .info import Info
-    from .info import _RawInfo
+    from .info import Info, RawInfo
     from .permissions import Permissions
 
 
@@ -88,8 +90,11 @@ class FS(object):
     # ---------------------------------------------------------------- #
 
     @abc.abstractmethod
-    def getinfo(self, path, namespaces=None):
-        # type: (Text, Optional[Collection[Text]]) -> Info
+    def getinfo(self,
+                path,            # type: Text
+                namespaces=None  # type: Optional[Collection[Text]]
+                ):
+        # type: (...) -> Info
         """Get information about a resource on a filesystem.
 
         Arguments:
@@ -147,8 +152,13 @@ class FS(object):
         """
 
     @abc.abstractmethod
-    def openbin(self, path, mode="r", buffering=-1, **options):
-        # type: (Text, Text, int, **Any) -> BinaryIO
+    def openbin(self,
+                path,           # type: Text
+                mode="r",       # type: Text
+                buffering=-1,   # type: int
+                **options       # type: Any
+                ):
+        # type: (...) -> BinaryIO
         """Open a binary file-like object.
 
         Arguments:
@@ -210,7 +220,7 @@ class FS(object):
 
     @abc.abstractmethod
     def setinfo(self, path, info):
-        # type: (Text, _RawInfo) -> None
+        # type: (Text, RawInfo) -> None
         """Set info on a resource.
 
         This method is the compliment to `~fs.base.FS.getinfo`

--- a/fs/base.py
+++ b/fs/base.py
@@ -38,9 +38,10 @@ from .walk import Walker
 
 if False:  # typing imports
     from datetime import datetime
-    from typing import *
+    from typing import *   # FIXME
     from .enums import ResourceType
     from .info import Info
+    from .info import _RawInfo
     from .permissions import Permissions
 
 
@@ -209,7 +210,7 @@ class FS(object):
 
     @abc.abstractmethod
     def setinfo(self, path, info):
-        # type: (Text, dict) -> None
+        # type: (Text, _RawInfo) -> None
         """Set info on a resource.
 
         This method is the compliment to `~fs.base.FS.getinfo`

--- a/fs/base.py
+++ b/fs/base.py
@@ -681,7 +681,7 @@ class FS(object):
         return meta
 
     def getsize(self, path):
-        # type: (Text) -> int
+        # type: (Text) -> Optional[int]
         """Get the size (in bytes) of a resource.
 
         Arguments:

--- a/fs/base.py
+++ b/fs/base.py
@@ -1019,7 +1019,7 @@ class FS(object):
              encoding=None,  # type: Optional[Text]
              errors=None,    # type: Optional[Text]
              newline='',     # type: Text
-             **options,      # type: Any
+             **options       # type: Any
              ):
         # type: (...) -> IO
         """Open a file.

--- a/fs/base.py
+++ b/fs/base.py
@@ -36,6 +36,15 @@ from .time import datetime_to_epoch
 from .walk import Walker
 
 
+# type annotations
+if False:
+    from datetime import datetime
+    from typing import *
+    from .enums import ResourceType
+    from .info import Info
+    from .permissions import Permissions
+
+
 @six.add_metaclass(abc.ABCMeta)
 class FS(object):
     """Base class for FS objects.
@@ -48,6 +57,7 @@ class FS(object):
     walker_class = Walker
 
     def __init__(self):
+        # type: (...) -> None
         """Create a filesystem. See help(type(self)) for accurate signature.
         """
         self._closed = False
@@ -55,11 +65,13 @@ class FS(object):
         super(FS, self).__init__()
 
     def __enter__(self):
+        # type: (...) -> FS
         """Allow use of filesystem as a context manager.
         """
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        # type: (...) -> None
         """Close filesystem on exit.
         """
         self.close()
@@ -77,12 +89,13 @@ class FS(object):
 
     @abc.abstractmethod
     def getinfo(self, path, namespaces=None):
+        # type: (Text, Optional[Container[Text]]) -> Info
         """Get information about a resource on a filesystem.
 
         Arguments:
             path (str): A path to a resource on the filesystem.
             namespaces (list, optional): Info namespaces to query
-                (defaults to *basic*).
+                (defaults to *[basic]*).
 
         Returns:
             ~fs.info.Info: resource information object.
@@ -93,6 +106,7 @@ class FS(object):
 
     @abc.abstractmethod
     def listdir(self, path):
+        # type: (Text) -> List[Text]
         """Get a list of the resource names in a directory.
 
         This method will return a list of the resources in a directory.
@@ -113,14 +127,15 @@ class FS(object):
 
     @abc.abstractmethod
     def makedir(self, path, permissions=None, recreate=False):
+        # type: (Text, Optional[Permissions], bool) -> FS
         """Make a directory.
 
         Arguments:
             path (str): Path to directory from root.
             permissions (~fs.permissions.Permissions, optional): a
                 `Permissions` instance, or `None` to use default.
-            recreate (bool, optional): Set to `True` to avoid raising an
-                error if the directory already exists (defaults to `False`).
+            recreate (bool): Set to `True` to avoid raising an error if
+                the directory already exists (defaults to `False`).
 
         Returns:
             ~fs.subfs.SubFS: a filesystem whose root is the new directory.
@@ -133,16 +148,17 @@ class FS(object):
 
     @abc.abstractmethod
     def openbin(self, path, mode="r", buffering=-1, **options):
+        # type: (Text, Text, int, **Any) -> BinaryIO
         """Open a binary file-like object.
 
         Arguments:
             path (str): A path on the filesystem.
-            mode (str, optional): Mode to open file (must be a valid
-                non-text mode, defaults to *r*). Since this method only
-                opens binary files, the ``b`` in the mode string is implied.s
-            buffering (int, optional): Buffering policy (-1 to use
-                default buffering, 0 to disable buffering, or any
-                positive integer to indicate a buffer size).
+            mode (str): Mode to open file (must be a valid non-text mode,
+                defaults to *r*). Since this method only opens binary files,
+                the ``b`` in the mode string is implied.
+            buffering (int): Buffering policy (-1 to use default buffering,
+                0 to disable buffering, or any positive integer to indicate
+                a buffer size).
             **options: keyword arguments for any additional information
                 required by the filesystem (if any).
 
@@ -159,6 +175,7 @@ class FS(object):
 
     @abc.abstractmethod
     def remove(self, path):
+        # type: (Text) -> None
         """Remove a file from the filesystem.
 
         Arguments:
@@ -172,6 +189,7 @@ class FS(object):
 
     @abc.abstractmethod
     def removedir(self, path):
+        # type: (Text) -> None
         """Remove a directory from the filesystem.
 
         Arguments:
@@ -192,6 +210,7 @@ class FS(object):
 
     @abc.abstractmethod
     def setinfo(self, path, info):
+        # type: (Text, dict) -> None
         """Set info on a resource.
 
         This method is the compliment to `~fs.base.FS.getinfo`
@@ -222,6 +241,7 @@ class FS(object):
     # ---------------------------------------------------------------- #
 
     def appendbytes(self, path, data):
+        # type: (Text, bytes) -> None
         """Append bytes to the end of a file, creating it if needed.
 
         Arguments:
@@ -241,21 +261,22 @@ class FS(object):
                 append_file.write(data)
 
     def appendtext(self,
-                   path,
-                   text,
-                   encoding='utf-8',
-                   errors=None,
-                   newline=''):
+                   path,                # type: Text
+                   text,                # type: Text
+                   encoding='utf-8',    # type: Text
+                   errors=None,         # type: Optional[Text]
+                   newline=''           # type: Text
+                   ):
+        # type: (...) -> None
         """Append text to the end of a file, creating it if needed.
 
         Arguments:
             path (str): Path to a file.
             text (str): Text to append.
-            encoding (str, optional): Encoding for text files
-                (defaults to ``utf-8``).
+            encoding (str): Encoding for text files (defaults to ``utf-8``).
             errors (str, optional): What to do with unicode decode errors
                 (see `codecs` module for more information).
-            newline (str, optional): Newline parameter.
+            newline (str): Newline parameter.
 
         Raises:
             TypeError: if ``text`` is not an unicode string.
@@ -274,6 +295,7 @@ class FS(object):
                 append_file.write(text)
 
     def close(self):
+        # type: () -> None
         """Close the filesystem and release any resources.
 
         It is important to call this method when you have finished
@@ -297,13 +319,14 @@ class FS(object):
         self._closed = True
 
     def copy(self, src_path, dst_path, overwrite=False):
+        # type: (Text, Text, bool) -> None
         """Copy file contents from ``src_path`` to ``dst_path``.
 
         Arguments:
             src_path (str): Path of source file.
             dst_path (str): Path to destination file.
-            overwrite (bool, Optional): If `True`, overwrite the
-                destination file if it exists (defaults to `False`).
+            overwrite (bool): If `True`, overwrite the destination file
+                if it exists (defaults to `False`).
 
         Raises:
             fs.errors.DestinationExists: If ``dst_path`` exists,
@@ -316,17 +339,18 @@ class FS(object):
             if not overwrite and self.exists(dst_path):
                 raise errors.DestinationExists(dst_path)
             with closing(self.open(src_path, 'rb')) as read_file:
-                self.setbinfile(dst_path, read_file)
+                # FIXME(@althonos): typing complains because open return IO
+                self.setbinfile(dst_path, read_file)   # type: ignore
 
     def copydir(self, src_path, dst_path, create=False):
+        # type: (Text, Text, bool) -> None
         """Copy the contents of ``src_path`` to ``dst_path``.
 
         Arguments:
             src_path (str): Path of source directory.
             dst_path (str): Path to destination directory.
-            create (bool, optional): If `True`, then ``dst_path``
-                will be created if it doesn't exist alreadys
-                (defaults to `False`).
+            create (bool): If `True`, then ``dst_path`` will be created
+                if it doesn't exist alreadys (defaults to `False`).
 
         Raises:
             fs.errors.ResourceNotFound: If the ``dst_path``
@@ -346,6 +370,7 @@ class FS(object):
             )
 
     def create(self, path, wipe=False):
+        # type: (Text, bool) -> bool
         """Create an empty file.
 
         The default behavior is to create a new file if one doesn't
@@ -369,6 +394,7 @@ class FS(object):
             return True
 
     def desc(self, path):
+        # type: (Text) -> Text
         """Return a short descriptive text regarding a path.
 
         Arguments:
@@ -388,6 +414,7 @@ class FS(object):
             return syspath
 
     def exists(self, path):
+        # type: (Text) -> bool
         """Check if a path maps to a resource.
 
         Arguments:
@@ -405,13 +432,15 @@ class FS(object):
             return True
 
     def filterdir(self,
-                  path,
-                  files=None,
-                  dirs=None,
-                  exclude_dirs=None,
-                  exclude_files=None,
-                  namespaces=None,
-                  page=None):
+                  path,                 # type: Text
+                  files=None,           # type: Optional[Iterable[Text]]
+                  dirs=None,            # type: Optional[Iterable[Text]]
+                  exclude_dirs=None,    # type: Optional[Iterable[Text]]
+                  exclude_files=None,   # type: Optional[Iterable[Text]]
+                  namespaces=None,      # type: Optional[Container[Text]]
+                  page=None,            # type: Optional[Tuple[int, int]]
+                  ):
+        # type: (...) -> Iterator[Info]
         """Get an iterator of resource info, filtered by patterns.
 
         This method enhances `~fs.base.FS.scandir` with additional
@@ -443,21 +472,25 @@ class FS(object):
         filters = []
 
         def match_dir(patterns, info):
+            # type: (Optional[Iterable[Text]], Info) -> bool
             """Pattern match info.name.
             """
             return info.is_file or self.match(patterns, info.name)
 
         def match_file(patterns, info):
+            # type: (Optional[Iterable[Text]], Info) -> bool
             """Pattern match info.name.
             """
             return info.is_dir or self.match(patterns, info.name)
 
         def exclude_dir(patterns, info):
+            # type: (Optional[Iterable[Text]], Info) -> bool
             """Pattern match info.name.
             """
             return info.is_file or not self.match(patterns, info.name)
 
         def exclude_file(patterns, info):
+            # type: (Optional[Iterable[Text]], Info) -> bool
             """Pattern match info.name.
             """
             return info.is_dir or not self.match(patterns, info.name)
@@ -485,6 +518,7 @@ class FS(object):
         return iter_info
 
     def getbytes(self, path):
+        # type: (Text) -> bytes
         """Get the contents of a file as bytes.
 
         Arguments:
@@ -502,6 +536,7 @@ class FS(object):
         return contents
 
     def getfile(self, path, file, chunk_size=None, **options):
+        # type: (Text, IO, Optional[int], **Any) -> None
         """Copies a file from the filesystem to a file-like object.
 
         This may be more efficient that opening and copying files
@@ -535,6 +570,7 @@ class FS(object):
                 )
 
     def gettext(self, path, encoding=None, errors=None, newline=''):
+        # type: (Text, Optional[Text], Optional[Text], Text) -> None
         """Get the contents of a file as a string.
 
         Arguments:
@@ -542,7 +578,7 @@ class FS(object):
             encoding (str, optional): Encoding to use when reading contents
                 in text mode (defaults to `None`, reading in binary mode).
             errors (str, optional): Unicode errors parameter.
-            newline (str, optional): Newlines parameter.
+            newline (str): Newlines parameter.
 
         Returns:
             str: file contents.
@@ -563,6 +599,7 @@ class FS(object):
         return contents
 
     def getmeta(self, namespace="standard"):
+        # type: (Text) -> dict
         """Get meta information regarding a filesystem.
 
         Arguments:
@@ -616,6 +653,7 @@ class FS(object):
         return meta
 
     def getsize(self, path):
+        # type: (Text) -> int
         """Get the size (in bytes) of a resource.
 
         Arguments:
@@ -636,6 +674,7 @@ class FS(object):
         return size
 
     def getsyspath(self, path):
+        # type: (Text) -> Text
         """Get the *system path* of a resource.
 
         Parameters:
@@ -669,6 +708,7 @@ class FS(object):
         raise errors.NoSysPath(path=path)
 
     def gettype(self, path):
+        # type: (Text) -> ResourceType
         """Get the type of a resource.
 
         Parameters:
@@ -706,6 +746,7 @@ class FS(object):
         return resource_type
 
     def geturl(self, path, purpose='download'):
+        # type: (Text, Text) -> Text
         """Get the URL to a given resource.
 
         Parameters:
@@ -726,6 +767,7 @@ class FS(object):
         raise errors.NoURL(path, purpose)
 
     def hassyspath(self, path):
+        # type: (Text) -> bool
         """Check if a path maps to a system path.
 
         Parameters:
@@ -743,6 +785,7 @@ class FS(object):
         return has_sys_path
 
     def hasurl(self, path, purpose='download'):
+        # type: (Text, Text) -> bool
         """Check if a path has a corresponding URL.
 
         Parameters:
@@ -762,11 +805,13 @@ class FS(object):
         return has_url
 
     def isclosed(self):
+        # type: () -> bool
         """Check if the filesystem is closed.
         """
         return getattr(self, '_closed', False)
 
     def isdir(self, path):
+        # type: (Text) -> bool
         """Check if a path maps to an existing directory.
 
         Parameters:
@@ -782,6 +827,7 @@ class FS(object):
             return False
 
     def isempty(self, path):
+        # type: (Text) -> bool
         """Check if a directory is empty.
 
         A directory is considered empty when it does not contain
@@ -801,6 +847,7 @@ class FS(object):
         return next(iter(self.scandir(path)), None) is None
 
     def isfile(self, path):
+        # type: (Text) -> bool
         """Check if a path maps to an existing file.
 
         Parameters:
@@ -816,6 +863,7 @@ class FS(object):
             return False
 
     def islink(self, path):
+        # type: (Text) -> bool
         """Check if a path maps to a symlink.
 
         Parameters:
@@ -829,6 +877,7 @@ class FS(object):
         return False
 
     def lock(self):
+        # type: () -> threading.RLock
         """Get a context manager that *locks* the filesystem.
 
         Locking a filesystem gives a thread exclusive access to it.
@@ -860,6 +909,7 @@ class FS(object):
         return self._lock
 
     def movedir(self, src_path, dst_path, create=False):
+        # type: (Text, Text, bool) -> None
         """Move contents of directory ``src_path`` to ``dst_path``.
 
         Parameters:
@@ -885,6 +935,7 @@ class FS(object):
             )
 
     def makedirs(self, path, permissions=None, recreate=False):
+        # type: (Text, Optional[Permissions], bool) -> FS
         """Make a directory, and any missing intermediate directories.
 
         Arguments:
@@ -918,10 +969,8 @@ class FS(object):
                     raise
             return self.opendir(path)
 
-    def move(self,
-             src_path,
-             dst_path,
-             overwrite=False):
+    def move(self, src_path, dst_path, overwrite=False):
+        # type: (Text, Text, bool) -> None
         """Move a file from ``src_path`` to ``dst_path``.
 
         Arguments:
@@ -959,17 +1008,20 @@ class FS(object):
                     return
         with self._lock:
             with self.open(src_path, 'rb') as read_file:
-                self.setbinfile(dst_path, read_file)
+                # FIXME(@althonos): typing complains because open return IO
+                self.setbinfile(dst_path, read_file)  # type: ignore
             self.remove(src_path)
 
     def open(self,
-             path,
-             mode='r',
-             buffering=-1,
-             encoding=None,
-             errors=None,
-             newline='',
-             **options):
+             path,           # type: Text
+             mode='r',       # type: Text
+             buffering=-1,   # type: int
+             encoding=None,  # type: Optional[Text]
+             errors=None,    # type: Optional[Text]
+             newline='',     # type: Text
+             **options,      # type: Any
+             ):
+        # type: (...) -> IO
         """Open a file.
 
         Arguments:
@@ -1014,6 +1066,8 @@ class FS(object):
         return io_stream
 
     def opendir(self, path, factory=None):
+        # type: (Text, Optional[Callable[[FS, Text], FS]]) -> FS
+        # FIXME(@althonos): use generics here if possible
         """Get a filesystem object for a sub-directory.
 
         Arguments:
@@ -1041,6 +1095,7 @@ class FS(object):
         return factory(self, path)
 
     def removetree(self, dir_path):
+        # type: (Text) -> None
         """Recursively remove the contents of a directory.
 
         This method is similar to `~fs.base.removedir`, but will
@@ -1062,7 +1117,12 @@ class FS(object):
             if _dir_path != '/':
                 self.removedir(dir_path)
 
-    def scandir(self, path, namespaces=None, page=None):
+    def scandir(self,
+                path,             # type: Text
+                namespaces=None,  # type: Optional[Container[Text]]
+                page=None,        # type: Optional[Tuple[int, int]]
+                ):
+        # type: (...) -> Iterator[Info]
         """Get an iterator of resource info.
 
         Arguments:
@@ -1100,6 +1160,7 @@ class FS(object):
         return iter_info
 
     def setbytes(self, path, contents):
+        # type: (Text, bytes) -> None
         """Copy binary data to a file.
 
         Arguments:
@@ -1116,6 +1177,7 @@ class FS(object):
             write_file.write(contents)
 
     def setbinfile(self, path, file):
+        # type: (Text, BinaryIO) -> None
         """Set a file to the contents of a binary file object.
 
         This method copies bytes from an open binary file to a file on
@@ -1141,11 +1203,13 @@ class FS(object):
                 tools.copy_file_data(file, dst_file)
 
     def setfile(self,
-                path,
-                file,
-                encoding=None,
-                errors=None,
-                newline=None):
+                path,           # type: Text
+                file,           # type: IO
+                encoding=None,  # type: Optional[Text]
+                errors=None,    # type: Optional[Text]
+                newline='',     # type: Text
+                ):
+        # type: (...) -> None
         """Set a file to the contents of a file object.
 
         Arguments:
@@ -1185,6 +1249,7 @@ class FS(object):
                 tools.copy_file_data(file, dst_file)
 
     def settimes(self, path, accessed=None, modified=None):
+        # type: (Text, Optional[datetime], Optional[datetime]) -> None
         """Set the accessed and modified time on a resource.
 
         Arguments:
@@ -1196,7 +1261,7 @@ class FS(object):
                 ``accessed`` parameter.
 
         """
-        details = {}
+        details = {}  # type: dict
         raw_info = {
             "details": details
         }
@@ -1216,11 +1281,13 @@ class FS(object):
         self.setinfo(path, raw_info)
 
     def settext(self,
-                path,
-                contents,
-                encoding='utf-8',
-                errors=None,
-                newline=''):
+                path,               # type: Text
+                contents,           # type: Text
+                encoding='utf-8',   # type: Text
+                errors=None,        # type: Optional[Text]
+                newline='',         # type: Text
+                ):
+        # typing:
         """Create or replace a file with text.
 
         Arguments:
@@ -1246,6 +1313,7 @@ class FS(object):
             write_file.write(contents)
 
     def touch(self, path):
+        # type: (Text) -> None
         """Touch a file on the filesystem.
 
         Touching a file means creating a new file if ``path`` doesn't
@@ -1269,6 +1337,7 @@ class FS(object):
                 self.setinfo(path, raw_info)
 
     def validatepath(self, path):
+        # type: (Text) -> Text
         """Check if a path is valid, returning a normalized absolute
         path.
 
@@ -1328,6 +1397,7 @@ class FS(object):
     # ---------------------------------------------------------------- #
 
     def getbasic(self, path):
+        # type: (Text) -> Info
         """Get the *basic* resource info.
 
         This method is shorthand for the following::
@@ -1344,6 +1414,7 @@ class FS(object):
         return self.getinfo(path, namespaces=['basic'])
 
     def getdetails(self, path):
+        # type: (Text) -> Info
         """Get the *details* resource info.
 
         This method is shorthand for the following::
@@ -1360,6 +1431,7 @@ class FS(object):
         return self.getinfo(path, namespaces=['details'])
 
     def check(self):
+        # type: () -> None
         """Check if a filesystem may be used.
 
         Raises:
@@ -1370,6 +1442,7 @@ class FS(object):
             raise errors.FilesystemClosed()
 
     def match(self, patterns, name):
+        # type: (Iterable[Text], Text) -> bool
         """Check if a name matches any of a list of wildcards.
 
         Arguments:
@@ -1405,6 +1478,7 @@ class FS(object):
         return matcher(name)
 
     def tree(self, **kwargs):
+        # type: (**Any) -> None
         """Render a tree view of the filesystem to stdout or a file.
 
         The parameters are passed to :func:`~fs.tree.render`.

--- a/fs/base.py
+++ b/fs/base.py
@@ -39,12 +39,14 @@ from .walk import Walker
 
 if typing.TYPE_CHECKING:
     from datetime import datetime
+    from threading import RLock
     from typing import (
         Any, BinaryIO, Callable, Collection, Dict, IO, Iterable,
-        Iterator, List, Optional, Text, Tuple, Union)
+        Iterator, List, Mapping, Optional, Text, Tuple, Union)
     from .enums import ResourceType
     from .info import Info, RawInfo
     from .permissions import Permissions
+    OpendirFactory = Callable[[FS, Text], FS]
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -580,8 +582,13 @@ class FS(object):
                     chunk_size=chunk_size
                 )
 
-    def gettext(self, path, encoding=None, errors=None, newline=''):
-        # type: (Text, Optional[Text], Optional[Text], Text) -> Text
+    def gettext(self,
+                path,           # type: Text
+                encoding=None,  # type: Optional[Text]
+                errors=None,    # type: Optional[Text]
+                newline=''      # type: Text
+                ):
+        # type: (...) -> Text
         """Get the contents of a file as a string.
 
         Arguments:
@@ -610,7 +617,7 @@ class FS(object):
         return contents
 
     def getmeta(self, namespace="standard"):
-        # type: (Text) -> dict
+        # type: (Text) -> Mapping[Text, object]
         """Get meta information regarding a filesystem.
 
         Arguments:
@@ -888,7 +895,7 @@ class FS(object):
         return False
 
     def lock(self):
-        # type: () -> threading.RLock
+        # type: () -> RLock
         """Get a context manager that *locks* the filesystem.
 
         Locking a filesystem gives a thread exclusive access to it.
@@ -945,8 +952,12 @@ class FS(object):
                 dst_path
             )
 
-    def makedirs(self, path, permissions=None, recreate=False):
-        # type: (Text, Optional[Permissions], bool) -> FS
+    def makedirs(self,
+                 path,              # type: Text
+                 permissions=None,  # type: Optional[Permissions]
+                 recreate=False     # type: bool
+                 ):
+        # type: (...) -> FS
         """Make a directory, and any missing intermediate directories.
 
         Arguments:
@@ -1076,8 +1087,11 @@ class FS(object):
         )
         return io_stream
 
-    def opendir(self, path, factory=None):
-        # type: (Text, Optional[Callable[[FS, Text], FS]]) -> FS
+    def opendir(self,
+                path,           # type: Text
+                factory=None    # type: Optional[OpendirFactory]
+                ):
+        # type: (...) -> FS
         # FIXME(@althonos): use generics here if possible
         """Get a filesystem object for a sub-directory.
 

--- a/fs/base.py
+++ b/fs/base.py
@@ -402,7 +402,7 @@ class FS(object):
 
         Arguments:
             path (str): Path to a new file in the filesystem.
-            wipe (bool, optional): If `True`, truncate any existing
+            wipe (bool): If `True`, truncate any existing
                 file to 0 bytes (defaults to `False`).
 
         Returns:
@@ -475,10 +475,10 @@ class FS(object):
                 to filter file names, e.g. ``['*.py']``.
             dirs (list, optional): A list of UNIX shell-style patterns
                 to filter directory names.
-            exclude_dirs (list, optional): An optional list of patterns
-                used to exclude directories.
-            exclude_files (list, optional): An optional list of patterns
-                used to exclude files.
+            exclude_dirs (list, optional): A list of patterns used
+                to exclude directories.
+            exclude_files (list, optional): A list of patterns used
+                to exclude files.
             namespaces (list, optional): A list of namespaces to include
                 in the resource information, e.g. ``['basic', 'access']``.
             page (tuple, optional): May be a tuple of ``(<start>, <end>)``
@@ -631,8 +631,8 @@ class FS(object):
         """Get meta information regarding a filesystem.
 
         Arguments:
-            namespace (str, optional): The meta namespace
-                (defaults to ``"standard"``).
+            namespace (str): The meta namespace (defaults
+                to ``"standard"``).
 
         Returns:
             dict: the meta information.
@@ -779,11 +779,11 @@ class FS(object):
 
         Parameters:
             path (str): A path on the filesystem
-            purpose (str, optional): A short string that indicates which
-                URL to retrieve for the given path (if there is more
-                than one). The default is ``'download'``, which should
-                return a URL that serves the file. Other filesystems may
-                support other values for ``purpose``.
+            purpose (str): A short string that indicates which URL
+                to retrieve for the given path (if there is more than
+                one). The default is ``'download'``, which should return
+                a URL that serves the file. Other filesystems may support
+                other values for ``purpose``.
 
         Returns:
             str: a URL.
@@ -818,7 +818,7 @@ class FS(object):
 
         Parameters:
             path (str): A path on the filesystem.
-            purpose (str, optional): A purpose parameter, as given in
+            purpose (str): A purpose parameter, as given in
                 `~fs.base.FS.geturl`.
 
         Returns:
@@ -943,9 +943,8 @@ class FS(object):
         Parameters:
             src_path (str): Path of source directory on the filesystem.
             dst_path (str): Path to destination directory.
-            create (bool, optional): If `True`, then ``dst_path`` will
-                be created if it doesn't exist already (defaults
-                to `False`).
+            create (bool): If `True`, then ``dst_path`` will be created
+                if it doesn't exist already (defaults to `False`).
 
         Raises:
             fs.errors.ResourceNotFound: if ``dst_path`` does not exist,
@@ -974,9 +973,9 @@ class FS(object):
             path (str): Path to directory from root.
             permissions (~fs.permissions.Permissions, optional): Initial
                 permissions, or `None` to use defaults.
-            recreate (bool, optional):  If `False` (the default),
-                attempting to create an existing directory will raise an
-                error. Set to `True` to ignore existing directories.
+            recreate (bool):  If `False` (the default), attempting to
+                create an existing directory will raise an error. Set
+                to `True` to ignore existing directories.
 
         Returns:
             ~fs.subfs.SubFS: A sub-directory filesystem.
@@ -1009,8 +1008,8 @@ class FS(object):
             src_path (str): A path on the filesystem to move.
             dst_path (str): A path on the filesystem where the source
                 file will be written to.
-            overwrite (bool, optional): If `True`, destination path
-                will be overwritten if it exists.
+            overwrite (bool): If `True`, destination path will be
+                overwritten if it exists.
 
         Raises:
             fs.errors.FileExpected: If ``src_path`` maps to a
@@ -1058,17 +1057,17 @@ class FS(object):
 
         Arguments:
             path (str): A path to a file on the filesystem.
-            mode (str, optional): Mode to open the file object with
+            mode (str): Mode to open the file object with
                 (defaults to *r*).
-            buffering (int, optional): Buffering policy (-1 to use
+            buffering (int): Buffering policy (-1 to use
                 default buffering, 0 to disable buffering, 1 to select
                 line buffering, of any positive integer to indicate
                 a buffer size).
-            encoding (str, optional): Encoding for text files
-                (defaults to ``utf-8``)
+            encoding (str): Encoding for text files (defaults to
+                ``utf-8``)
             errors (str, optional): What to do with unicode decode errors
                 (see `codecs` module for more information).
-            newline (str, optional): Newline parameter.
+            newline (str): Newline parameter.
             **options: keyword arguments for any additional information
                 required by the filesystem (if any).
 
@@ -1255,8 +1254,7 @@ class FS(object):
                 defaults to `None` for binary.
             errors (str, optional): How encoding errors should be treated
                 (same as `io.open`).
-            newline (str, optional): Newline parameter (same
-                as `io.open`).
+            newline (str): Newline parameter (same as `io.open`).
 
         This method will read the contents of a supplied file object,
         and write to a file on the filesystem. If the destination
@@ -1332,8 +1330,7 @@ class FS(object):
                 (defaults to ``'ut-8'``).
             errors (str, optional): How encoding errors should be treated
                 (same as `io.open`).
-            newline (str, optional): Newline parameter (same
-                as `io.open`).
+            newline (str): Newline parameter (same as `io.open`).
 
         Raises:
             TypeError: if ``contents`` is not a unicode string.

--- a/fs/base.py
+++ b/fs/base.py
@@ -50,12 +50,13 @@ if typing.TYPE_CHECKING:
     from .permissions import Permissions
     from .walk import BoundWalker
 
+    _F = typing.TypeVar('_F', bound='FS')
+    _T = typing.TypeVar('_T', bound='FS')
+    _OpendirFactory = Callable[[_T, Text], SubFS[_T]]
+
+
 
 __all__ = ["FS"]
-
-
-# typing.TypeVar: the type variable of a filesystem subclass
-_FS = typing.TypeVar('_FS', bound='FS')
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -95,7 +96,7 @@ class FS(object):
 
     @property
     def walk(self):
-        # type: (_FS) -> BoundWalker[_FS]
+        # type: (_F) -> BoundWalker[_F]
         """`~fs.walk.BoundWalker`: a walker bound to this filesystem.
         """
         return self.walker_class.bind(self)
@@ -147,12 +148,12 @@ class FS(object):
         """
 
     @abc.abstractmethod
-    def makedir(self,               # type: _FS
+    def makedir(self,
                 path,               # type: Text
                 permissions=None,   # type: Optional[Permissions]
                 recreate=False      # type: bool
                 ):
-        # type: (...) -> SubFS[_FS]
+        # type: (...) -> SubFS[FS]
         """Make a directory.
 
         Arguments:
@@ -969,12 +970,12 @@ class FS(object):
                 dst_path
             )
 
-    def makedirs(self,              # type: _FS
+    def makedirs(self,
                  path,              # type: Text
                  permissions=None,  # type: Optional[Permissions]
                  recreate=False     # type: bool
                  ):
-        # type: (...) -> SubFS[_FS]
+        # type: (...) -> SubFS[FS]
         """Make a directory, and any missing intermediate directories.
 
         Arguments:
@@ -1104,11 +1105,11 @@ class FS(object):
         )
         return io_stream
 
-    def opendir(self,         # type: _FS
+    def opendir(self,         # type: _F
                 path,         # type: Text
-                factory=None  # type: Optional[Callable[[_FS, Text], SubFS[_FS]]]
+                factory=None  # type: Optional[_OpendirFactory]
                 ):
-        # type: (...) -> SubFS[_FS]
+        # type: (...) -> SubFS[FS]
         # FIXME(@althonos): use generics here if possible
         """Get a filesystem object for a sub-directory.
 

--- a/fs/base.py
+++ b/fs/base.py
@@ -36,7 +36,7 @@ from .path import normpath
 from .time import datetime_to_epoch
 from .walk import Walker
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from datetime import datetime
     from threading import RLock
     from typing import (

--- a/fs/base.py
+++ b/fs/base.py
@@ -36,8 +36,7 @@ from .time import datetime_to_epoch
 from .walk import Walker
 
 
-# type annotations
-if False:
+if False:  # typing imports
     from datetime import datetime
     from typing import *
     from .enums import ResourceType
@@ -242,6 +241,7 @@ class FS(object):
 
     def appendbytes(self, path, data):
         # type: (Text, bytes) -> None
+        # FIXME(@althonos): accept bytearray and memoryview as well ?
         """Append bytes to the end of a file, creating it if needed.
 
         Arguments:
@@ -570,7 +570,7 @@ class FS(object):
                 )
 
     def gettext(self, path, encoding=None, errors=None, newline=''):
-        # type: (Text, Optional[Text], Optional[Text], Text) -> None
+        # type: (Text, Optional[Text], Optional[Text], Text) -> Text
         """Get the contents of a file as a string.
 
         Arguments:
@@ -1161,6 +1161,7 @@ class FS(object):
 
     def setbytes(self, path, contents):
         # type: (Text, bytes) -> None
+        # FIXME(@althonos): accept bytearray and memoryview as well ?
         """Copy binary data to a file.
 
         Arguments:

--- a/fs/base.py
+++ b/fs/base.py
@@ -547,7 +547,7 @@ class FS(object):
         return contents
 
     def getfile(self, path, file, chunk_size=None, **options):
-        # type: (Text, IO, Optional[int], **Any) -> None
+        # type: (Text, BinaryIO, Optional[int], **Any) -> None
         """Copies a file from the filesystem to a file-like object.
 
         This may be more efficient that opening and copying files

--- a/fs/compress.py
+++ b/fs/compress.py
@@ -22,14 +22,22 @@ from .errors import NoSysPath, MissingInfoNamespace
 from .walk import Walker
 
 
-def write_zip(src_fs,
-              file,
-              compression=zipfile.ZIP_DEFLATED,
-              encoding="utf-8",
-              walker=None):
+if False:  # typing imports
+    from typing import IO, Optional, Text, Type
+    from .base import FS
+
+
+def write_zip(src_fs,                            # type: FS
+              file,                              # type: IO
+              compression=zipfile.ZIP_DEFLATED,  # type: int
+              encoding="utf-8",                  # type: Text
+              walker=None                        # type: Optional[Type[Walker]]
+              ):
+    # type: (...) -> None
     """Write the contents of a filesystem to a zip file.
 
     Arguments:
+        src_fs (~fs.base.FS): The source filesystem to compress.
         file (str or io.IOBase): Destination file, may be a file name
             or an open file object.
         compression (str, optional): Compression to use (one of the constants
@@ -102,11 +110,13 @@ def write_zip(src_fs,
                     _zip.write(sys_path, zip_name)
 
 
-def write_tar(src_fs,
-              file,
-              compression=None,
-              encoding="utf-8",
-              walker=None):
+def write_tar(src_fs,            # type: FS
+              file,              # type: IO
+              compression=None,  # type: Optional[Text]
+              encoding="utf-8",  # type: Text
+              walker=None        # type: Optional[Type[Walker]]
+              ):
+    # type: (...) -> None
     """Write the contents of a filesystem to a tar file.
 
     Arguments:

--- a/fs/compress.py
+++ b/fs/compress.py
@@ -41,10 +41,10 @@ def write_zip(src_fs,                            # type: FS
         src_fs (~fs.base.FS): The source filesystem to compress.
         file (str or io.IOBase): Destination file, may be a file name
             or an open file object.
-        compression (str, optional): Compression to use (one of the constants
+        compression (int): Compression to use (one of the constants
             defined in the `zipfile` module in the stdlib). Defaults
             to `zipfile.ZIP_DEFLATED`.
-        encoding (str, optional):
+        encoding (str):
              The encoding to use for filenames. The default is ``"utf-8"``,
              use ``"CP437"`` if compatibility with WinZip is desired.
         walker (~fs.walk.Walker, optional): A `Walker` instance, or `None`
@@ -124,15 +124,15 @@ def write_tar(src_fs,            # type: FS
     """Write the contents of a filesystem to a tar file.
 
     Arguments:
-        file (str or io.IOBase): Destination file, may be a file name or
-            an open file object.
+        file (str or io.IOBase): Destination file, may be a file
+            name or an open file object.
         compression (str, optional): Compression to use, or `None`
             for a plain Tar archive without compression.
-        encoding(str, optional): The encoding to use for filenames. The
+        encoding(str): The encoding to use for filenames. The
             default is ``"utf-8"``.
-        walker (~fs.walk.Walker, optional): A `Walker` instance, or `None`
-            to use default walker. You can use this to specify which files
-            you want to compress.
+        walker (~fs.walk.Walker, optional): A `Walker` instance, or
+            `None` to use default walker. You can use this to specify
+            which files you want to compress.
 
     """
     type_map = {

--- a/fs/compress.py
+++ b/fs/compress.py
@@ -22,7 +22,7 @@ from .time import datetime_to_epoch
 from .errors import NoSysPath, MissingInfoNamespace
 from .walk import Walker
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import BinaryIO, Optional, Text, Tuple, Type, Union
     from .base import FS
     ZipTime = Tuple[int, int, int, int, int, int]

--- a/fs/compress.py
+++ b/fs/compress.py
@@ -8,10 +8,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from datetime import datetime
 import time
-import zipfile
 import tarfile
+import typing
+import zipfile
+from datetime import datetime
 
 import six
 
@@ -21,8 +22,7 @@ from .time import datetime_to_epoch
 from .errors import NoSysPath, MissingInfoNamespace
 from .walk import Walker
 
-
-if False:  # typing imports
+if typing.TYPE_CHECKING:
     from typing import IO, Optional, Text, Type
     from .base import FS
 
@@ -31,7 +31,7 @@ def write_zip(src_fs,                            # type: FS
               file,                              # type: IO
               compression=zipfile.ZIP_DEFLATED,  # type: int
               encoding="utf-8",                  # type: Text
-              walker=None                        # type: Optional[Type[Walker]]
+              walker=None                        # type: Optional[Walker]
               ):
     # type: (...) -> None
     """Write the contents of a filesystem to a zip file.
@@ -114,7 +114,7 @@ def write_tar(src_fs,            # type: FS
               file,              # type: IO
               compression=None,  # type: Optional[Text]
               encoding="utf-8",  # type: Text
-              walker=None        # type: Optional[Type[Walker]]
+              walker=None        # type: Optional[Walker]
               ):
     # type: (...) -> None
     """Write the contents of a filesystem to a tar file.

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -4,6 +4,8 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from .walk import Walker
 from .opener import manage_fs
 from .path import abspath
@@ -12,14 +14,11 @@ from .path import frombase
 from .path import normpath
 from .errors import FSError
 
-
 if False:  # typing imports
     from typing import *
     from .base import FS
     from .walk import Walker
-
     _OnCopy = Callable[[FS, Text, FS, Text], None]
-
 
 
 def copy_fs(src_fs,       # type: Union[FS, Text]

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -13,7 +13,21 @@ from .path import normpath
 from .errors import FSError
 
 
-def copy_fs(src_fs, dst_fs, walker=None, on_copy=None):
+if False:  # typing imports
+    from typing import *
+    from .base import FS
+    from .walk import Walker
+
+    OnCopy = Callable[[FS, Text, FS, Text], None]
+
+
+
+def copy_fs(src_fs,       # type: Union[FS, Text]
+            dst_fs,       # type: Union[FS, Text]
+            walker=None,  # type: Optional[Walker]
+            on_copy=None  # type: Optional[OnCopy]
+            ):
+    # type: (...) -> None
     """Copy the contents of one filesystem to another.
 
     Arguments:
@@ -31,7 +45,12 @@ def copy_fs(src_fs, dst_fs, walker=None, on_copy=None):
                     walker=walker, on_copy=on_copy)
 
 
-def copy_fs_if_newer(src_fs, dst_fs, walker=None, on_copy=None):
+def copy_fs_if_newer(src_fs,        # type: Union[FS, Text]
+                     dst_fs,        # type: Union[FS, Text]
+                     walker=None,   # type: Optional[Walker]
+                     on_copy=None   # type: Optional[OnCopy]
+                     ):
+    # type: (...) -> None
     """Copy the contents of one filesystem to another, checking times.
 
     If both source and destination files exist, the copy is executed
@@ -55,12 +74,13 @@ def copy_fs_if_newer(src_fs, dst_fs, walker=None, on_copy=None):
 
 
 def _source_is_newer(src_fs, src_path, dst_fs, dst_path):
+    # type: (FS, Text, FS, Text) -> bool
     """Determine if source file is newer than destination file.
 
     Arguments:
-        src_fs (FS or str): Source filesystem (instance or URL).
+        src_fs (FS): Source filesystem (instance or URL).
         src_path (str): Path to a file on the source filesystem.
-        dst_fs (FS or str): Destination filesystem (instance or URL).
+        dst_fs (FS): Destination filesystem (instance or URL).
         dst_path (str): Path to a file on the destination filesystem.
 
     Returns:
@@ -82,7 +102,12 @@ def _source_is_newer(src_fs, src_path, dst_fs, dst_path):
         return True
 
 
-def copy_file(src_fs, src_path, dst_fs, dst_path):
+def copy_file(src_fs,    # type: Union[FS, Text]
+              src_path,  # type: Text
+              dst_fs,    # type: Union[FS, Text]
+              dst_path   # type: Text
+              ):
+    # type: (...) -> None
     """Copy a file from one filesystem to another.
 
     If the destination exists, and is a file, it will be first truncated.
@@ -94,24 +119,29 @@ def copy_file(src_fs, src_path, dst_fs, dst_path):
         dst_path (str): Path to a file on the destination filesystem.
 
     """
-    with manage_fs(src_fs) as src_fs:
-        with manage_fs(dst_fs, create=True) as dst_fs:
-            if src_fs is dst_fs:
+    with manage_fs(src_fs) as _src_fs:
+        with manage_fs(dst_fs, create=True) as _dst_fs:
+            if _src_fs is _dst_fs:
                 # Same filesystem, so we can do a potentially optimized
                 # copy
-                src_fs.copy(src_path, dst_path, overwrite=True)
+                _src_fs.copy(src_path, dst_path, overwrite=True)
             else:
                 # Standard copy
-                with src_fs.lock(), dst_fs.lock():
-                    if dst_fs.hassyspath(dst_path):
-                        with dst_fs.openbin(dst_path, 'w') as write_file:
-                            src_fs.getfile(src_path, write_file)
+                with _src_fs.lock(), _dst_fs.lock():
+                    if _dst_fs.hassyspath(dst_path):
+                        with _dst_fs.openbin(dst_path, 'w') as write_file:
+                            _src_fs.getfile(src_path, write_file)
                     else:
-                        with src_fs.openbin(src_path) as read_file:
-                            dst_fs.setbinfile(dst_path, read_file)
+                        with _src_fs.openbin(src_path) as read_file:
+                            _dst_fs.setbinfile(dst_path, read_file)
 
 
-def copy_file_internal(src_fs, src_path, dst_fs, dst_path):
+def copy_file_internal(src_fs,      # type: FS
+                       src_path,    # type: Text
+                       dst_fs,      # type: FS
+                       dst_path     # type: Text
+                       ):
+    # type: (...) -> None
     """Low level copy, that doesn't call manage_fs or lock.
 
     If the destination exists, and is a file, it will be first truncated.
@@ -120,9 +150,9 @@ def copy_file_internal(src_fs, src_path, dst_fs, dst_path):
     should prefer `copy_file`.
 
     Arguments:
-        src_fs (FS or str): Source filesystem.
+        src_fs (FS): Source filesystem.
         src_path (str): Path to a file on the source filesystem.
-        dst_fs (FS or str): Destination filesystem.
+        dst_fs (FS: Destination filesystem.
         dst_path (str): Path to a file on the destination filesystem.
 
     """
@@ -138,7 +168,12 @@ def copy_file_internal(src_fs, src_path, dst_fs, dst_path):
             dst_fs.setbinfile(dst_path, read_file)
 
 
-def copy_file_if_newer(src_fs, src_path, dst_fs, dst_path):
+def copy_file_if_newer(src_fs,      # type: Union[FS, Text]
+                       src_path,    # type: Text
+                       dst_fs,      # type: Union[FS, Text]
+                       dst_path     # type: Text
+                       ):
+    # type: (...) -> bool
     """Copy a file from one filesystem to another, checking times.
 
     If the destination exists, and is a file, it will be first truncated.
@@ -157,28 +192,31 @@ def copy_file_if_newer(src_fs, src_path, dst_fs, dst_path):
         bool: `True` if the file copy was executed, `False` otherwise.
 
     """
-    with manage_fs(src_fs) as src_fs:
-        with manage_fs(dst_fs, create=True) as dst_fs:
-            if src_fs is dst_fs:
+    with manage_fs(src_fs) as _src_fs:
+        with manage_fs(dst_fs, create=True) as _dst_fs:
+            if _src_fs is _dst_fs:
                 # Same filesystem, so we can do a potentially optimized
                 # copy
-                if _source_is_newer(src_fs, src_path, dst_fs, dst_path):
-                    src_fs.copy(src_path, dst_path, overwrite=True)
+                if _source_is_newer(_src_fs, src_path, _dst_fs, dst_path):
+                    _src_fs.copy(src_path, dst_path, overwrite=True)
                     return True
                 else:
                     return False
             else:
                 # Standard copy
-                with src_fs.lock(), dst_fs.lock():
-                    if _source_is_newer(src_fs, src_path,
-                                        dst_fs, dst_path):
-                        copy_file_internal(src_fs, src_path, dst_fs, dst_path)
+                with _src_fs.lock(), _dst_fs.lock():
+                    if _source_is_newer(_src_fs, src_path, _dst_fs, dst_path):
+                        copy_file_internal(_src_fs, src_path, _dst_fs, dst_path)
                         return True
                     else:
                         return False
 
 
-def copy_structure(src_fs, dst_fs, walker=None):
+def copy_structure(src_fs,      # type: Union[FS, Text]
+                   dst_fs,      # type: Union[FS, Text]
+                   walker=None  # type: Optional[Walker]
+                   ):
+    # type: (...) -> None
     """Copy directories (but not files) from ``src_fs`` to ``dst_fs``.
 
     Arguments:
@@ -190,15 +228,21 @@ def copy_structure(src_fs, dst_fs, walker=None):
 
     """
     walker = walker or Walker()
-    with manage_fs(src_fs) as src_fs:
-        with manage_fs(dst_fs, create=True) as dst_fs:
-            with src_fs.lock(), dst_fs.lock():
-                for dir_path in walker.dirs(src_fs):
-                    dst_fs.makedir(dir_path, recreate=True)
+    with manage_fs(src_fs) as _src_fs:
+        with manage_fs(dst_fs, create=True) as _dst_fs:
+            with _src_fs.lock(), _dst_fs.lock():
+                for dir_path in walker.dirs(_src_fs):
+                    _dst_fs.makedir(dir_path, recreate=True)
 
 
-def copy_dir(src_fs, src_path, dst_fs, dst_path,
-             walker=None, on_copy=None):
+def copy_dir(src_fs,        # type: Union[FS, Text]
+             src_path,      # type: Text
+             dst_fs,        # type: Union[FS, Text]
+             dst_path,      # type: Text
+             walker=None,   # type: Optional[Walker]
+             on_copy=None   # type: Optional[OnCopy]
+             ):
+    # type: (...) -> None
     """Copy a directory from one filesystem to another.
 
     Arguments:
@@ -218,17 +262,17 @@ def copy_dir(src_fs, src_path, dst_fs, dst_path,
     walker = walker or Walker()
     _src_path = abspath(normpath(src_path))
     _dst_path = abspath(normpath(dst_path))
-    with manage_fs(src_fs) as src_fs:
-        with manage_fs(dst_fs, create=True) as dst_fs:
-            with src_fs.lock(), dst_fs.lock():
-                dst_fs.makedir(_dst_path, recreate=True)
+    with manage_fs(src_fs) as _src_fs:
+        with manage_fs(dst_fs, create=True) as _dst_fs:
+            with _src_fs.lock(), _dst_fs.lock():
+                _dst_fs.makedir(_dst_path, recreate=True)
                 for dir_path, dirs, files in walker.walk(src_fs, _src_path):
                     copy_path = combine(
                         _dst_path,
                         frombase(_src_path, dir_path)
                     )
                     for info in dirs:
-                        dst_fs.makedir(
+                        _dst_fs.makedir(
                             info.make_path(copy_path),
                             recreate=True
                         )
@@ -236,16 +280,22 @@ def copy_dir(src_fs, src_path, dst_fs, dst_path,
                         src_path = info.make_path(dir_path)
                         dst_path = info.make_path(copy_path)
                         copy_file_internal(
-                            src_fs,
+                            _src_fs,
                             src_path,
-                            dst_fs,
+                            _dst_fs,
                             dst_path
                         )
-                        on_copy(src_fs, src_path, dst_fs, dst_path)
+                        on_copy(_src_fs, src_path, _dst_fs, dst_path)
 
 
-def copy_dir_if_newer(src_fs, src_path, dst_fs, dst_path,
-                      walker=None, on_copy=None):
+def copy_dir_if_newer(src_fs,       # type: Union[FS, Text]
+                      src_path,     # type: Text
+                      dst_fs,       # type: Union[FS, Text]
+                      dst_path,     # type: Text
+                      walker=None,  # type: Optional[Walker]
+                      on_copy=None  # type: Optional[OnCopy]
+                      ):
+    # type: (...) -> None
     """Copy a directory from one filesystem to another, checking times.
 
     If both source and destination files exist, the copy is executed only
@@ -270,10 +320,10 @@ def copy_dir_if_newer(src_fs, src_path, dst_fs, dst_path,
     walker = walker or Walker()
     _src_path = abspath(normpath(src_path))
     _dst_path = abspath(normpath(dst_path))
-    with manage_fs(src_fs) as src_fs:
-        with manage_fs(dst_fs, create=True) as dst_fs:
-            with src_fs.lock(), dst_fs.lock():
-                dst_fs.makedir(_dst_path, recreate=True)
+    with manage_fs(src_fs) as _src_fs:
+        with manage_fs(dst_fs, create=True) as _dst_fs:
+            with _src_fs.lock(), _dst_fs.lock():
+                _dst_fs.makedir(_dst_path, recreate=True)
                 namespace = ('details', 'modified')
                 dst_state = {
                     path: info
@@ -282,7 +332,7 @@ def copy_dir_if_newer(src_fs, src_path, dst_fs, dst_path,
                 }
                 src_state = [
                     (path, info)
-                    for path, info in walker.info(src_fs, _src_path, namespace)
+                    for path, info in walker.info(_src_fs, _src_path, namespace)
                 ]
                 for dir_path, copy_info in src_state:
                     copy_path = combine(
@@ -290,7 +340,7 @@ def copy_dir_if_newer(src_fs, src_path, dst_fs, dst_path,
                         frombase(_src_path, dir_path)
                     )
                     if copy_info.is_dir:
-                        dst_fs.makedir(copy_path, recreate=True)
+                        _dst_fs.makedir(copy_path, recreate=True)
                     elif copy_info.is_file:
                         # dst file is present, try to figure out if copy
                         # is necessary
@@ -302,5 +352,5 @@ def copy_dir_if_newer(src_fs, src_path, dst_fs, dst_path,
                             src_modified > dst_state[dir_path].modified
                         )
                         if do_copy:
-                            copy_file_internal(src_fs, dir_path, dst_fs, copy_path)
-                            on_copy(src_fs, dir_path, dst_fs, copy_path)
+                            copy_file_internal(_src_fs, dir_path, _dst_fs, copy_path)
+                            on_copy(_src_fs, dir_path, _dst_fs, copy_path)

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -14,8 +14,8 @@ from .path import frombase
 from .path import normpath
 from .errors import FSError
 
-if False:  # typing imports
-    from typing import *
+if typing.TYPE_CHECKING:
+    from typing import Callable, Optional, Text, Union
     from .base import FS
     from .walk import Walker
     _OnCopy = Callable[[FS, Text, FS, Text], None]

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -343,14 +343,18 @@ def copy_dir_if_newer(src_fs,       # type: Union[FS, Text]
                     elif copy_info.is_file:
                         # dst file is present, try to figure out if copy
                         # is necessary
-                        src_modified = copy_info.modified
-                        dst_modified = dst_state[dir_path].modified
-                        do_copy = (
-                            dir_path not in dst_state or
-                            src_modified is None or
-                            dst_modified is None or
-                            src_modified > dst_modified
-                        )
+                        try:
+                            src_modified = copy_info.modified
+                            dst_modified = dst_state[dir_path].modified
+                        except KeyError:
+                            do_copy = True
+                        else:
+                            do_copy = (
+                                src_modified is None or
+                                dst_modified is None or
+                                src_modified > dst_modified
+                            )
+
                         if do_copy:
                             copy_file_internal(_src_fs, dir_path, _dst_fs, copy_path)
                             on_copy(_src_fs, dir_path, _dst_fs, copy_path)

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -18,14 +18,14 @@ if False:  # typing imports
     from .base import FS
     from .walk import Walker
 
-    OnCopy = Callable[[FS, Text, FS, Text], None]
+    _OnCopy = Callable[[FS, Text, FS, Text], None]
 
 
 
 def copy_fs(src_fs,       # type: Union[FS, Text]
             dst_fs,       # type: Union[FS, Text]
             walker=None,  # type: Optional[Walker]
-            on_copy=None  # type: Optional[OnCopy]
+            on_copy=None  # type: Optional[_OnCopy]
             ):
     # type: (...) -> None
     """Copy the contents of one filesystem to another.
@@ -48,7 +48,7 @@ def copy_fs(src_fs,       # type: Union[FS, Text]
 def copy_fs_if_newer(src_fs,        # type: Union[FS, Text]
                      dst_fs,        # type: Union[FS, Text]
                      walker=None,   # type: Optional[Walker]
-                     on_copy=None   # type: Optional[OnCopy]
+                     on_copy=None   # type: Optional[_OnCopy]
                      ):
     # type: (...) -> None
     """Copy the contents of one filesystem to another, checking times.
@@ -240,7 +240,7 @@ def copy_dir(src_fs,        # type: Union[FS, Text]
              dst_fs,        # type: Union[FS, Text]
              dst_path,      # type: Text
              walker=None,   # type: Optional[Walker]
-             on_copy=None   # type: Optional[OnCopy]
+             on_copy=None   # type: Optional[_OnCopy]
              ):
     # type: (...) -> None
     """Copy a directory from one filesystem to another.
@@ -293,7 +293,7 @@ def copy_dir_if_newer(src_fs,       # type: Union[FS, Text]
                       dst_fs,       # type: Union[FS, Text]
                       dst_path,     # type: Text
                       walker=None,  # type: Optional[Walker]
-                      on_copy=None  # type: Optional[OnCopy]
+                      on_copy=None  # type: Optional[_OnCopy]
                       ):
     # type: (...) -> None
     """Copy a directory from one filesystem to another, checking times.

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -14,7 +14,7 @@ from .path import frombase
 from .path import normpath
 from .errors import FSError
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Callable, Optional, Text, Union
     from .base import FS
     from .walk import Walker

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -18,7 +18,7 @@ if typing.TYPE_CHECKING:
     from typing import Callable, Optional, Text, Union
     from .base import FS
     from .walk import Walker
-    _OnCopy = Callable[[FS, Text, FS, Text], None]
+    _OnCopy = Callable[[FS, Text, FS, Text], object]
 
 
 def copy_fs(src_fs,       # type: Union[FS, Text]

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -265,7 +265,7 @@ def copy_dir(src_fs,        # type: Union[FS, Text]
         with manage_fs(dst_fs, create=True) as _dst_fs:
             with _src_fs.lock(), _dst_fs.lock():
                 _dst_fs.makedir(_dst_path, recreate=True)
-                for dir_path, dirs, files in walker.walk(src_fs, _src_path):
+                for dir_path, dirs, files in walker.walk(_src_fs, _src_path):
                     copy_path = combine(
                         _dst_path,
                         frombase(_src_path, dir_path)
@@ -326,7 +326,7 @@ def copy_dir_if_newer(src_fs,       # type: Union[FS, Text]
                 namespace = ('details', 'modified')
                 dst_state = {
                     path: info
-                    for path, info in walker.info(dst_fs, _dst_path, namespace)
+                    for path, info in walker.info(_dst_fs, _dst_path, namespace)
                     if info.is_file
                 }
                 src_state = [
@@ -344,11 +344,12 @@ def copy_dir_if_newer(src_fs,       # type: Union[FS, Text]
                         # dst file is present, try to figure out if copy
                         # is necessary
                         src_modified = copy_info.modified
+                        dst_modified = dst_state[dir_path].modified
                         do_copy = (
                             dir_path not in dst_state or
                             src_modified is None or
-                            dst_state[dir_path].modified is None or
-                            src_modified > dst_state[dir_path].modified
+                            dst_modified is None or
+                            src_modified > dst_modified
                         )
                         if do_copy:
                             copy_file_internal(_src_fs, dir_path, _dst_fs, copy_path)

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -14,6 +14,10 @@ from . import errors
 from six import reraise
 
 
+if False:  # typing imports
+    from typing import Text
+
+
 _WINDOWS_PLATFORM = platform.system() == 'Windows'
 
 
@@ -54,6 +58,7 @@ class _ConvertOSErrors(object):
         FILE_ERRORS[13] = errors.FileExpected
 
     def __init__(self, opname, path, directory=False):
+        # type: (Text, Text, bool) -> None
         self._opname = opname
         self._path = path
         self._directory = directory

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -16,7 +16,9 @@ from six import reraise
 from . import errors
 
 if typing.TYPE_CHECKING:  # typing imports
-    from typing import Iterator, Mapping, Text, Union
+    from types import TracebackType
+    from typing import (
+        Iterator, Optional, Mapping, Text, Type, Union)
 
 
 _WINDOWS_PLATFORM = platform.system() == 'Windows'
@@ -65,9 +67,15 @@ class _ConvertOSErrors(object):
         self._directory = directory
 
     def __enter__(self):
+        # type: () -> _ConvertOSErrors
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self,
+                 exc_type,      # type: Optional[Type[BaseException]]
+                 exc_value,     # type: Optional[BaseException]
+                 traceback      # type: Optional[TracebackType]
+                 ):
+        # type: (...) -> None
         os_errors = (
             self.DIR_ERRORS
             if self._directory

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -15,7 +15,7 @@ from six import reraise
 
 from . import errors
 
-if typing.TYPE_CHECKING:  # typing imports
+if False:  # typing.TYPE_CHECKING
     from types import TracebackType
     from typing import (
         Iterator, Optional, Mapping, Text, Type, Union)

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -21,7 +21,7 @@ if typing.TYPE_CHECKING:  # typing imports
 _WINDOWS_PLATFORM = platform.system() == 'Windows'
 
 
-class _ConvertOSErrors(typing.ContextManager):
+class _ConvertOSErrors(object):
     """Context manager to convert OSErrors in to FS Errors.
     """
 

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -4,6 +4,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import collections
 import errno
 import platform
 import sys
@@ -15,7 +16,7 @@ from six import reraise
 from . import errors
 
 if typing.TYPE_CHECKING:  # typing imports
-    from typing import Iterator, Text
+    from typing import Iterator, Mapping, Text, Union
 
 
 _WINDOWS_PLATFORM = platform.system() == 'Windows'
@@ -93,7 +94,7 @@ convert_os_errors = _ConvertOSErrors
 
 @contextmanager
 def unwrap_errors(path_replace):
-    # type: (Text) -> Iterator[None]
+    # type: (Union[Text, Mapping[Text, Text]]) -> Iterator[None]
     """Get a context to map OS errors to their `fs.errors` counterpart.
 
     The context will re-write the paths in resource exceptions to be
@@ -108,7 +109,7 @@ def unwrap_errors(path_replace):
         yield
     except errors.ResourceError as e:
         if hasattr(e, 'path'):
-            if isinstance(path_replace, dict):
+            if isinstance(path_replace, collections.Mapping):
                 e.path = path_replace.get(e.path, e.path)
             else:
                 e.path = path_replace

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -5,9 +5,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import errno
-from contextlib import contextmanager
-import sys
 import platform
+import sys
+import typing
+
+from contextlib import contextmanager
+from typing import Text
 
 from . import errors
 
@@ -21,7 +24,7 @@ if False:  # typing imports
 _WINDOWS_PLATFORM = platform.system() == 'Windows'
 
 
-class _ConvertOSErrors(object):
+class _ConvertOSErrors(typing.ContextManager):
     """Context manager to convert OSErrors in to FS Errors.
     """
 

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -8,17 +8,14 @@ import errno
 import platform
 import sys
 import typing
-
 from contextlib import contextmanager
-from typing import Text
-
-from . import errors
 
 from six import reraise
 
+from . import errors
 
-if False:  # typing imports
-    from typing import Text
+if typing.TYPE_CHECKING:  # typing imports
+    from typing import Iterator, Text
 
 
 _WINDOWS_PLATFORM = platform.system() == 'Windows'
@@ -96,6 +93,7 @@ convert_os_errors = _ConvertOSErrors
 
 @contextmanager
 def unwrap_errors(path_replace):
+    # type: (Text) -> Iterator[None]
     """Get a context to map OS errors to their `fs.errors` counterpart.
 
     The context will re-write the paths in resource exceptions to be

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -111,6 +111,7 @@ class CreateFailed(FSError):
         self.details = '' if exc is None else text_type(exc)
         self.exc = exc
 
+
 class PathError(FSError):
     """Base exception for errors to do with a path string.
     """

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -12,9 +12,14 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import functools
+import typing
 
 import six
 from six import text_type
+
+if typing.TYPE_CHECKING:
+    from typing import Callable, Optional, Text
+
 
 __all__ = [
     'CreateFailed',
@@ -53,6 +58,7 @@ class MissingInfoNamespace(AttributeError):
     """
 
     def __init__(self, namespace):
+        # type: (Text) -> None
         msg = "namespace '{}' is required for this attribute"
         super(MissingInfoNamespace, self).__init__(
             msg.format(namespace)
@@ -67,16 +73,19 @@ class FSError(Exception):
     default_message = "Unspecified error"
 
     def __init__(self, msg=None):
+        # type: (Optional[Text]) -> None
         self._msg = msg or self.default_message
         super(FSError, self).__init__()
 
     def __str__(self):
+        # type: () -> Text
         """Return the error message.
         """
         msg = self._msg.format(**self.__dict__)
         return msg
 
     def __repr__(self):
+        # type: () -> Text
         msg = self._msg.format(**self.__dict__)
         return "{}({!r})".format(self.__class__.__name__, msg)
 
@@ -94,8 +103,15 @@ class CreateFailed(FSError):
 
     default_message = "unable to create filesystem, {details}"
 
+    def __init__(self, msg=None, exc=None):
+        # type: (Optional[Text], Optional[Exception]) -> None
+        self._msg = msg or self.default_message
+        self.details = '' if exc is None else text_type(exc)
+        self.exc = exc
+
     @classmethod
     def catch_all(cls, func):
+        # type: (Callable) -> Callable
         @functools.wraps(func)
         def new_func(*args, **kwargs):
             try:
@@ -106,12 +122,6 @@ class CreateFailed(FSError):
                 raise cls(exc=e)
         return new_func
 
-    def __init__(self, msg=None, exc=None):
-        self._msg = msg or self.default_message
-        self.details = '' if exc is None else text_type(exc)
-        self.exc = exc
-
-
 class PathError(FSError):
     """Base exception for errors to do with a path string.
     """
@@ -119,6 +129,7 @@ class PathError(FSError):
     default_message = "path '{path}' is invalid"
 
     def __init__(self, path, msg=None):
+        # type: (Text, Optional[Text]) -> None
         self.path = path
         super(PathError, self).__init__(msg=msg)
 
@@ -137,6 +148,7 @@ class NoURL(PathError):
     default_message = "path '{path}' has no '{purpose}' URL"
 
     def __init__(self, path, purpose, msg=None):
+        # type: (Text, Text, Optional[Text]) -> None
         self.purpose = purpose
         super(NoURL, self).__init__(path, msg=msg)
 
@@ -161,7 +173,12 @@ class OperationFailed(FSError):
 
     default_message = "operation failed, {details}"
 
-    def __init__(self, path=None, exc=None, msg=None):
+    def __init__(self,
+                 path=None,     # type: Optional[Text]
+                 exc=None,      # type: Optional[Text]
+                 msg=None       # type: Optional[Text]
+                 ):
+        # type: (...) -> None
         self.path = path
         self.exc = exc
         self.details = '' if exc is None else text_type(exc)
@@ -218,6 +235,7 @@ class ResourceError(FSError):
     default_message = "failed on path {path}"
 
     def __init__(self, path, exc=None, msg=None):
+        # type: (Text, Optional[Exception], Optional[Text]) -> None
         self.path = path
         self.exc = exc
         super(ResourceError, self).__init__(msg=msg)
@@ -307,6 +325,7 @@ class IllegalBackReference(ValueError):
     """
 
     def __init__(self, path):
+        # type: (Text) -> None
         _msg = \
             "path '{path}' contains back-references outside of filesystem"
         _msg = _msg.format(path=path)

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -18,8 +18,8 @@ import six
 from six import text_type
 
 if typing.TYPE_CHECKING:
-    from typing import Callable, Optional, Text
-
+    from typing import Optional, Text
+    
 
 __all__ = [
     'CreateFailed',
@@ -111,7 +111,6 @@ class CreateFailed(FSError):
 
     @classmethod
     def catch_all(cls, func):
-        # type: (Callable) -> Callable
         @functools.wraps(func)
         def new_func(*args, **kwargs):
             try:
@@ -120,7 +119,7 @@ class CreateFailed(FSError):
                 raise
             except Exception as e:
                 raise cls(exc=e)
-        return new_func
+        return new_func  # type: ignore
 
 class PathError(FSError):
     """Base exception for errors to do with a path string.

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -17,7 +17,7 @@ import typing
 import six
 from six import text_type
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Optional, Text
     
 

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -175,7 +175,7 @@ class OperationFailed(FSError):
 
     def __init__(self,
                  path=None,     # type: Optional[Text]
-                 exc=None,      # type: Optional[Text]
+                 exc=None,      # type: Optional[Exception]
                  msg=None       # type: Optional[Text]
                  ):
         # type: (...) -> None

--- a/fs/filesize.py
+++ b/fs/filesize.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 
 import typing
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Iterable, SupportsInt, Text
 
 

--- a/fs/filesize.py
+++ b/fs/filesize.py
@@ -14,10 +14,16 @@ See Also:
 from __future__ import division
 from __future__ import unicode_literals
 
+
+if False:  # typing imports
+    from typing import Iterable, SupportsInt, Text
+
+
 __all__ = ['traditional', 'decimal', 'binary']
 
 
 def _to_str(size, suffixes, base):
+    # type: (SupportsInt, Iterable[Text], int) -> Text
     try:
         size = int(size)
     except ValueError:
@@ -37,6 +43,7 @@ def _to_str(size, suffixes, base):
 
 
 def traditional(size):
+    # type: (SupportsInt) -> Text
     """Convert a filesize in to a string (powers of 1024, JDEC prefixes).
 
     In this convention, ``1024 B = 1 KB``.
@@ -66,6 +73,7 @@ def traditional(size):
 
 
 def binary(size):
+    # type: (SupportsInt) -> Text
     """Convert a filesize in to a string (powers of 1024, IEC prefixes).
 
     In this convention, ``1024 B = 1 KiB``.
@@ -95,6 +103,7 @@ def binary(size):
 
 
 def decimal(size):
+    # type: (SupportsInt) -> Text
     """Convert a filesize in to a string (powers of 1000, SI prefixes).
 
     In this convention, ``1000 B = 1 kB``.

--- a/fs/filesize.py
+++ b/fs/filesize.py
@@ -14,8 +14,9 @@ See Also:
 from __future__ import division
 from __future__ import unicode_literals
 
+import typing
 
-if False:  # typing imports
+if typing.TYPE_CHECKING:
     from typing import Iterable, SupportsInt, Text
 
 

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -35,7 +35,7 @@ from .path import normpath
 from .path import split
 from . import _ftp_parse as ftp_parse
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     import ftplib
     from typing import (
         Any, BinaryIO, ByteString, ContextManager,
@@ -580,7 +580,7 @@ class FTPFS(FS):
                 details['created'] = cls._parse_ftp_time(facts['create'])
             yield raw_info
 
-    if typing.TYPE_CHECKING:
+    if False:  # typing.TYPE_CHECKING
         def opendir(self, path, factory=None):
             # type: (_F, Text, Optional[_OpendirFactory]) -> SubFS[_F]
             pass

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -4,14 +4,14 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from collections import OrderedDict
 import calendar
+import ftplib
 import io
 import itertools
 import socket
 import threading
 import typing
-
+from collections import OrderedDict
 from contextlib import contextmanager
 from ftplib import FTP
 from ftplib import error_perm
@@ -25,7 +25,7 @@ from .base import FS
 from .constants import DEFAULT_CHUNK_SIZE
 from .enums import ResourceType
 from .enums import Seek
-from .info import Info, _RawInfo
+from .info import Info
 from .iotools import line_iterator
 from .mode import Mode
 from .path import abspath
@@ -35,12 +35,10 @@ from .path import normpath
 from .path import split
 from . import _ftp_parse as ftp_parse
 
-
 if typing.TYPE_CHECKING:
     import ftplib
-    import typing
     from typing import ByteString, Iterator, Dict, Optional, Text, Union
-    from .info import _RawInfo
+    from .info import RawInfo
     from .permissions import Permissions
 
 
@@ -539,7 +537,7 @@ class FTPFS(FS):
 
     @classmethod
     def _parse_mlsx(cls, lines):
-        # type: (typing.Iterable[Text]) -> Iterator[_RawInfo]
+        # type: (typing.Iterable[Text]) -> Iterator[RawInfo]
         for line in lines:
             name, facts = cls._parse_facts(line.strip())
             if name is None:
@@ -755,7 +753,7 @@ class FTPFS(FS):
         self.setbinfile(path, io.BytesIO(contents))
 
     def setinfo(self, path, info):
-        # type: (Text, _RawInfo) -> None
+        # type: (Text, RawInfo) -> None
         if not self.exists(path):
             raise errors.ResourceNotFound(path)
 

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -40,6 +40,8 @@ if typing.TYPE_CHECKING:
     from typing import ByteString, Iterator, Dict, Optional, Text, Union
     from .info import RawInfo
     from .permissions import Permissions
+    from .subfs import SubFS
+    F = typing.TypeVar('F', bound='FTPFS')
 
 
 __all__ = ['FTPFS']
@@ -619,8 +621,12 @@ class FTPFS(FS):
             ]
         return dir_list
 
-    def makedir(self, path, permissions=None, recreate=False):
-        # type: (Text, Optional[Permissions], bool) -> FS
+    def makedir(self,               # type: F
+                path,               # type: Text
+                permissions=None,   # type: Optional[Permissions]
+                recreate=False      # type: bool
+                ):
+        # type: (...) -> SubFS[F]
         _path = self.validatepath(path)
 
         with ftp_errors(self, path=path):

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -309,13 +309,14 @@ class FTPFS(FS):
 
     Arguments:
         host (str): A FTP host, e.g. ``'ftp.mirror.nl'``.
-        user (str, optional): A username (default is ``'anonymous'``).
-        passwd (str, optional): Password for the server, or `None` for anon.
-        acct (str, optional): FTP account.
-        timeout (int, optional): Timeout for contacting server (in seconds,
+        user (str): A username (default is ``'anonymous'``).
+        passwd (str): Password for the server, or `None` for anon.
+        acct (str): FTP account.
+        timeout (int): Timeout for contacting server (in seconds,
             defaults to 10).
-        port (int, optional): FTP port number (default 21).
-        proxy (str): An FTP proxy, or ``None`` (default) for no proxy.
+        port (int): FTP port number (default 21).
+        proxy (str, optional): An FTP proxy, or ``None`` (default)
+            for no proxy.
 
     """
 
@@ -488,7 +489,7 @@ class FTPFS(FS):
         return 'MLST' in self.features
 
     def create(self, path, wipe=False):
-        # type: (Text, bool) -> None
+        # type: (Text, bool) -> bool
         _path = self.validatepath(path)
         with ftp_errors(self, path):
             if wipe or not self.isfile(path):
@@ -497,6 +498,8 @@ class FTPFS(FS):
                     str("STOR ") + _encode(_path, self.ftp.encoding),
                     empty_file
                 )
+                return True
+        return False
 
     @classmethod
     def _parse_ftp_time(cls, time_text):

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -104,13 +104,17 @@ def _parse_ftp_error(error):
 
 if PY2:
     def _encode(st, encoding):
+        # type: (Union[Text, bytes], Text) -> str
         return st.encode(encoding) if isinstance(st, text_type) else st
     def _decode(st, encoding):
+        # type: (Union[Text, bytes], Text) -> Text
         return st.decode(encoding, 'replace') if isinstance(st, bytes) else st
 else:
     def _encode(st, _):
+        # type: (str, str) -> str
         return st
     def _decode(st, _):
+        # type: (str, str) -> str
         return st
 
 
@@ -419,7 +423,7 @@ class FTPFS(FS):
                     else 'latin-1'
                 )
                 if not PY2:
-                    _ftp.file = _ftp.sock.makefile(    # type: ignore
+                    _ftp.file = _ftp.sock.makefile(  # type: ignore
                         'r',
                         encoding=self.encoding
                     )

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -10,6 +10,7 @@ import io
 import itertools
 import socket
 import threading
+import typing
 
 from contextlib import contextmanager
 from ftplib import FTP
@@ -24,7 +25,7 @@ from .base import FS
 from .constants import DEFAULT_CHUNK_SIZE
 from .enums import ResourceType
 from .enums import Seek
-from .info import Info
+from .info import Info, _RawInfo
 from .iotools import line_iterator
 from .mode import Mode
 from .path import abspath
@@ -35,11 +36,20 @@ from .path import split
 from . import _ftp_parse as ftp_parse
 
 
+if typing.TYPE_CHECKING:
+    import ftplib
+    import typing
+    from typing import ByteString, Iterator, Dict, Optional, Text, Union
+    from .info import _RawInfo
+    from .permissions import Permissions
+
+
 __all__ = ['FTPFS']
 
 
 @contextmanager
 def ftp_errors(fs, path=None):
+    # type: (FTPFS, Optional[Text]) -> Iterator[None]
     try:
         with fs._lock:
             yield
@@ -73,6 +83,7 @@ def ftp_errors(fs, path=None):
 
 @contextmanager
 def manage_ftp(ftp):
+    # type: (FTP) -> Iterator[FTP]
     try:
         yield ftp
     finally:
@@ -83,10 +94,11 @@ def manage_ftp(ftp):
 
 
 def _parse_ftp_error(error):
+    # type: (ftplib.Error) -> typing.Tuple[Union[int, Text], Text]
     """Extract code and message from ftp error."""
     code, _, message = text_type(error).partition(' ')
     if code.isdigit():
-        code = int(code)
+        return int(code), message
     return code, message
 
 
@@ -102,9 +114,10 @@ else:
         return st
 
 
-class FTPFile(io.IOBase):
+class FTPFile(io.RawIOBase):
 
     def __init__(self, ftpfs, path, mode):
+        # type: (FTPFS, Text, Text) -> None
         super(FTPFile, self).__init__()
         self.fs = ftpfs
         self.path = path
@@ -112,10 +125,11 @@ class FTPFile(io.IOBase):
         self.pos = 0
         self._lock = threading.Lock()
         self.ftp = self._open_ftp()
-        self._read_conn = None
-        self._write_conn = None
+        self._read_conn = None          # type: Optional[socket.socket]
+        self._write_conn = None         # type: Optional[socket.socket]
 
     def _open_ftp(self):
+        # type: () -> FTP
         """Open an ftp object for the file."""
         ftp = self.fs._open_ftp()
         ftp.voidcmd(str('TYPE I'))
@@ -123,6 +137,7 @@ class FTPFile(io.IOBase):
 
     @property
     def read_conn(self):
+        # type: () -> socket.socket
         if self._read_conn is None:
             self._read_conn = self.ftp.transfercmd(
                 str('RETR ') + _encode(self.path, self.ftp.encoding),
@@ -132,6 +147,7 @@ class FTPFile(io.IOBase):
 
     @property
     def write_conn(self):
+        # type: () -> socket.socket
         if self._write_conn is None:
             if self.mode.appending:
                 self._write_conn = self.ftp.transfercmd(
@@ -145,10 +161,12 @@ class FTPFile(io.IOBase):
         return self._write_conn
 
     def __repr__(self):
+        # type: () -> str
         _repr = "<ftpfile {!r} {!r} {!r}>"
         return _repr.format(self.fs.ftp_url, self.path, self.mode)
 
     def close(self):
+        # type: () -> None
         if not self.closed:
             with self._lock:
                 try:
@@ -166,12 +184,15 @@ class FTPFile(io.IOBase):
                     super(FTPFile, self).close()
 
     def tell(self):
+        # type: () -> int
         return self.pos
 
     def readable(self):
+        # type: () -> bool
         return self.mode.reading
 
     def read(self, size=-1):
+        # type: (int) -> bytes
         if not self.mode.reading:
             raise IOError('File not open for reading')
 
@@ -196,10 +217,12 @@ class FTPFile(io.IOBase):
                 remaining -= len(chunk)
         return b''.join(chunks)
 
-    def readline(self, size=None):
+    def readline(self, size=-1):
+        # type: (int) -> bytes
         return next(line_iterator(self, size))
 
     def readlines(self, hint=-1):
+        # type: (int) -> typing.List[bytes]
         lines = []
         size = 0
         for line in line_iterator(self):
@@ -210,9 +233,11 @@ class FTPFile(io.IOBase):
         return lines
 
     def writable(self):
+        # type: () -> bool
         return self.mode.writing
 
     def write(self, data):
+        # type: (bytes) -> int
         if not self.mode.writing:
             raise IOError('File not open for writing')
 
@@ -231,9 +256,11 @@ class FTPFile(io.IOBase):
         return data_pos
 
     def writelines(self, lines):
+        # type: (typing.Iterable[bytes]) -> None
         self.write(b''.join(lines))
 
     def truncate(self, size=None):
+        # type: (Optional[int]) -> int
         # Inefficient, but I don't know if truncate is possible with ftp
         with self._lock:
             if size is None:
@@ -247,17 +274,20 @@ class FTPFile(io.IOBase):
         return size
 
     def seekable(self):
+        # type: () -> bool
         return True
 
     def seek(self, pos, whence=Seek.set):
-        if whence not in (Seek.set, Seek.current, Seek.end):
+        # type: (int, typing.SupportsInt) -> int
+        _whence = int(whence)
+        if _whence not in (Seek.set, Seek.current, Seek.end):
             raise ValueError('invalid value for whence')
         with self._lock:
-            if whence == Seek.set:
+            if _whence == Seek.set:
                 new_pos = pos
-            elif whence == Seek.current:
+            elif _whence == Seek.current:
                 new_pos = self.pos + pos
-            elif whence == Seek.end:
+            elif _whence == Seek.end:
                 file_size = self.fs.getsize(self.path)
                 new_pos = file_size + pos
             self.pos = max(0, new_pos)
@@ -299,13 +329,15 @@ class FTPFS(FS):
     }
 
     def __init__(self,
-                 host,
-                 user='anonymous',
-                 passwd='',
-                 acct='',
-                 timeout=10,
-                 port=21,
-                 proxy=None):
+                 host,                  # type: Text
+                 user='anonymous',      # type: Text
+                 passwd='',             # type: Text
+                 acct='',               # type: Text
+                 timeout=10,            # type: int
+                 port=21,               # type: int
+                 proxy=None             # type: Optional[Text]
+                 ):
+        # type: (...) -> None
         super(FTPFS, self).__init__()
         self._host = host
         self._user = user
@@ -316,14 +348,16 @@ class FTPFS(FS):
         self.proxy = proxy
 
         self.encoding = 'latin-1'
-        self._ftp = None
-        self._welcome = None
-        self._features = None
+        self._ftp = None            # type: Optional[FTP]
+        self._welcome = None        # type: Optional[Text]
+        self._features = {}         # type: Dict[Text, Text]
 
     def __repr__(self):
+        # type: (...) -> Text
         return "FTPFS({!r}, port={!r})".format(self.host, self.port)
 
     def __str__(self):
+        # type: (...) -> Text
         _fmt = (
             "<ftpfs '{host}'>"
             if self.port == 21
@@ -333,6 +367,7 @@ class FTPFS(FS):
 
     @property
     def user(self):
+        # type: () -> Text
         return (
             self._user
             if self.proxy is None else
@@ -341,6 +376,7 @@ class FTPFS(FS):
 
     @property
     def host(self):
+        # type: () -> Text
         return (
             self._host
             if self.proxy is None else
@@ -349,7 +385,9 @@ class FTPFS(FS):
 
     @classmethod
     def _parse_features(cls, feat_response):
-        """Parse a dict of features from FTP feat response."""
+        # type: (Text) -> Dict[Text, Text]
+        """Parse a dict of features from FTP feat response.
+        """
         features = {}
         if feat_response.split('-')[0] == '211':
             for line in feat_response.splitlines():
@@ -359,7 +397,9 @@ class FTPFS(FS):
         return features
 
     def _open_ftp(self):
-        """Open a new ftp object."""
+        # type: () -> FTP
+        """Open a new ftp object.
+        """
         _ftp = FTP()
         _ftp.set_debuglevel(0)
         with ftp_errors(self):
@@ -378,7 +418,7 @@ class FTPFS(FS):
                     else 'latin-1'
                 )
                 if not PY2:
-                    _ftp.file = _ftp.sock.makefile(
+                    _ftp.file = _ftp.sock.makefile(    # type: ignore
                         'r',
                         encoding=self.encoding
                     )
@@ -387,11 +427,13 @@ class FTPFS(FS):
         return _ftp
 
     def _manage_ftp(self):
+        # type: () -> typing.ContextManager[FTP]
         ftp = self._open_ftp()
         return manage_ftp(ftp)
 
     @property
     def ftp_url(self):
+        # type: () -> Text
         """Get the FTP url this filesystem will open."""
         url = (
             "ftp://{}".format(self.host)
@@ -402,25 +444,29 @@ class FTPFS(FS):
 
     @property
     def ftp(self):
-        """`~ftplib.FTP`: the underlying FTP client.
+        # type: () -> FTP
+        """~ftplib.FTP: the underlying FTP client.
         """
         return self._get_ftp()
 
     def _get_ftp(self):
+        # type: () -> FTP
         if self._ftp is None:
             self._ftp = self._open_ftp()
         return self._ftp
 
     @property
     def features(self):
-        """`dict`: features of the remote FTP server.
+        # type: () -> Dict[Text, Text]
+        """dict: features of the remote FTP server.
         """
         self._get_ftp()
         return self._features
 
     def _read_dir(self, path):
+        # type: (Text) -> Dict[Text, Info]
         _path = abspath(normpath(path))
-        lines = []
+        lines = []  # type: typing.List[typing.Union[ByteString, Text]]
         with ftp_errors(self, path=path):
             self.ftp.retrlines(
                 str('LIST ') + _encode(_path, self.ftp.encoding),
@@ -436,10 +482,13 @@ class FTPFS(FS):
 
     @property
     def supports_mlst(self):
-        """Check if server supports MLST feature."""
+        # typing: () -> bool
+        """bool: whether the server supports MLST feature.
+        """
         return 'MLST' in self.features
 
     def create(self, path, wipe=False):
+        # type: (Text, bool) -> None
         _path = self.validatepath(path)
         with ftp_errors(self, path):
             if wipe or not self.isfile(path):
@@ -451,7 +500,9 @@ class FTPFS(FS):
 
     @classmethod
     def _parse_ftp_time(cls, time_text):
-        """Parse a time from an ftp directory listing."""
+        # type: (Text) -> Optional[int]
+        """Parse a time from an ftp directory listing.
+        """
         try:
             tm_year = int(time_text[0:4])
             tm_month = int(time_text[4:6])
@@ -473,6 +524,7 @@ class FTPFS(FS):
 
     @classmethod
     def _parse_facts(cls, line):
+        # type: (Text) -> typing.Tuple[Optional[Text], Dict[Text, Text]]
         name = None
         facts = {}
         for fact in line.split(';'):
@@ -487,27 +539,21 @@ class FTPFS(FS):
 
     @classmethod
     def _parse_mlsx(cls, lines):
+        # type: (typing.Iterable[Text]) -> Iterator[_RawInfo]
         for line in lines:
             name, facts = cls._parse_facts(line.strip())
             if name is None:
                 continue
             is_dir = facts.get('type', None) in ('dir', 'cdir', 'pdir')
-            raw_info = {
-                "basic":
-                {
-                    "name": name,
-                    "is_dir": is_dir,
-                },
-                "details":
-                {
-                    "type": (
-                        int(ResourceType.directory)
-                        if is_dir else
-                        int(ResourceType.file)
-                    )
-                },
-                "ftp": facts
-            }
+            raw_info = {} # type: Dict[Text, Dict[Text, object]]
+
+            raw_info["basic"] = {"name": name, "is_dir": is_dir}
+            raw_info["ftp"] = facts  # type: ignore
+            raw_info["details"] = {"type": (
+                int(ResourceType.directory)
+                if is_dir else int(ResourceType.file)
+            )}
+
             details = raw_info['details']
             size_str = facts.get('size', facts.get('sizd', '0'))
             size = 0
@@ -521,6 +567,7 @@ class FTPFS(FS):
             yield raw_info
 
     def getinfo(self, path, namespaces=None):
+        # type: (Text, Optional[typing.Container[Text]]) -> Info
         _path = self.validatepath(path)
         namespaces = namespaces or ()
 
@@ -556,15 +603,16 @@ class FTPFS(FS):
             return info
 
     def getmeta(self, namespace="standard"):
-        _meta = {}
+        # type: (Text) -> Dict[Text, object]
+        _meta = {}  # type: Dict[Text, object]
         self._get_ftp()
         if namespace == "standard":
             _meta = self._meta.copy()
             _meta['unicode_paths'] = "UTF8" in self.features
         return _meta
 
-
     def listdir(self, path):
+        # type: (Text) -> typing.List[Text]
         _path = self.validatepath(path)
         with self._lock:
             dir_list = [
@@ -574,6 +622,7 @@ class FTPFS(FS):
         return dir_list
 
     def makedir(self, path, permissions=None, recreate=False):
+        # type: (Text, Optional[Permissions], bool) -> FS
         _path = self.validatepath(path)
 
         with ftp_errors(self, path=path):
@@ -598,6 +647,7 @@ class FTPFS(FS):
         return self.opendir(path)
 
     def openbin(self, path, mode="r", buffering=-1, **options):
+        # type: (Text, Text, int, **typing.Any) -> typing.BinaryIO
         _mode = Mode(mode)
         _mode.validate_bin()
         _path = self.validatepath(path)
@@ -616,9 +666,10 @@ class FTPFS(FS):
             if _mode.exclusive:
                 raise errors.FileExists(path)
             ftp_file = FTPFile(self, _path, mode)
-        return ftp_file
+        return ftp_file  # type: ignore
 
     def remove(self, path):
+        # type: (Text) -> None
         self.check()
         _path = self.validatepath(path)
         with self._lock:
@@ -628,6 +679,7 @@ class FTPFS(FS):
                 self.ftp.delete(_encode(_path, self.ftp.encoding))
 
     def removedir(self, path):
+        # type: (Text) -> None
         _path = self.validatepath(path)
         if _path == '/':
             raise errors.RemoveRootError()
@@ -644,7 +696,11 @@ class FTPFS(FS):
                         raise errors.DirectoryNotEmpty(path)
                 raise  # pragma: no cover
 
-    def _scandir(self, path, namespaces=None):
+    def _scandir(self,
+                 path,            # type: Text
+                 namespaces=None  # type: Optional[typing.Container[Text]]
+                 ):
+        # type: (...) -> typing.Iterator[Info]
         _path = self.validatepath(path)
         with self._lock:
             if self.supports_mlst:
@@ -667,7 +723,12 @@ class FTPFS(FS):
                 for info in self._read_dir(_path).values():
                     yield info
 
-    def scandir(self, path, namespaces=None, page=None):
+    def scandir(self,
+                path,               # type: Text
+                namespaces=None,    # type: Optional[typing.Container[Text]]
+                page=None           # type: Optional[typing.Tuple[int, int]]
+                ):
+        # type: (...) -> typing.Iterator[Info]
         if not self.supports_mlst and not self.getinfo(path).is_dir:
             raise errors.DirectoryExpected(path)
         iter_info = self._scandir(path, namespaces=namespaces)
@@ -677,6 +738,7 @@ class FTPFS(FS):
         return iter_info
 
     def setbinfile(self, path, file):
+        # type: (Text, typing.BinaryIO) -> None
         _path = self.validatepath(path)
         with self._lock:
             with self._manage_ftp() as ftp:
@@ -687,15 +749,18 @@ class FTPFS(FS):
                     )
 
     def setbytes(self, path, contents):
+        # type: (Text, typing.ByteString) -> None
         if not isinstance(contents, bytes):
             raise TypeError('contents must be bytes')
         self.setbinfile(path, io.BytesIO(contents))
 
     def setinfo(self, path, info):
+        # type: (Text, _RawInfo) -> None
         if not self.exists(path):
             raise errors.ResourceNotFound(path)
 
     def getbytes(self, path):
+        # type: (Text) -> bytes
         _path = self.validatepath(path)
         data = io.BytesIO()
         with ftp_errors(self, path):
@@ -716,6 +781,7 @@ class FTPFS(FS):
         return data_bytes
 
     def close(self):
+        # type: () -> None
         if not self.isclosed():
             try:
                 self.ftp.quit()

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -42,10 +42,13 @@ if typing.TYPE_CHECKING:
         Iterable, Iterator, Collection, Container,
         Dict, List, Optional, SupportsInt, Text,
         Tuple, Union)
+    from .base import _OpendirFactory
     from .info import RawInfo
     from .permissions import Permissions
     from .subfs import SubFS
-    F = typing.TypeVar('F', bound='FTPFS')
+
+
+_F = typing.TypeVar('_F', bound='FTPFS')
 
 
 __all__ = ['FTPFS']
@@ -577,6 +580,11 @@ class FTPFS(FS):
                 details['created'] = cls._parse_ftp_time(facts['create'])
             yield raw_info
 
+    if typing.TYPE_CHECKING:
+        def opendir(self, path, factory=None):
+            # type: (_F, Text, Optional[_OpendirFactory]) -> SubFS[_F]
+            pass
+
     def getinfo(self, path, namespaces=None):
         # type: (Text, Optional[Container[Text]]) -> Info
         _path = self.validatepath(path)
@@ -632,12 +640,12 @@ class FTPFS(FS):
             ]
         return dir_list
 
-    def makedir(self,               # type: F
+    def makedir(self,               # type: _F
                 path,               # type: Text
                 permissions=None,   # type: Optional[Permissions]
                 recreate=False      # type: bool
                 ):
-        # type: (...) -> SubFS[F]
+        # type: (...) -> SubFS[_F]
         _path = self.validatepath(path)
 
         with ftp_errors(self, path=path):

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -487,7 +487,7 @@ class FTPFS(FS):
 
     @property
     def supports_mlst(self):
-        # typing: () -> bool
+        # type: () -> bool
         """bool: whether the server supports MLST feature.
         """
         return 'MLST' in self.features

--- a/fs/info.py
+++ b/fs/info.py
@@ -312,8 +312,7 @@ class Info(object):
 
     @property
     def size(self):
-        # type: () -> Optional[int]
-        # FIXME(@althonos): should this be always int ?
+        # type: () -> int
         """`int`: the size of the resource, in bytes.
 
         Requires the ``"details"`` namespace.

--- a/fs/info.py
+++ b/fs/info.py
@@ -33,7 +33,7 @@ class Info(object):
 
     Arguments:
         raw_info (dict): A dict containing resource info.
-        to_datetime (callable, optional): A callable that converts an
+        to_datetime (callable): A callable that converts an
             epoch time to a datetime object. The default uses
             :func:`~fs.time.epoch_to_datetime`.
 

--- a/fs/info.py
+++ b/fs/info.py
@@ -187,7 +187,7 @@ class Info(object):
         # type: () -> bool
         """`bool`: `True` if the resource references a directory.
         """
-        return self.get('basic', 'is_dir') 
+        return self.get('basic', 'is_dir')
 
     @property
     def is_file(self):

--- a/fs/info.py
+++ b/fs/info.py
@@ -14,7 +14,7 @@ from .errors import MissingInfoNamespace
 from .permissions import Permissions
 from .time import epoch_to_datetime
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from datetime import datetime
     from typing import Callable, Mapping, Optional, Text
     RawInfo = Mapping[Text, Mapping[Text, object]]

--- a/fs/info.py
+++ b/fs/info.py
@@ -5,13 +5,19 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from copy import deepcopy
+from typing import Mapping, Text
 
 from .path import join
 from .enums import ResourceType
 from .errors import MissingInfoNamespace
 from .permissions import Permissions
 from .time import epoch_to_datetime
+
+
+_RawInfo = Mapping[Text, Mapping[Text, object]]
 
 
 class Info(object):

--- a/fs/info.py
+++ b/fs/info.py
@@ -56,7 +56,7 @@ class Info(object):
 
     def __eq__(self, other):
         # type: (object) -> bool
-        return self.raw == other.raw
+        return self.raw == getattr(other, 'raw', None)
 
     @typing.overload
     def _make_datetime(self, t):

--- a/fs/info.py
+++ b/fs/info.py
@@ -180,21 +180,21 @@ class Info(object):
         # type: () -> Text
         """`str`: the resource name.
         """
-        return self.get('basic', 'name')        # type: ignore
+        return self.get('basic', 'name')
 
     @property
     def is_dir(self):
         # type: () -> bool
         """`bool`: `True` if the resource references a directory.
         """
-        return self.get('basic', 'is_dir')     # type: ignore
+        return self.get('basic', 'is_dir') 
 
     @property
     def is_file(self):
         # type: () -> bool
         """`bool`: `True` if the resource references a file.
         """
-        return not self.get('basic', 'is_dir')    # type: ignore
+        return not self.get('basic', 'is_dir')
 
     @property
     def is_link(self):

--- a/fs/info.py
+++ b/fs/info.py
@@ -6,9 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import typing
-
 from copy import deepcopy
-from typing import Mapping, Text
 
 from .path import join
 from .enums import ResourceType
@@ -16,8 +14,12 @@ from .errors import MissingInfoNamespace
 from .permissions import Permissions
 from .time import epoch_to_datetime
 
-
-_RawInfo = Mapping[Text, Mapping[Text, object]]
+if typing.TYPE_CHECKING:
+    from datetime import datetime
+    from typing import Callable, Mapping, Optional, Text
+    RawInfo = Mapping[Text, Mapping[Text, object]]
+    ToDatetime = Callable[[int], datetime]
+    T = typing.TypeVar("T")
 
 
 class Info(object):
@@ -37,9 +39,8 @@ class Info(object):
 
     """
 
-    def __init__(self,
-                 raw_info,
-                 to_datetime=epoch_to_datetime):
+    def __init__(self, raw_info, to_datetime=epoch_to_datetime):
+        # type: (RawInfo, ToDatetime) -> None
         """Create a resource info object from a raw info dict.
         """
         self.raw = raw_info
@@ -47,21 +48,50 @@ class Info(object):
         self.namespaces = frozenset(self.raw.keys())
 
     def __repr__(self):
+        # type: () -> str
         if self.is_dir:
             return "<dir '{}'>".format(self.name)
         else:
             return "<file '{}'>".format(self.name)
 
     def __eq__(self, other):
+        # type: (object) -> bool
         return self.raw == other.raw
 
+    @typing.overload
     def _make_datetime(self, t):
+        # type: (None) -> None
+        pass
+
+    @typing.overload
+    def _make_datetime(self, t):
+        # type: (int) -> datetime
+        pass
+
+    def _make_datetime(self, t):
+        # type: (Optional[int]) -> Optional[datetime]
         if t is not None:
             return self._to_datetime(t)
         else:
             return None
 
+    @typing.overload
     def get(self, namespace, key, default=None):
+        # type: (Text, Text, Optional[T]) -> Optional[T]
+        pass
+
+    @typing.overload
+    def get(self, namespace, key):
+        # type: (Text, Text) -> Optional[T]
+        pass
+
+    @typing.overload
+    def get(self, namespace, key, default):
+        # type: (Text, Text, T) -> T
+        pass
+
+    def get(self, namespace, key, default=None):
+        # type: (Text, Text, Optional[T]) -> Optional[T]
         """Get a raw info value.
 
         Arguments:
@@ -77,11 +107,12 @@ class Info(object):
 
         """
         try:
-            return self.raw[namespace].get(key, default)
+            return self.raw[namespace].get(key, default)  # type: ignore
         except KeyError:
             return default
 
     def _require_namespace(self, namespace):
+        # type: (Text) -> None
         """Check if the given namespace is present in the info.
 
         Raises:
@@ -93,6 +124,7 @@ class Info(object):
             raise MissingInfoNamespace(namespace)
 
     def is_writeable(self, namespace, key):
+        # type: (Text, Text) -> bool
         """Check if a given key in a namespace is writable.
 
         Uses `~fs.base.FS.setinfo`.
@@ -109,6 +141,7 @@ class Info(object):
         return key in _writeable
 
     def has_namespace(self, namespace):
+        # type: (Text) -> bool
         """Check if the resource info contains a given namespace.
 
         Arguments:
@@ -121,6 +154,7 @@ class Info(object):
         return namespace in self.raw
 
     def copy(self, to_datetime=None):
+        # type: (Optional[ToDatetime]) -> Info
         """Create a copy of this resource info object.
         """
         return Info(
@@ -129,6 +163,7 @@ class Info(object):
         )
 
     def make_path(self, dir_path):
+        # type: (Text) -> Text
         """Make a path by joining ``dir_path`` with the resource name.
 
         Arguments:
@@ -142,31 +177,36 @@ class Info(object):
 
     @property
     def name(self):
+        # type: () -> Text
         """`str`: the resource name.
         """
-        return self.get('basic', 'name')
+        return self.get('basic', 'name')        # type: ignore
 
     @property
     def is_dir(self):
+        # type: () -> bool
         """`bool`: `True` if the resource references a directory.
         """
-        return self.get('basic', 'is_dir')
+        return self.get('basic', 'is_dir')     # type: ignore
 
     @property
     def is_file(self):
+        # type: () -> bool
         """`bool`: `True` if the resource references a file.
         """
-        return not self.get('basic', 'is_dir')
+        return not self.get('basic', 'is_dir')    # type: ignore
 
     @property
     def is_link(self):
+        # type: () -> bool
         """`bool`: `True` if the resource is a symlink.
         """
         self._require_namespace('link')
-        return self.get('link', 'target') is not None
+        return self.get('link', 'target', None) is not None
 
     @property
     def type(self):
+        # type: () -> ResourceType
         """`~fs.ResourceType`: the type of the resource.
 
         Requires the ``"details"`` namespace.
@@ -181,6 +221,7 @@ class Info(object):
 
     @property
     def accessed(self):
+        # type: () -> Optional[datetime]
         """`~datetime.datetime`: the resource last access time, or `None`.
 
         Requires the ``"details"`` namespace.
@@ -198,6 +239,7 @@ class Info(object):
 
     @property
     def modified(self):
+        # type: () -> Optional[datetime]
         """`~datetime.datetime`: the resource last modification time, or `None`.
 
         Requires the ``"details"`` namespace.
@@ -215,6 +257,7 @@ class Info(object):
 
     @property
     def created(self):
+        # type: () -> Optional[datetime]
         """`~datetime.datetime`: the resource creation time, or `None`.
 
         Requires the ``"details"`` namespace.
@@ -232,6 +275,7 @@ class Info(object):
 
     @property
     def metadata_changed(self):
+        # type: () -> Optional[datetime]
         """`~datetime.datetime`: the resource metadata change time, or `None`.
 
         Requires the ``"details"`` namespace.
@@ -249,6 +293,7 @@ class Info(object):
 
     @property
     def permissions(self):
+        # type: () -> Optional[Permissions]
         """`Permissions`: the permissions of the resource, or `None`.
 
         Requires the ``"access"`` namespace.
@@ -267,6 +312,8 @@ class Info(object):
 
     @property
     def size(self):
+        # type: () -> Optional[int]
+        # FIXME(@althonos): should this be always int ?
         """`int`: the size of the resource, in bytes.
 
         Requires the ``"details"`` namespace.
@@ -281,6 +328,7 @@ class Info(object):
 
     @property
     def user(self):
+        # type: () -> Optional[Text]
         """`str`: the owner of the resource, or `None`.
 
         Requires the ``"access"`` namespace.
@@ -295,6 +343,7 @@ class Info(object):
 
     @property
     def uid(self):
+        # type: () -> Optional[int]
         """`int`: the user id of the resource, or `None`.
 
         Requires the ``"access"`` namespace.
@@ -309,6 +358,7 @@ class Info(object):
 
     @property
     def group(self):
+        # type: () -> Optional[Text]
         """`str`: the group of the resource owner, or `None`.
 
         Requires the ``"access"`` namespace.
@@ -323,6 +373,7 @@ class Info(object):
 
     @property
     def gid(self):
+        # type: () -> Optional[int]
         """`int`: the group id of the resource, or `None`.
 
         Requires the ``"access"`` namespace.
@@ -337,6 +388,7 @@ class Info(object):
 
     @property
     def target(self):  # noqa: D402
+        # type: () -> Optional[Text]
         """`str`: the link target (if resource is a symlink), or `None`.
 
         Requires the ``"link"`` namespace.

--- a/fs/iotools.py
+++ b/fs/iotools.py
@@ -10,7 +10,7 @@ from io import SEEK_SET, SEEK_CUR
 
 from .mode import Mode
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from io import RawIOBase, IOBase
     from typing import (
         Any, BinaryIO, Iterable, Iterator, IO,

--- a/fs/iotools.py
+++ b/fs/iotools.py
@@ -5,22 +5,31 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import io
+import typing
 from io import SEEK_SET, SEEK_CUR
 
 from .mode import Mode
 
+if typing.TYPE_CHECKING:
+    from io import RawIOBase, IOBase
+    from typing import (
+        Any, BinaryIO, Iterable, Iterator, IO,
+        List, Optional, Text, Union)
 
-class RawWrapper(io.IOBase):
+
+class RawWrapper(io.RawIOBase):
     """Convert a Python 2 style file-like object in to a IO object.
     """
 
     def __init__(self, f, mode=None, name=None):
+        # type: (IO[bytes], Optional[Text], Optional[Text]) -> None
         self._f = f
         self.mode = mode or getattr(f, 'mode', None)
         self.name = name
         super(RawWrapper, self).__init__()
 
     def close(self):
+        # type: () -> None
         if not self.closed:
             # Close self first since it will
             # flush itself, so we can't close
@@ -29,18 +38,23 @@ class RawWrapper(io.IOBase):
             self._f.close()
 
     def fileno(self):
+        # type: () -> int
         return self._f.fileno()
 
     def flush(self):
+        # type: () -> None
         return self._f.flush()
 
     def isatty(self):
+        # type: () -> bool
         return self._f.isatty()
 
     def seek(self, offset, whence=SEEK_SET):
+        # type: (int, int) -> int
         return self._f.seek(offset, whence)
 
     def readable(self):
+        # type: () -> bool
         return getattr(
             self._f,
             'readable',
@@ -48,6 +62,7 @@ class RawWrapper(io.IOBase):
         )()
 
     def writable(self):
+        # type: () -> bool
         return getattr(
             self._f,
             'writable',
@@ -55,6 +70,7 @@ class RawWrapper(io.IOBase):
         )()
 
     def seekable(self):
+        # type: () -> bool
         try:
             return self._f.seekable()
         except AttributeError:
@@ -66,29 +82,37 @@ class RawWrapper(io.IOBase):
                 return True
 
     def tell(self):
+        # type: () -> int
         return self._f.tell()
 
     def truncate(self, size=None):
+        # type: (Optional[int]) -> int
         return self._f.truncate(size)
 
     def write(self, data):
+        # type: (bytes) -> int
         count = self._f.write(data)
         return len(data) if count is None else count
 
+    @typing.no_type_check
     def read(self, n=-1):
+        # type: (int) -> bytes
         if n == -1:
             return self.readall()
         return self._f.read(n)
 
     def read1(self, n=-1):
-        if hasattr(self._f, 'read1'):
-            return self._f.read1(n)
-        return self.read(n)
+        # type: (int) -> bytes
+        return getattr(self._f, 'read1', self.read)(n)
 
+    @typing.no_type_check
     def readall(self):
+        # type: () -> bytes
         return self._f.read()
 
+    @typing.no_type_check
     def readinto(self, b):
+        # type: (bytearray) -> int
         try:
             return self._f.readinto(b)
         except AttributeError:
@@ -97,7 +121,9 @@ class RawWrapper(io.IOBase):
             b[:len(data)] = data
             return bytes_read
 
+    @typing.no_type_check
     def readinto1(self, b):
+        # type: (bytearray) -> int
         try:
             return self._f.readinto1(b)
         except AttributeError:
@@ -107,27 +133,34 @@ class RawWrapper(io.IOBase):
             return bytes_read
 
     def readline(self, limit=-1):
+        # type: (int) -> bytes
         return self._f.readline(limit)
 
     def readlines(self, hint=-1):
+        # type: (int) -> List[bytes]
         return self._f.readlines(hint)
 
     def writelines(self, sequence):
+        # type: (Iterable[Union[bytes, bytearray]]) -> None
         return self._f.writelines(sequence)
 
     def __iter__(self):
+        # type: () -> Iterator[bytes]
         return iter(self._f)
 
 
-def make_stream(name,
-                bin_file,
-                mode='r',
-                buffering=-1,
-                encoding=None,
-                errors=None,
-                newline='',
-                line_buffering=False,
-                **kwargs):
+@typing.no_type_check
+def make_stream(name,                       # type: Text
+                bin_file,                   # type: RawIOBase
+                mode='r',                   # type: Text
+                buffering=-1,               # type: int
+                encoding=None,              # type: Optional[Text]
+                errors=None,                # type: Optional[Text]
+                newline='',                 # type: Optional[Text]
+                line_buffering=False,       # type: bool
+                **kwargs                    # type: Any
+                ):
+    # type: (...) -> IO
     """Take a Python 2.x binary file and return an IO Stream.
     """
     reading = 'r' in mode
@@ -140,21 +173,21 @@ def make_stream(name,
 
     encoding = None if binary else (encoding or 'utf-8')
 
-    io_object = RawWrapper(bin_file, mode=mode, name=name)
+    io_object = RawWrapper(bin_file, mode=mode, name=name)  # type: io.IOBase
     if buffering >= 0:
         if reading and writing:
             io_object = io.BufferedRandom(
-                io_object,
+                typing.cast(io.RawIOBase, io_object),
                 buffering or io.DEFAULT_BUFFER_SIZE
             )
         elif reading:
             io_object = io.BufferedReader(
-                io_object,
+                typing.cast(io.RawIOBase, io_object),
                 buffering or io.DEFAULT_BUFFER_SIZE
             )
         elif writing or appending:
             io_object = io.BufferedWriter(
-                io_object,
+                typing.cast(io.RawIOBase, io_object),
                 buffering or io.DEFAULT_BUFFER_SIZE
             )
 
@@ -171,6 +204,7 @@ def make_stream(name,
 
 
 def line_iterator(readable_file, size=None):
+    # type: (IO[bytes], Optional[int]) -> Iterator[bytes]
     """Iterate over the lines of a file.
 
     Implementation reads each char individually, which is not very

--- a/fs/lrucache.py
+++ b/fs/lrucache.py
@@ -12,7 +12,7 @@ _K = typing.TypeVar('_K')
 _V = typing.TypeVar('_V')
 
 
-class LRUCache(OrderedDict[_K, _V], typing.Generic[_K, _V]):
+class LRUCache(OrderedDict, typing.Generic[_K, _V]):
     """A dictionary-like container that stores a given maximum items.
 
     If an additional item is added when the LRUCache is full, the least
@@ -38,7 +38,7 @@ class LRUCache(OrderedDict[_K, _V], typing.Generic[_K, _V]):
         # type: (_K) -> _V
         """Get the item, but also makes it most recent.
         """
-        _super = typing.cast(OrderedDict[_K, _V], super(LRUCache, self))
+        _super = typing.cast(OrderedDict, super(LRUCache, self))
         value = _super.__getitem__(key)
         _super.__delitem__(key)
         _super.__setitem__(key, value)

--- a/fs/lrucache.py
+++ b/fs/lrucache.py
@@ -38,7 +38,7 @@ class LRUCache(OrderedDict[_K, _V], typing.Generic[_K, _V]):
         # type: (_K) -> _V
         """Get the item, but also makes it most recent.
         """
-        _super = typing.cast(OrderedDict, super(LRUCache, self))
+        _super = typing.cast(OrderedDict[_K, _V], super(LRUCache, self))
         value = _super.__getitem__(key)
         _super.__delitem__(key)
         _super.__setitem__(key, value)

--- a/fs/lrucache.py
+++ b/fs/lrucache.py
@@ -7,6 +7,10 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 
 
+if False:  # typing imports
+    from typing import *
+
+
 class LRUCache(OrderedDict):
     """A dictionary-like container that stores a given maximum items.
 
@@ -16,10 +20,12 @@ class LRUCache(OrderedDict):
     """
 
     def __init__(self, cache_size):
+        # type: (int) -> None
         self.cache_size = cache_size
         super(LRUCache, self).__init__()
 
     def __setitem__(self, key, value):
+        # type: (object, object) -> None
         """Store a new views, potentially discarding an old value.
         """
         if key not in self:
@@ -28,10 +34,11 @@ class LRUCache(OrderedDict):
         OrderedDict.__setitem__(self, key, value)
 
     def __getitem__(self, key):
+        # type: (object) -> object
         """Get the item, but also makes it most recent.
         """
         _super = super(LRUCache, self)
-        value = _super.__getitem__(key)
-        _super.__delitem__(key)
-        _super.__setitem__(key, value)
+        value = _super.__getitem__(key)     # type: ignore
+        _super.__delitem__(key)             # type: ignore
+        _super.__setitem__(key, value)      # type: ignore
         return value

--- a/fs/lrucache.py
+++ b/fs/lrucache.py
@@ -4,11 +4,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import typing
 from collections import OrderedDict
-
-
-if False:  # typing imports
-    from typing import *
 
 
 class LRUCache(OrderedDict):
@@ -37,8 +34,8 @@ class LRUCache(OrderedDict):
         # type: (object) -> object
         """Get the item, but also makes it most recent.
         """
-        _super = super(LRUCache, self)
-        value = _super.__getitem__(key)     # type: ignore
-        _super.__delitem__(key)             # type: ignore
-        _super.__setitem__(key, value)      # type: ignore
+        _super = typing.cast(OrderedDict, super(LRUCache, self))
+        value = _super.__getitem__(key)
+        _super.__delitem__(key)
+        _super.__setitem__(key, value)
         return value

--- a/fs/lrucache.py
+++ b/fs/lrucache.py
@@ -8,7 +8,11 @@ import typing
 from collections import OrderedDict
 
 
-class LRUCache(OrderedDict):
+_K = typing.TypeVar('_K')
+_V = typing.TypeVar('_V')
+
+
+class LRUCache(OrderedDict[_K, _V], typing.Generic[_K, _V]):
     """A dictionary-like container that stores a given maximum items.
 
     If an additional item is added when the LRUCache is full, the least
@@ -22,7 +26,7 @@ class LRUCache(OrderedDict):
         super(LRUCache, self).__init__()
 
     def __setitem__(self, key, value):
-        # type: (object, object) -> None
+        # type: (_K, _V) -> None
         """Store a new views, potentially discarding an old value.
         """
         if key not in self:
@@ -31,7 +35,7 @@ class LRUCache(OrderedDict):
         OrderedDict.__setitem__(self, key, value)
 
     def __getitem__(self, key):
-        # type: (object) -> object
+        # type: (_K) -> _V
         """Get the item, but also makes it most recent.
         """
         _super = typing.cast(OrderedDict, super(LRUCache, self))

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -22,7 +22,7 @@ from .path import iteratepath
 from .path import normpath
 from .path import split
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import (
         Any, BinaryIO, Collection, Dict, Iterator, List,
         Optional, SupportsInt, Union, Text)
@@ -370,7 +370,7 @@ class MemoryFS(FS):
                 raise errors.DirectoryExpected(path)
             return dir_entry.list()
 
-    if typing.TYPE_CHECKING:
+    if False:  # typing.TYPE_CHECKING
         def opendir(self, path, factory=None):
             # type: (_M, Text, Optional[_OpendirFactory]) -> SubFS[_M]
             pass

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -313,8 +313,9 @@ class MemoryFS(FS):
         # type: () -> str
         return "<memfs>"
 
-    def _make_dir_entry(self, *args, **kwargs):
-        return _DirEntry(*args, **kwargs)
+    def _make_dir_entry(self, resource_type, name):
+        # type: (ResourceType, Text) -> _DirEntry
+        return _DirEntry(resource_type, name)
 
     def _get_dir_entry(self, dir_path):
         # type: (Text) -> Optional[_DirEntry]

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -28,6 +28,8 @@ if typing.TYPE_CHECKING:
         Optional, SupportsInt, Union, Text)
     from .info import RawInfo
     from .permissions import Permissions
+    from .subfs import SubFS
+    M = typing.TypeVar('M', bound='MemoryFS')
 
 
 @six.python_2_unicode_compatible
@@ -365,8 +367,12 @@ class MemoryFS(FS):
                 raise errors.DirectoryExpected(path)
             return dir_entry.list()
 
-    def makedir(self, path, permissions=None, recreate=False):
-        # type: (Text, Optional[Permissions], bool) -> FS
+    def makedir(self,               # type: M
+                path,               # type: Text
+                permissions=None,   # type: Optional[Permissions]
+                recreate=False      # type: bool
+                ):
+        # type: (...) -> SubFS[M]
         _path = self.validatepath(path)
         with self._lock:
             if _path == '/':

--- a/fs/mirror.py
+++ b/fs/mirror.py
@@ -26,7 +26,7 @@ from .errors import ResourceNotFound
 from .walk import Walker
 from .opener import manage_fs
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Optional, Text, Union
     from .base import FS
     from .info import Info

--- a/fs/mirror.py
+++ b/fs/mirror.py
@@ -65,7 +65,7 @@ def mirror(src_fs,              # type: Union[FS, Text]
         src_fs (FS or str): Source filesystem (URL or instance).
         dst_fs (FS or str): Destination filesystem (URL or instance).
         walker (~fs.walk.Walker, optional): An optional walker instance.
-        copy_if_newer (bool, optional): Only copy newer files (the default).
+        copy_if_newer (bool): Only copy newer files (the default).
 
     """
     with manage_fs(src_fs, writeable=False) as _src_fs:

--- a/fs/mirror.py
+++ b/fs/mirror.py
@@ -19,14 +19,21 @@ the expense of potentially copying extra files.
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
 
 from .copy import copy_file_internal
 from .errors import ResourceNotFound
 from .walk import Walker
 from .opener import manage_fs
 
+if typing.TYPE_CHECKING:
+    from typing import Optional, Text, Union
+    from .base import FS
+    from .info import Info
+
 
 def _compare(info1, info2):
+    # type: (Info, Info) -> bool
     """Compare two `Info` objects to see if they should be copied.
 
     Returns:
@@ -42,7 +49,12 @@ def _compare(info1, info2):
     return date1 is None or date2 is None or date1 > date2
 
 
-def mirror(src_fs, dst_fs, walker=None, copy_if_newer=True):
+def mirror(src_fs,              # type: Union[FS, Text]
+           dst_fs,              # type: Union[FS, Text]
+           walker=None,         # type: Optional[Walker]
+           copy_if_newer=True   # type: bool
+           ):
+    # type: (...) -> None
     """Mirror files / directories from one filesystem to another.
 
     Mirroring a filesystem will create an exact copy of ``src_fs`` on
@@ -68,6 +80,7 @@ def mirror(src_fs, dst_fs, walker=None, copy_if_newer=True):
 
 
 def _mirror(src_fs, dst_fs, walker=None, copy_if_newer=True):
+    # type: (FS, FS, Optional[Walker], bool) -> None
     walker = walker or Walker()
     walk = walker.walk(src_fs, namespaces=['details'])
     for path, dirs, files in walk:

--- a/fs/mode.py
+++ b/fs/mode.py
@@ -12,7 +12,7 @@ import typing
 
 import six
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Container, FrozenSet, Set, Text, Union
 
 

--- a/fs/mode.py
+++ b/fs/mode.py
@@ -91,7 +91,7 @@ class Mode(typing.Container[typing.Text]):
         return _mode if 'b' in _mode else _mode + 'b'
 
     def validate(self, _valid_chars=frozenset('rwxtab+')):
-        # type(Set[Text]) -> None
+        # type: (Union[Set[Text], FrozenSet[Text]]) -> None
         """Validate the mode string.
 
         Raises:
@@ -184,6 +184,7 @@ class Mode(typing.Container[typing.Text]):
 
     @property
     def text(self):
+        # type: () -> bool
         """`bool`: `True` if a mode specifies text.
         """
         return 't' in self or 'b' not in self

--- a/fs/mode.py
+++ b/fs/mode.py
@@ -8,13 +8,21 @@ Mode strings are used in in `~fs.base.FS.open` and
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+from typing import Container, FrozenSet, Set, Text, Union
+
 import six
-from typing import Container, Set, Text
+
+
+__all__ = ["Mode",
+           "check_readable",
+           "check_writable",
+           "validate_openbin_mode"]
 
 
 # https://docs.python.org/3/library/functions.html#open
 @six.python_2_unicode_compatible
-class Mode(Container[Text]):
+class Mode(typing.Container[Text]):
     """An abstraction for I/O modes.
 
     A mode object provides properties that can be used to interrogate the
@@ -206,7 +214,7 @@ def check_writable(mode):
 
 
 def validate_open_mode(mode):
-    # type: (Text) -> bool
+    # type: (Text) -> None
     """Check ``mode`` parameter of `~fs.base.FS.open` is valid.
 
     Arguments:
@@ -220,7 +228,7 @@ def validate_open_mode(mode):
 
 
 def validate_openbin_mode(mode, _valid_chars=frozenset('rwxab+')):
-    # type: (Text) -> bool
+    # type: (Text, Union[Set[Text], FrozenSet[Text]]) -> None
     """Check ``mode`` parameter of `~fs.base.FS.openbin` is valid.
 
     Arguments:

--- a/fs/mode.py
+++ b/fs/mode.py
@@ -9,9 +9,11 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import typing
-from typing import Container, FrozenSet, Set, Text, Union
 
 import six
+
+if typing.TYPE_CHECKING:
+    from typing import Container, FrozenSet, Set, Text, Union
 
 
 __all__ = ["Mode",
@@ -22,7 +24,7 @@ __all__ = ["Mode",
 
 # https://docs.python.org/3/library/functions.html#open
 @six.python_2_unicode_compatible
-class Mode(typing.Container[Text]):
+class Mode(typing.Container[typing.Text]):
     """An abstraction for I/O modes.
 
     A mode object provides properties that can be used to interrogate the
@@ -54,9 +56,11 @@ class Mode(typing.Container[Text]):
         self.validate()
 
     def __repr__(self):
+        # type: () -> Text
         return "Mode({!r})".format(self._mode)
 
     def __str__(self):
+        # type: () -> Text
         return self._mode
 
     def __contains__(self, character):

--- a/fs/mode.py
+++ b/fs/mode.py
@@ -9,11 +9,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import six
+from typing import Container, Set, Text
 
 
 # https://docs.python.org/3/library/functions.html#open
 @six.python_2_unicode_compatible
-class Mode(object):
+class Mode(Container[Text]):
     """An abstraction for I/O modes.
 
     A mode object provides properties that can be used to interrogate the
@@ -40,6 +41,7 @@ class Mode(object):
     """
 
     def __init__(self, mode):
+        # type: (Text) -> None
         self._mode = mode
         self.validate()
 
@@ -50,11 +52,13 @@ class Mode(object):
         return self._mode
 
     def __contains__(self, character):
+        # type: (object) -> bool
         """Check if a mode contains a given character.
         """
         return character in self._mode
 
     def to_platform(self):
+        # type: () -> Text
         """Get a mode string for the current platform.
 
         Currently, this just removes the 'x' on PY2 because PY2 doesn't
@@ -64,6 +68,7 @@ class Mode(object):
         return self._mode.replace('x', 'w') if six.PY2 else self._mode
 
     def to_platform_bin(self):
+        # type: () -> Text
         """Get a *binary* mode string for the current platform.
 
         Currently, this just removes the 'x' on PY2 because PY2 doesn't
@@ -74,6 +79,7 @@ class Mode(object):
         return _mode if 'b' in _mode else _mode + 'b'
 
     def validate(self, _valid_chars=frozenset('rwxtab+')):
+        # type(Set[Text]) -> None
         """Validate the mode string.
 
         Raises:
@@ -97,6 +103,7 @@ class Mode(object):
             )
 
     def validate_bin(self):
+        # type: () -> None
         """Validate a mode for opening a binary file.
 
         Raises:
@@ -109,48 +116,56 @@ class Mode(object):
 
     @property
     def create(self):
+        # type: () -> bool
         """`bool`: `True` if the mode would create a file.
         """
         return 'a' in self or 'w' in self or 'x' in self
 
     @property
     def reading(self):
+        # type: () -> bool
         """`bool`: `True` if the mode permits reading.
         """
         return 'r' in self or '+' in self
 
     @property
     def writing(self):
+        # type: () -> bool
         """`bool`: `True` if the mode permits writing.
         """
         return 'w' in self or 'a' in self or '+' in self or 'x' in self
 
     @property
     def appending(self):
+        # type: () -> bool
         """`bool`: `True` if the mode permits appending.
         """
         return 'a' in self
 
     @property
     def updating(self):
+        # type: () -> bool
         """`bool`: `True` if the mode permits both reading and writing.
         """
         return '+' in self
 
     @property
     def truncate(self):
+        # type: () -> bool
         """`bool`: `True` if the mode would truncate an existing file.
         """
         return 'w' in self or 'x' in self
 
     @property
     def exclusive(self):
+        # type: () -> bool
         """`bool`: `True` if the mode require exclusive creation.
         """
         return 'x' in self
 
     @property
     def binary(self):
+        # type: () -> bool
         """`bool`: `True` if a mode specifies binary.
         """
         return 'b' in self
@@ -163,6 +178,7 @@ class Mode(object):
 
 
 def check_readable(mode):
+    # type: (Text) -> bool
     """Check a mode string allows reading.
 
     Arguments:
@@ -176,6 +192,7 @@ def check_readable(mode):
 
 
 def check_writable(mode):
+    # type: (Text) -> bool
     """Check a mode string allows writing.
 
     Arguments:
@@ -189,6 +206,7 @@ def check_writable(mode):
 
 
 def validate_open_mode(mode):
+    # type: (Text) -> bool
     """Check ``mode`` parameter of `~fs.base.FS.open` is valid.
 
     Arguments:
@@ -202,6 +220,7 @@ def validate_open_mode(mode):
 
 
 def validate_openbin_mode(mode, _valid_chars=frozenset('rwxab+')):
+    # type: (Text) -> bool
     """Check ``mode`` parameter of `~fs.base.FS.openbin` is valid.
 
     Arguments:

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -119,7 +119,7 @@ class MountFS(FS):
         self.default_fs.makedirs(_path, recreate=True)
 
     def close(self):
-        # type() -> None
+        # type: () -> None
         # Explicitly closes children if requested
         if self.auto_close:
             for _path, fs in self.mounts:

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -22,10 +22,11 @@ if typing.TYPE_CHECKING:
     from typing import (
         Any, BinaryIO, Collection, Iterator, IO, List,
         MutableSequence, Optional, Text, Tuple, Union)
+    from .enums import ResourceType
     from .info import Info, RawInfo
     from .permissions import Permissions
-    from .enums import ResourceType
-
+    from .subfs import SubFS
+    M = typing.TypeVar('M', bound='MountFS')
 
 class MountError(Exception):
     """Thrown when mounts conflict.
@@ -148,8 +149,12 @@ class MountFS(FS):
         fs, _path = self._delegate(path)
         return fs.listdir(_path)
 
+    # NOTE(@althonos): here, the returned FS does not always wrap
+    #     filesystems of the same type, so we cannot assume anything
+    #     about the type of the filesystem wrapped in the SubFS.
+    @typing.no_type_check
     def makedir(self, path, permissions=None, recreate=False):
-        # type: (Text, Optional[Permissions], bool) -> FS
+        # type: (M, Text, Optional[Permissions], bool) -> SubFS[FS]
         self.check()
         fs, _path = self._delegate(path)
         return fs.makedir(

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -37,7 +37,7 @@ class MountFS(FS):
     """A virtual filesystem that maps directories on to other file-systems.
 
     Arguments:
-        auto_close (bool, optional): If `True` (the default), the child
+        auto_close (bool): If `True` (the default), the child
             filesystems will be closed when `MountFS` is closed.
 
     """

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -18,7 +18,7 @@ from .path import normpath
 from .mode import validate_open_mode
 from .mode import validate_openbin_mode
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import (
         Any, BinaryIO, Collection, Iterator, IO, List,
         MutableSequence, Optional, Text, Tuple, Union)

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -207,7 +207,7 @@ class MountFS(FS):
         )
 
     def getsize(self, path):
-        # type: (Text) -> Optional[int]
+        # type: (Text) -> int
         self.check()
         fs, _path = self._delegate(path)
         return fs.getsize(_path)

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -5,6 +5,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from six import text_type
 
 from . import errors
@@ -15,6 +17,14 @@ from .path import forcedir
 from .path import normpath
 from .mode import validate_open_mode
 from .mode import validate_openbin_mode
+
+if typing.TYPE_CHECKING:
+    from typing import (
+        Any, BinaryIO, Collection, Iterator, IO, List,
+        MutableSequence, Optional, Text, Tuple, Union)
+    from .info import Info, RawInfo
+    from .permissions import Permissions
+    from .enums import ResourceType
 
 
 class MountError(Exception):
@@ -40,18 +50,22 @@ class MountFS(FS):
     }
 
     def __init__(self, auto_close=True):
+        # type: (bool) -> None
         super(MountFS, self).__init__()
         self.auto_close = auto_close
-        self.default_fs = MemoryFS()
-        self.mounts = []
+        self.default_fs = MemoryFS()  # type: FS
+        self.mounts = []              # type: MutableSequence[Tuple[Text, FS]]
 
     def __repr__(self):
+        # type: () -> str
         return "MountFS(auto_close={!r})".format(self.auto_close)
 
     def __str__(self):
+        # type: () -> str
         return "<mountfs>"
 
     def _delegate(self, path):
+        # type: (Text) -> Tuple[FS, Text]
         """Get the delegate FS for a given path.
 
         Arguments:
@@ -73,6 +87,7 @@ class MountFS(FS):
         return self.default_fs, path
 
     def mount(self, path, fs):
+        # type: (Text, Union[FS, Text]) -> None
         """Mounts a host FS object on a given path.
 
         Arguments:
@@ -103,6 +118,7 @@ class MountFS(FS):
         self.default_fs.makedirs(_path, recreate=True)
 
     def close(self):
+        # type() -> None
         # Explicitly closes children if requested
         if self.auto_close:
             for _path, fs in self.mounts:
@@ -112,6 +128,7 @@ class MountFS(FS):
         super(MountFS, self).close()
 
     def desc(self, path):
+        # type: (Text) -> Text
         if not self.exists(path):
             raise errors.ResourceNotFound(path)
         fs, delegate_path = self._delegate(path)
@@ -120,33 +137,39 @@ class MountFS(FS):
         return "{path} on {fs}".format(fs=fs, path=delegate_path)
 
     def getinfo(self, path, namespaces=None):
+        # type: (Text, Optional[Collection[Text]]) -> Info
         self.check()
         fs, _path = self._delegate(path)
         return fs.getinfo(_path, namespaces=namespaces)
 
     def listdir(self, path):
+        # type: (Text) -> List[Text]
         self.check()
         fs, _path = self._delegate(path)
         return fs.listdir(_path)
 
     def makedir(self, path, permissions=None, recreate=False):
+        # type: (Text, Optional[Permissions], bool) -> FS
         self.check()
         fs, _path = self._delegate(path)
         return fs.makedir(
             _path, permissions=permissions, recreate=recreate)
 
     def openbin(self, path, mode='r', buffering=-1, **kwargs):
+        # type: (Text, Text, int, **Any) -> BinaryIO
         validate_openbin_mode(mode)
         self.check()
         fs, _path = self._delegate(path)
         return fs.openbin(_path, mode=mode, buffering=-1, **kwargs)
 
     def remove(self, path):
+        # type: (Text) -> None
         self.check()
         fs, _path = self._delegate(path)
         return fs.remove(_path)
 
     def removedir(self, path):
+        # type: (Text) -> None
         self.check()
         path = normpath(path)
         if path in ('', '/'):
@@ -155,15 +178,23 @@ class MountFS(FS):
         return fs.removedir(_path)
 
     def getbytes(self, path):
+        # type: (Text) -> bytes
         self.check()
         fs, _path = self._delegate(path)
         return fs.getbytes(_path)
 
     def getfile(self, path, file, chunk_size=None, **options):
+        # type: (Text, BinaryIO, Optional[int], **Any) -> None
         fs, _path = self._delegate(path)
         return fs.getfile(_path, file, chunk_size=chunk_size, **options)
 
-    def gettext(self, path, encoding=None, errors=None, newline=None):
+    def gettext(self,
+                path,               # type: Text
+                encoding=None,      # type: Optional[Text]
+                errors=None,        # type: Optional[Text]
+                newline=''          # type: Text
+                ):
+        # type: (...) -> Text
         self.check()
         fs, _path = self._delegate(path)
         return fs.gettext(
@@ -174,51 +205,65 @@ class MountFS(FS):
         )
 
     def getsize(self, path):
+        # type: (Text) -> int
         self.check()
         fs, _path = self._delegate(path)
         return fs.getsize(_path)
 
     def getsyspath(self, path):
+        # type: (Text) -> Text
         self.check()
         fs, _path = self._delegate(path)
         return fs.getsyspath(_path)
 
     def gettype(self, path):
+        # type: (Text) -> ResourceType
         self.check()
         fs, _path = self._delegate(path)
         return fs.gettype(_path)
 
     def geturl(self, path, purpose='download'):
+        # type: (Text, Text) -> Text
         self.check()
         fs, _path = self._delegate(path)
         return fs.geturl(_path, purpose=purpose)
 
     def hasurl(self, path, purpose='download'):
+        # type: (Text, Text) -> bool
         self.check()
         fs, _path = self._delegate(path)
         return fs.hasurl(_path, purpose=purpose)
 
     def isdir(self, path):
+        # type: (Text) -> bool
         self.check()
         fs, _path = self._delegate(path)
         return fs.isdir(_path)
 
     def isfile(self, path):
+        # type: (Text) -> bool
         self.check()
         fs, _path = self._delegate(path)
         return fs.isfile(_path)
 
-    def scandir(self, path, namespaces=None, page=None):
+    def scandir(self,
+                path,               # type: Text
+                namespaces=None,    # type: Optional[Collection[Text]]
+                page=None           # type: Optional[Tuple[int, int]]
+                ):
+        # type: (...) -> Iterator[Info]
         self.check()
         fs, _path = self._delegate(path)
         return fs.scandir(_path, namespaces=namespaces, page=page)
 
     def setinfo(self, path, info):
+        # type: (Text, RawInfo) -> None
         self.check()
         fs, _path = self._delegate(path)
         return fs.setinfo(_path, info)
 
     def validatepath(self, path):
+        # type: (Text) -> Text
         self.check()
         fs, _path = self._delegate(path)
         fs.validatepath(_path)
@@ -226,13 +271,15 @@ class MountFS(FS):
         return path
 
     def open(self,
-             path,
-             mode='r',
-             buffering=-1,
-             encoding=None,
-             errors=None,
-             newline='',
-             **options):
+             path,              # type: Text
+             mode='r',          # type: Text
+             buffering=-1,      # type: int
+             encoding=None,     # type: Optional[Text]
+             errors=None,       # type: Optional[Text]
+             newline='',        # type: Text
+             **options          # type: Any
+             ):
+        # type: (...) -> IO
         validate_open_mode(mode)
         self.check()
         fs, _path = self._delegate(path)
@@ -247,21 +294,25 @@ class MountFS(FS):
         )
 
     def setbinfile(self, path, file):
+        # type: (Text, BinaryIO) -> None
         self.check()
         fs, _path = self._delegate(path)
         return fs.setbinfile(_path, file)
 
     def setbytes(self, path, contents):
+        # type: (Text, bytes) -> None
         self.check()
         fs, _path = self._delegate(path)
         return fs.setbytes(_path, contents)
 
     def settext(self,
-                path,
-                contents,
-                encoding='utf-8',
-                errors=None,
-                newline=''):
+                path,               # type: Text
+                contents,           # type: Text
+                encoding='utf-8',   # type: Text
+                errors=None,        # type: Optional[Text]
+                newline=''          # type: Text
+                ):
+        # type: (...) -> None
         fs, _path = self._delegate(path)
         return fs.settext(
             _path,

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -28,6 +28,7 @@ if typing.TYPE_CHECKING:
     from .subfs import SubFS
     M = typing.TypeVar('M', bound='MountFS')
 
+
 class MountError(Exception):
     """Thrown when mounts conflict.
     """
@@ -149,12 +150,8 @@ class MountFS(FS):
         fs, _path = self._delegate(path)
         return fs.listdir(_path)
 
-    # NOTE(@althonos): here, the returned FS does not always wrap
-    #     filesystems of the same type, so we cannot assume anything
-    #     about the type of the filesystem wrapped in the SubFS.
-    @typing.no_type_check
     def makedir(self, path, permissions=None, recreate=False):
-        # type: (M, Text, Optional[Permissions], bool) -> SubFS[FS]
+        # type: (Text, Optional[Permissions], bool) -> SubFS[FS]
         self.check()
         fs, _path = self._delegate(path)
         return fs.makedir(
@@ -210,7 +207,7 @@ class MountFS(FS):
         )
 
     def getsize(self, path):
-        # type: (Text) -> int
+        # type: (Text) -> Optional[int]
         self.check()
         fs, _path = self._delegate(path)
         return fs.getsize(_path)

--- a/fs/move.py
+++ b/fs/move.py
@@ -10,7 +10,7 @@ from .copy import copy_dir
 from .copy import copy_file
 from .opener import manage_fs
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from .base import FS
     from typing import Text, Union
 

--- a/fs/move.py
+++ b/fs/move.py
@@ -4,12 +4,19 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from .copy import copy_dir
 from .copy import copy_file
 from .opener import manage_fs
 
+if typing.TYPE_CHECKING:
+    from .base import FS
+    from typing import Text, Union
+
 
 def move_fs(src_fs, dst_fs):
+    # type: (Union[Text, FS], Union[Text, FS]) -> None
     """Move the contents of a filesystem to another filesystem.
 
     Arguments:
@@ -20,7 +27,12 @@ def move_fs(src_fs, dst_fs):
     move_dir(src_fs, '/', dst_fs, '/')
 
 
-def move_file(src_fs, src_path, dst_fs, dst_path):
+def move_file(src_fs,       # type: Union[Text, FS]
+              src_path,     # type: Text
+              dst_fs,       # type: Union[Text, FS]
+              dst_path      # type: Text
+              ):
+    # type: (...) -> None
     """Move a file from one filesystem to another.
 
     Arguments:
@@ -30,19 +42,24 @@ def move_file(src_fs, src_path, dst_fs, dst_path):
         dst_path (str): Path to a file on ``dst_fs``.
 
     """
-    with manage_fs(src_fs) as src_fs:
-        with manage_fs(dst_fs, create=True) as dst_fs:
-            if src_fs is dst_fs:
+    with manage_fs(src_fs) as _src_fs:
+        with manage_fs(dst_fs, create=True) as _dst_fs:
+            if _src_fs is _dst_fs:
                 # Same filesystem, may be optimized
-                src_fs.move(src_path, dst_path, overwrite=True)
+                _src_fs.move(src_path, dst_path, overwrite=True)
             else:
                 # Standard copy and delete
-                with src_fs.lock(), dst_fs.lock():
-                    copy_file(src_fs, src_path, dst_fs, dst_path)
-                    src_fs.remove(src_path)
+                with _src_fs.lock(), _dst_fs.lock():
+                    copy_file(_src_fs, src_path, _dst_fs, dst_path)
+                    _src_fs.remove(src_path)
 
 
-def move_dir(src_fs, src_path, dst_fs, dst_path):
+def move_dir(src_fs,        # type: Union[Text, FS]
+             src_path,      # type: Text
+             dst_fs,        # type: Union[Text, FS]
+             dst_path       # type: Text
+             ):
+    # type: (...) -> None
     """Move a directory from one filesystem to another.
 
     Arguments:
@@ -52,14 +69,14 @@ def move_dir(src_fs, src_path, dst_fs, dst_path):
         dst_path (str): Path to a directory on ``dst_fs``
 
     """
-    with manage_fs(src_fs) as src_fs:
-        with manage_fs(dst_fs, create=True) as dst_fs:
-            with src_fs.lock(), dst_fs.lock():
-                dst_fs.makedir(dst_path, recreate=True)
+    with manage_fs(src_fs) as _src_fs:
+        with manage_fs(dst_fs, create=True) as _dst_fs:
+            with _src_fs.lock(), _dst_fs.lock():
+                _dst_fs.makedir(dst_path, recreate=True)
                 copy_dir(
                     src_fs,
                     src_path,
                     dst_fs,
                     dst_path
                 )
-                src_fs.removetree(src_path)
+                _src_fs.removetree(src_path)

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -83,12 +83,11 @@ class MultiFS(FS):
             name (str): A unique name to refer to the filesystem being
                 added.
             fs (FS or str): The filesystem (instance or URL) to add.
-            write (bool, optional): If this value is True,
-                then the ``fs`` will be used as the writeable FS (defaults
-                to False).
-            priority (int, optional): An integer that denotes the priority
-                of the filesystem being added. Filesystems will be searched
-                in descending priority order and then by the reverse order
+            write (bool): If this value is True, then the ``fs`` will
+                be used as the writeable FS (defaults to False).
+            priority (int): An integer that denotes the priority of the
+                filesystem being added. Filesystems will be searched in
+                descending priority order and then by the reverse order
                 they were added. So by default, the most recently added
                 filesystem will be looked at first.
 

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -17,7 +17,7 @@ from .mode import check_writable
 from .opener import open_fs
 from .path import abspath, normpath
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import (
         Any, BinaryIO, Collection, Iterator, IO,
         MutableMapping, List, MutableSet, Optional,

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -24,7 +24,8 @@ if typing.TYPE_CHECKING:
     from .enums import ResourceType
     from .info import Info, RawInfo
     from .permissions import Permissions
-
+    from .subfs import SubFS
+    M = typing.TypeVar('M', bound='MultiFS')
 
 
 _PrioritizedFS = namedtuple(
@@ -230,8 +231,13 @@ class MultiFS(FS):
         directory = list(OrderedDict.fromkeys(directory))
         return directory
 
-    def makedir(self, path, permissions=None, recreate=False):
-        # type: (Text, Optional[Permissions], bool) -> FS
+    @typing.no_type_check
+    def makedir(self,               # type: M
+                path,               # type: Text
+                permissions=None,   # type: Optional[Permissions]
+                recreate=False      # type: bool
+                ):
+        # type: (...) -> SubFS[FS]
         self.check()
         write_fs = self._writable_required(path)
         return write_fs.makedir(
@@ -373,8 +379,13 @@ class MultiFS(FS):
         path = abspath(normpath(path))
         return path
 
-    def makedirs(self, path, permissions=None, recreate=False):
-        # type: (Text, Optional[Permissions], bool) -> FS
+    @typing.no_type_check
+    def makedirs(self,              # type: M
+                 path,              # type: Text
+                 permissions=None,  # type: Optional[Permissions]
+                 recreate=False     # type: bool
+                 ):
+        # type: (...) -> SubFS[FS]
         self.check()
         write_fs = self._writable_required(path)
         return write_fs.makedirs(

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -19,8 +19,9 @@ from .path import abspath, normpath
 
 if typing.TYPE_CHECKING:
     from typing import (
-        Any, BinaryIO, Collection, Iterator, MutableMapping,
-        List, MutableSet, Optional, Text, Tuple)
+        Any, BinaryIO, Collection, Iterator, IO,
+        MutableMapping, List, MutableSet, Optional,
+        Text, Tuple)
     from .enums import ResourceType
     from .info import Info, RawInfo
     from .permissions import Permissions
@@ -402,6 +403,7 @@ class MultiFS(FS):
              newline='',       # type: Text
              **kwargs          # type: Any
              ):
+        # type: (...) -> IO
         self.check()
         if check_writable(mode):
             _fs = self._writable_required(path)
@@ -432,6 +434,7 @@ class MultiFS(FS):
                 errors=None,        # type: Optional[Text]
                 newline=''          # type: Text
                 ):
+        # type: (...) -> None
         write_fs = self._writable_required(path)
         return write_fs.settext(
             path,

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -231,7 +231,6 @@ class MultiFS(FS):
         directory = list(OrderedDict.fromkeys(directory))
         return directory
 
-    @typing.no_type_check
     def makedir(self,               # type: M
                 path,               # type: Text
                 permissions=None,   # type: Optional[Permissions]
@@ -316,7 +315,7 @@ class MultiFS(FS):
         )
 
     def getsize(self, path):
-        # type: (Text) -> int
+        # type: (Text) -> Optional[int]
         self.check()
         fs = self._delegate_required(path)
         return fs.getsize(path)
@@ -379,8 +378,7 @@ class MultiFS(FS):
         path = abspath(normpath(path))
         return path
 
-    @typing.no_type_check
-    def makedirs(self,              # type: M
+    def makedirs(self,
                  path,              # type: Text
                  permissions=None,  # type: Optional[Permissions]
                  recreate=False     # type: bool

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -315,7 +315,7 @@ class MultiFS(FS):
         )
 
     def getsize(self, path):
-        # type: (Text) -> Optional[int]
+        # type: (Text) -> int
         self.check()
         fs = self._delegate_required(path)
         return fs.getsize(path)

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -5,16 +5,26 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import typing
 from collections import namedtuple, OrderedDict
 from operator import itemgetter
 
 from six import text_type
 
+from . import errors
 from .base import FS
 from .mode import check_writable
-from . import errors
 from .opener import open_fs
 from .path import abspath, normpath
+
+if typing.TYPE_CHECKING:
+    from typing import (
+        Any, BinaryIO, Collection, Iterator, MutableMapping,
+        List, MutableSet, Optional, Text, Tuple)
+    from .enums import ResourceType
+    from .info import Info, RawInfo
+    from .permissions import Permissions
+
 
 
 _PrioritizedFS = namedtuple(
@@ -42,27 +52,30 @@ class MultiFS(FS):
     }
 
     def __init__(self, auto_close=True):
+        # type: (bool) -> None
         super(MultiFS, self).__init__()
 
         self._auto_close = auto_close
-        self.write_fs = None
-
-        self._write_fs_name = None
+        self.write_fs = None            # type: Optional[FS]
+        self._write_fs_name = None      # type: Optional[Text]
         self._sort_index = 0
-        self._filesystems = {}
-        self._fs_sequence = None
+        self._filesystems = {}     # type: MutableMapping[Text, _PrioritizedFS]
+        self._fs_sequence = None   # type: Optional[List[Tuple[Text, FS]]]
         self._closed = False
 
     def __repr__(self):
+        # type: () -> Text
         if self._auto_close:
             return "MultiFS()"
         else:
             return "MultiFS(auto_close=False)"
 
     def __str__(self):
+        # type: () -> Text
         return "<multifs>"
 
     def add_fs(self, name, fs, write=False, priority=0):
+        # type: (Text, FS, bool, int) -> None
         """Add a filesystem to the MultiFS.
 
         Arguments:
@@ -99,6 +112,7 @@ class MultiFS(FS):
             self._write_fs_name = name
 
     def get_fs(self, name):
+        # type: (Text) -> FS
         """Get a filesystem from its name.
 
         Arguments:
@@ -114,11 +128,13 @@ class MultiFS(FS):
         return self._filesystems[name].fs
 
     def _resort(self):
+        # type: () -> None
         """Force `iterate_fs` to re-sort on next reference.
         """
         self._fs_sequence = None
 
     def iterate_fs(self):
+        # type: () -> Iterator[Tuple[Text, FS]]
         """Get iterator that returns (name, fs) in priority order.
         """
         if self._fs_sequence is None:
@@ -134,6 +150,7 @@ class MultiFS(FS):
         return iter(self._fs_sequence)
 
     def _delegate(self, path):
+        # type: (Text) -> Optional[FS]
         """Get a filesystem which has a given path.
         """
         for _name, fs in self.iterate_fs():
@@ -142,6 +159,7 @@ class MultiFS(FS):
         return None
 
     def _delegate_required(self, path):
+        # type: (Text) -> FS
         """Check that there is a filesystem with the given ``path``.
         """
         fs = self._delegate(path)
@@ -150,12 +168,14 @@ class MultiFS(FS):
         return fs
 
     def _require_writable(self, path):
+        # type: (Text) -> None
         """Check that ``path`` is writeable.
         """
         if self.write_fs is None:
             raise errors.ResourceReadOnly(path)
 
     def which(self, path, mode="r"):
+        # type: (Text, Text) -> Tuple[Optional[Text], Optional[FS]]
         """Get a tuple of (name, fs) that the given path would map to.
 
         Arguments:
@@ -171,6 +191,7 @@ class MultiFS(FS):
         return None, None
 
     def close(self):
+        # type: () -> None
         self._closed = True
         if self._auto_close:
             try:
@@ -181,6 +202,7 @@ class MultiFS(FS):
                 self._resort()
 
     def getinfo(self, path, namespaces=None):
+        # type: (Text, Optional[Collection[Text]]) -> Info
         self.check()
         namespaces = namespaces or ()
         fs = self._delegate(path)
@@ -191,6 +213,7 @@ class MultiFS(FS):
         return info
 
     def listdir(self, path):
+        # type: (Text) -> List[Text]
         self.check()
         directory = []
         exists = False
@@ -207,12 +230,14 @@ class MultiFS(FS):
         return directory
 
     def makedir(self, path, permissions=None, recreate=False):
+        # type: (Text, Optional[Permissions], bool) -> FS
         self.check()
         self._require_writable(path)
         return self.write_fs.makedir(
             path, permissions=permissions, recreate=recreate)
 
     def openbin(self, path, mode='r', buffering=-1, **options):
+        # type: (Text, Text, int, **Any) -> BinaryIO
         self.check()
         if check_writable(mode):
             self._require_writable(path)
@@ -227,18 +252,25 @@ class MultiFS(FS):
         )
 
     def remove(self, path):
+        # type: (Text) -> None
         self.check()
         fs = self._delegate_required(path)
         return fs.remove(path)
 
     def removedir(self, path):
+        # type: (Text) -> None
         self.check()
         fs = self._delegate_required(path)
         return fs.removedir(path)
 
-    def scandir(self, path, namespaces=None, page=None):
+    def scandir(self,
+                path,               # type: Text
+                namespaces=None,    # type: Optional[Collection[Text]]
+                page=None           # type: Optional[Tuple[int, int]]
+                ):
+        # type: (...) -> Iterator[Info]
         self.check()
-        seen = set()
+        seen = set()    # type: MutableSet[Text]
         exists = False
         for _name, fs in self.iterate_fs():
             try:
@@ -254,6 +286,7 @@ class MultiFS(FS):
             raise errors.ResourceNotFound(path)
 
     def getbytes(self, path):
+        # type: (Text) -> bytes
         self.check()
         fs = self._delegate(path)
         if fs is None:
@@ -261,10 +294,12 @@ class MultiFS(FS):
         return fs.getbytes(path)
 
     def getfile(self, path, file, chunk_size=None, **options):
+        # type: (Text, BinaryIO, Optional[int], **Any) -> None
         fs = self._delegate_required(path)
         return fs.getfile(path, file, chunk_size=chunk_size, **options)
 
     def gettext(self, path, encoding=None, errors=None, newline=''):
+        # type: (Text, Optional[Text], Optional[Text], Text) -> Text
         self.check()
         fs = self._delegate_required(path)
         return fs.gettext(
@@ -275,51 +310,61 @@ class MultiFS(FS):
         )
 
     def getsize(self, path):
+        # type: (Text) -> int
         self.check()
         fs = self._delegate_required(path)
         return fs.getsize(path)
 
     def getsyspath(self, path):
+        # type: (Text) -> Text
         self.check()
         fs = self._delegate_required(path)
         return fs.getsyspath(path)
 
     def gettype(self, path):
+        # type: (Text) -> ResourceType
         self.check()
         fs = self._delegate_required(path)
         return fs.gettype(path)
 
     def geturl(self, path, purpose='download'):
+        # type: (Text, Text) -> Text
         self.check()
         fs = self._delegate_required(path)
         return fs.geturl(path, purpose=purpose)
 
     def hassyspath(self, path):
+        # type: (Text) -> bool
         self.check()
         fs = self._delegate(path)
         return fs is not None and fs.hassyspath(path)
 
     def hasurl(self, path, purpose='download'):
+        # type: (Text, Text) -> bool
         self.check()
         fs = self._delegate(path)
         return fs is not None and fs.hasurl(path, purpose=purpose)
 
     def isdir(self, path):
+        # type: (Text) -> bool
         self.check()
         fs = self._delegate(path)
         return fs and fs.isdir(path)
 
     def isfile(self, path):
+        # type: (Text) -> bool
         self.check()
         fs = self._delegate(path)
         return fs and fs.isfile(path)
 
     def setinfo(self, path, info):
+        # type:(Text, RawInfo) -> None
         self.check()
         self._require_writable(path)
         return self.write_fs.setinfo(path, info)
 
     def validatepath(self, path):
+        # type: (Text) -> Text
         self.check()
         if self.write_fs is not None:
             self.write_fs.validatepath(path)
@@ -329,6 +374,7 @@ class MultiFS(FS):
         return path
 
     def makedirs(self, path, permissions=None, recreate=False):
+        # type: (Text, Optional[Permissions], bool) -> FS
         self.check()
         self._require_writable(path)
         return self.write_fs.makedirs(
@@ -338,13 +384,14 @@ class MultiFS(FS):
         )
 
     def open(self,
-             path,
-             mode='r',
-             buffering=-1,
-             encoding=None,
-             errors=None,
-             newline='',
-             **kwargs):
+             path,             # type: Text
+             mode='r',         # type: Text
+             buffering=-1,     # type: int
+             encoding=None,    # type: Optional[Text]
+             errors=None,      # type: Optional[Text]
+             newline='',       # type: Text
+             **kwargs          # type: Any
+             ):
         self.check()
         if check_writable(mode):
             self._require_writable(path)
@@ -362,19 +409,22 @@ class MultiFS(FS):
         )
 
     def setbinfile(self, path, file):
+        # type: (Text, BinaryIO) -> None
         self._require_writable(path)
         self.write_fs.setbinfile(path, file)
 
     def setbytes(self, path, contents):
+        # type: (Text, bytes) -> None
         self._require_writable(path)
         return self.write_fs.setbytes(path, contents)
 
     def settext(self,
-                path,
-                contents,
-                encoding='utf-8',
-                errors=None,
-                newline=''):
+                path,               # type: Text
+                contents,           # type: Text
+                encoding='utf-8',   # type: Text
+                errors=None,        # type: Optional[Text]
+                newline=''          # type: Text
+                ):
         self._require_writable(path)
         return self.write_fs.settext(
             path,

--- a/fs/opener/appfs.py
+++ b/fs/opener/appfs.py
@@ -13,7 +13,7 @@ from .errors import OpenerError
 from ..subfs import ClosingSubFS
 from .. import appfs
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Text, Union
     from .parse import ParseResult
     from ..appfs import _AppFS

--- a/fs/opener/appfs.py
+++ b/fs/opener/appfs.py
@@ -6,11 +6,19 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from .base import Opener
 from .errors import OpenerError
 from ..subfs import ClosingSubFS
 from .. import appfs
 
+if typing.TYPE_CHECKING:
+    from typing import Text, Union
+    from .parse import ParseResult
+    from ..appfs import _AppFS
+    from ..subfs import SubFS
+    
 
 class AppFSOpener(Opener):
     """``AppFS`` opener.
@@ -34,8 +42,14 @@ class AppFSOpener(Opener):
         'userlog': appfs.UserLogFS
     }
 
-    def open_fs(self, fs_url, parse_result, writeable, create, cwd):
-
+    def open_fs(self,
+                fs_url,        # type: Text
+                parse_result,  # type: ParseResult
+                writeable,     # type: bool
+                create,        # type: bool
+                cwd            # type: Text
+                ):
+        # type: (...) -> Union[_AppFS, SubFS[_AppFS]]
         fs_class = self._protocol_mapping[parse_result.protocol]
         resource, delim, path = parse_result.resource.partition('/')
         tokens = resource.split(':', 3)
@@ -57,10 +71,7 @@ class AppFSOpener(Opener):
             create=create
         )
 
-        app_fs = (
-            app_fs.opendir(path, factory=ClosingSubFS)
-            if delim
-            else app_fs
-        )
+        if delim:
+            return app_fs.opendir(path, factory=ClosingSubFS)
 
         return app_fs

--- a/fs/opener/base.py
+++ b/fs/opener/base.py
@@ -6,6 +6,12 @@ import six
 import abc
 
 
+if False:  # typing imports
+    from typing import List, Text, Union
+    from ..base import FS
+    from .parse import ParseResult
+
+
 @six.add_metaclass(abc.ABCMeta)
 class Opener(object):
     """The base class for filesystem openers.
@@ -15,13 +21,20 @@ class Opener(object):
 
     """
 
-    protocols = []
+    protocols = []  # type: List[Text]
 
     def __repr__(self):
         return "<opener {!r}>".format(self.protocols)
 
     @abc.abstractmethod
-    def open_fs(self, fs_url, parse_result, writeable, create, cwd):
+    def open_fs(self,
+                fs_url,        # type: Text
+                parse_result,  # type: ParseResult
+                writeable,     # type: bool
+                create,        # type: bool
+                cwd            # type: Text
+                ):
+        # type: (...) -> FS
         """Open a filesystem object from a FS URL.
 
         Arguments:

--- a/fs/opener/base.py
+++ b/fs/opener/base.py
@@ -2,15 +2,15 @@
 """`Opener` abstract base class.
 """
 
-import six
 import abc
+import typing
 
+import six
 
-if False:  # typing imports
+if typing.TYPE_CHECKING:
     from typing import List, Text, Union
     from ..base import FS
     from .parse import ParseResult
-
 
 @six.add_metaclass(abc.ABCMeta)
 class Opener(object):
@@ -24,6 +24,7 @@ class Opener(object):
     protocols = []  # type: List[Text]
 
     def __repr__(self):
+        # type: () -> Text
         return "<opener {!r}>".format(self.protocols)
 
     @abc.abstractmethod

--- a/fs/opener/base.py
+++ b/fs/opener/base.py
@@ -7,7 +7,7 @@ import typing
 
 import six
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import List, Text, Union
     from ..base import FS
     from .parse import ParseResult

--- a/fs/opener/ftpfs.py
+++ b/fs/opener/ftpfs.py
@@ -10,7 +10,7 @@ import typing
 
 from .base import Opener
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import List, Text, Union
     from ..ftpfs import FTPFS
     from ..subfs import SubFS

--- a/fs/opener/ftpfs.py
+++ b/fs/opener/ftpfs.py
@@ -6,7 +6,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from .base import Opener
+
+if typing.TYPE_CHECKING:
+    from typing import List, Text, Union
+    from ..ftpfs import FTPFS
+    from ..subfs import SubFS
+    from .parse import ParseResult
+
 
 class FTPOpener(Opener):
     """`FTPFS` opener.
@@ -14,7 +23,14 @@ class FTPOpener(Opener):
 
     protocols = ['ftp']
 
-    def open_fs(self, fs_url, parse_result, writeable, create, cwd):
+    def open_fs(self,
+                fs_url,         # type: Text
+                parse_result,   # type: ParseResult
+                writeable,      # type: bool
+                create,         # type: bool
+                cwd             # type: Text
+                ):
+        # type: (...) -> Union[FTPFS, SubFS[FTPFS]]
         from ..ftpfs import FTPFS
         from ..subfs import ClosingSubFS
         ftp_host, _, dir_path = parse_result.resource.partition('/')
@@ -27,9 +43,8 @@ class FTPOpener(Opener):
             passwd=parse_result.password,
             proxy=parse_result.params.get('proxy')
         )
-        ftp_fs = (
-            ftp_fs.opendir(dir_path, factory=ClosingSubFS)
-            if dir_path else
-            ftp_fs
-        )
+
+        if dir_path:
+            return ftp_fs.opendir(dir_path, factory=ClosingSubFS)
+
         return ftp_fs

--- a/fs/opener/memoryfs.py
+++ b/fs/opener/memoryfs.py
@@ -6,7 +6,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from .base import Opener
+
+if typing.TYPE_CHECKING:
+    from typing import Text
+    from .parse import ParseResult
+    from ..memoryfs import MemoryFS
+
 
 class MemOpener(Opener):
     """`MemoryFS` opener.
@@ -14,7 +22,14 @@ class MemOpener(Opener):
 
     protocols = ['mem']
 
-    def open_fs(self, fs_url, parse_result, writeable, create, cwd):
+    def open_fs(self,
+                fs_url,         # type: Text
+                parse_result,   # type: ParseResult
+                writeable,      # type: bool
+                create,         # type: bool
+                cwd             # type: Text
+                ):
+        # type: (...) -> MemoryFS
         from ..memoryfs import MemoryFS
         mem_fs = MemoryFS()
         return mem_fs

--- a/fs/opener/memoryfs.py
+++ b/fs/opener/memoryfs.py
@@ -10,7 +10,7 @@ import typing
 
 from .base import Opener
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Text
     from .parse import ParseResult
     from ..memoryfs import MemoryFS

--- a/fs/opener/osfs.py
+++ b/fs/opener/osfs.py
@@ -6,7 +6,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from .base import Opener
+
+if typing.TYPE_CHECKING:
+    from typing import Text
+    from .parse import ParseResult
+    from ..osfs import OSFS
+
 
 class OSFSOpener(Opener):
     """`OSFS` opener.
@@ -14,7 +22,14 @@ class OSFSOpener(Opener):
 
     protocols = ['file', 'osfs']
 
-    def open_fs(self, fs_url, parse_result, writeable, create, cwd):
+    def open_fs(self,
+                fs_url,         # type: Text
+                parse_result,   # type: ParseResult
+                writeable,      # type: bool
+                create,         # type: bool
+                cwd             # type: Text
+                ):
+        # type: (...) -> OSFS
         from ..osfs import OSFS
         from os.path import abspath, expanduser, normpath, join
         _path = abspath(join(cwd, expanduser(parse_result.resource)))

--- a/fs/opener/osfs.py
+++ b/fs/opener/osfs.py
@@ -10,7 +10,7 @@ import typing
 
 from .base import Opener
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Text
     from .parse import ParseResult
     from ..osfs import OSFS

--- a/fs/opener/parse.py
+++ b/fs/opener/parse.py
@@ -7,10 +7,15 @@ from __future__ import unicode_literals
 
 import collections
 import re
+import typing
 
+import six
 from six.moves.urllib.parse import parse_qs, unquote
 
 from .errors import ParseError
+
+if typing.TYPE_CHECKING:
+    from typing import Optional, Text
 
 
 _ParseResult = collections.namedtuple(
@@ -59,6 +64,7 @@ _RE_FS_URL = re.compile(r'''
 
 
 def parse_fs_url(fs_url):
+    # type: (Text) -> ParseResult
     """Parse a Filesystem URL and return a `ParseResult`.
 
     Arguments:
@@ -76,20 +82,20 @@ def parse_fs_url(fs_url):
         raise ParseError('{!r} is not a fs2 url'.format(fs_url))
 
     fs_name, credentials, url1, url2, path = match.groups()
-    if credentials:
+    if not credentials:
+        username = None     # type: Optional[Text]
+        password = None     # type: Optional[Text]
+        url = url2
+    else:
         username, _, password = credentials.partition(':')
         username = unquote(username)
         password = unquote(password)
         url = url1
-    else:
-        username = None
-        password = None
-        url = url2
-    url, has_qs, _params = url.partition('?')
+    url, has_qs, qs = url.partition('?')
     resource = unquote(url)
     if has_qs:
-        params = parse_qs(_params, keep_blank_values=True)
-        params = {k:v[0] for k, v in params.items()}
+        _params = parse_qs(qs, keep_blank_values=True)
+        params = {k:v[0] for k, v in six.iteritems(_params)}
     else:
         params = {}
     return ParseResult(

--- a/fs/opener/parse.py
+++ b/fs/opener/parse.py
@@ -14,7 +14,7 @@ from six.moves.urllib.parse import parse_qs, unquote
 
 from .errors import ParseError
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Optional, Text
 
 

--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -16,7 +16,7 @@ from .parse import parse_fs_url
 
 
 if False:  # typing imports
-    from typing import Text, Union
+    from typing import Text, Tuple, Union
     from ..base import FS
 
 

--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -7,6 +7,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import contextlib
+import typing
+
 import six
 import pkg_resources
 
@@ -14,8 +16,7 @@ from .base import Opener
 from .errors import UnsupportedProtocol, EntryPointError
 from .parse import parse_fs_url
 
-
-if False:  # typing imports
+if typing.TYPE_CHECKING:
     from typing import Text, Tuple, Union
     from ..base import FS
 

--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -16,7 +16,7 @@ from .base import Opener
 from .errors import UnsupportedProtocol, EntryPointError
 from .parse import parse_fs_url
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Iterator, List, Text, Tuple, Union
     from ..base import FS
 

--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -17,7 +17,7 @@ from .errors import UnsupportedProtocol, EntryPointError
 from .parse import parse_fs_url
 
 if typing.TYPE_CHECKING:
-    from typing import Text, Tuple, Union
+    from typing import Iterator, List, Text, Tuple, Union
     from ..base import FS
 
 
@@ -36,13 +36,15 @@ class Registry(object):
 
         """
         self.default_opener = default_opener
-        self._protocols = None
+        self._protocols = None  # type: Union[None, List[Text]]
 
     def __repr__(self):
+        # type: () -> Text
         return "<fs-registry {!r}>".format(self.protocols)
 
     @property
     def protocols(self):
+        # type: () -> List[Text]
         """`list`: the list of supported protocols.
         """
         if self._protocols is None:
@@ -160,6 +162,7 @@ class Registry(object):
                 cwd=".",                    # type: Text
                 default_protocol='osfs'     # type: Text
                 ):
+        # type: (...) -> FS
         """Open a filesystem from a FS URL (ignoring the path component).
 
         Arguments:
@@ -197,6 +200,7 @@ class Registry(object):
                   writeable=False,  # type: bool
                   cwd='.'           # type: Text
                   ):
+        # type: (...) -> Iterator[FS]
         """Get a context manager to open and close a filesystem.
 
         Arguments:

--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -15,11 +15,17 @@ from .errors import UnsupportedProtocol, EntryPointError
 from .parse import parse_fs_url
 
 
+if False:  # typing imports
+    from typing import Text, Union
+    from ..base import FS
+
+
 class Registry(object):
     """A registry for `Opener` instances.
     """
 
     def __init__(self, default_opener='osfs'):
+        # type: (Text) -> None
         """Create a registry object.
 
         Arguments:
@@ -30,7 +36,6 @@ class Registry(object):
         """
         self.default_opener = default_opener
         self._protocols = None
-
 
     def __repr__(self):
         return "<fs-registry {!r}>".format(self.protocols)
@@ -48,6 +53,7 @@ class Registry(object):
         return self._protocols
 
     def get_opener(self, protocol):
+        # type: (Text) -> Opener
         """Get the opener class associated to a given protocol.
 
         Arguments:
@@ -103,11 +109,13 @@ class Registry(object):
         return opener_instance
 
     def open(self,
-             fs_url,
-             writeable=True,
-             create=False,
-             cwd=".",
-             default_protocol='osfs'):
+             fs_url,                    # type: Text
+             writeable=True,            # type: bool
+             create=False,              # type: bool
+             cwd=".",                   # type: Text
+             default_protocol='osfs'    # type: Text
+             ):
+        # type: (...) -> Tuple[FS, Text]
         """Open a filesystem from a FS URL.
 
         Returns a tuple of a filesystem object and a path. If there is
@@ -119,7 +127,7 @@ class Registry(object):
                 writeable.
             create (bool, optional): `True` if the filesystem should be
                 created if it does not exist.
-            cwd (str, optional): The current working directory, or `None`.
+            cwd (str): The current working directory.
 
         Returns:
             (FS, str): a tuple of ``(<filesystem>, <path from url>)``
@@ -145,11 +153,12 @@ class Registry(object):
         return open_fs, open_path
 
     def open_fs(self,
-                fs_url,
-                writeable=False,
-                create=False,
-                cwd=".",
-                default_protocol='osfs'):
+                fs_url,                     # type: Text
+                writeable=False,            # type: bool
+                create=False,               # type: bool
+                cwd=".",                    # type: Text
+                default_protocol='osfs'     # type: Text
+                ):
         """Open a filesystem from a FS URL (ignoring the path component).
 
         Arguments:
@@ -158,8 +167,8 @@ class Registry(object):
                 be writeable.
             create (bool, optional): `True` if the filesystem should be
                 created if it does not exist.
-            cwd (str, optional): The current working directory (generally
-                only relevant for OS filesystems).
+            cwd (str): The current working directory (generally only
+                relevant for OS filesystems).
             default_protocol (str): The protocol to use if one is not
                 supplied in the FS URL (defaults to ``"osfs"``).
 
@@ -181,7 +190,12 @@ class Registry(object):
         return _fs
 
     @contextlib.contextmanager
-    def manage_fs(self, fs_url, create=False, writeable=False, cwd='.'):  # noqa: D300,D301
+    def manage_fs(self,
+                  fs_url,           # type: Union[FS, Text]
+                  create=False,     # type: bool
+                  writeable=False,  # type: bool
+                  cwd='.'           # type: Text
+                  ):
         """Get a context manager to open and close a filesystem.
 
         Arguments:
@@ -199,7 +213,7 @@ class Registry(object):
 
         Example:
             >>> def print_ls(list_fs):
-            ...     \"\"\"List a directory.\"\"\"
+            ...     '''List a directory.'''
             ...     with manage_fs(list_fs) as fs:
             ...         print(' '.join(fs.listdir()))
 

--- a/fs/opener/tarfs.py
+++ b/fs/opener/tarfs.py
@@ -11,7 +11,7 @@ import typing
 from .base import Opener
 from .errors import NotWriteable
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Text
     from .parse import ParseResult
     from ..tarfs import TarFS

--- a/fs/opener/tarfs.py
+++ b/fs/opener/tarfs.py
@@ -6,8 +6,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from .base import Opener
 from .errors import NotWriteable
+
+if typing.TYPE_CHECKING:
+    from typing import Text
+    from .parse import ParseResult
+    from ..tarfs import TarFS
 
 
 class TarOpener(Opener):
@@ -16,7 +23,14 @@ class TarOpener(Opener):
 
     protocols = ['tar']
 
-    def open_fs(self, fs_url, parse_result, writeable, create, cwd):
+    def open_fs(self,
+                fs_url,         # type: Text
+                parse_result,   # type: ParseResult
+                writeable,      # type: bool
+                create,         # type: bool
+                cwd             # type: Text
+                ):
+        # type: (...) -> TarFS
         from ..tarfs import TarFS
         if not create and writeable:
             raise NotWriteable(

--- a/fs/opener/tempfs.py
+++ b/fs/opener/tempfs.py
@@ -10,7 +10,7 @@ import typing
 
 from .base import Opener
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Text
     from .parse import ParseResult
     from ..tempfs import TempFS

--- a/fs/opener/tempfs.py
+++ b/fs/opener/tempfs.py
@@ -6,15 +6,30 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from .base import Opener
+
+if typing.TYPE_CHECKING:
+    from typing import Text
+    from .parse import ParseResult
+    from ..tempfs import TempFS
+
 
 class TempOpener(Opener):
     """`TempFS` opener.
     """
-    
+
     protocols = ['temp']
 
-    def open_fs(self, fs_url, parse_result, writeable, create, cwd):
+    def open_fs(self,
+                fs_url,         # type: Text
+                parse_result,   # type: ParseResult
+                writeable,      # type: bool
+                create,         # type: bool
+                cwd             # type: Text
+                ):
+        # type: (...) -> TempFS
         from ..tempfs import TempFS
         temp_fs = TempFS(identifier=parse_result.resource)
         return temp_fs

--- a/fs/opener/zipfs.py
+++ b/fs/opener/zipfs.py
@@ -6,8 +6,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from .base import Opener
 from .errors import NotWriteable
+
+if typing.TYPE_CHECKING:
+    from typing import Text
+    from .parse import ParseResult
+    from ..zipfs import ZipFS
 
 
 class ZipOpener(Opener):
@@ -16,7 +23,14 @@ class ZipOpener(Opener):
 
     protocols = ['zip']
 
-    def open_fs(self, fs_url, parse_result, writeable, create, cwd):
+    def open_fs(self,
+                fs_url,         # type: Text
+                parse_result,   # type: ParseResult
+                writeable,      # type: bool
+                create,         # type: bool
+                cwd             # type: Text
+                ):
+        # type: (...) -> ZipFS
         from ..zipfs import ZipFS
         if not create and writeable:
             raise NotWriteable(

--- a/fs/opener/zipfs.py
+++ b/fs/opener/zipfs.py
@@ -11,7 +11,7 @@ import typing
 from .base import Opener
 from .errors import NotWriteable
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Text
     from .parse import ParseResult
     from ..zipfs import ZipFS

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -132,11 +132,13 @@ class OSFS(FS):
                 )
 
     def __repr__(self):
+        # type: () -> str
         _fmt = "{}({!r})"
         return _fmt.format(self.__class__.__name__,
                            self.root_path)
 
     def __str__(self):
+        # type: () -> str
         fmt = "<{} '{}'>"
         return fmt.format(self.__class__.__name__.lower(),
                           self.root_path)

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -62,11 +62,11 @@ class OSFS(FS):
     Arguments:
         root_path (str or ~os.PathLike): An OS path or path-like object to
             the location on your HD you wish to manage.
-        create (bool, optional): Set to `True` to create the root directory
-            if it does not already exist, otherwise the directory should exist
-            prior to creating the ``OSFS`` instance (default `False`).
-        create_mode (int, optional): The permissions that will be used to
-            create the directory if ``create`` is `True` and the path doesn't
+        create (bool): Set to `True` to create the root directory if it
+            does not already exist, otherwise the directory should exist
+            prior to creating the ``OSFS`` instance (defaults to `False`).
+        create_mode (int): The permissions that will be used to create
+            the directory if ``create`` is `True` and the path doesn't
             exist, defaults to ``0o777``.
 
     Raises:

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -235,7 +235,7 @@ class OSFS(FS):
     def _make_link_info(self, sys_path):
         # type: (Text) -> Dict[Text, object]
         _target = self._gettarget(sys_path)
-        return {'target': _target}  # type: ignore
+        return {'target': _target}
 
     def getinfo(self, path, namespaces=None):
         # type: (Text, Optional[Collection[Text]]) -> Info
@@ -511,7 +511,7 @@ class OSFS(FS):
                     if 'link' in namespaces:
                         info['link'] = self._make_link_info(
                             os.path.join(sys_path, entry_name)
-                        )   # type: ignore
+                        )
                     if 'access' in namespaces:
                         info['access'] =\
                             self._make_access_from_stat(stat_result)

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -40,7 +40,7 @@ from .error_tools import convert_os_errors
 from .mode import Mode, validate_open_mode
 from .errors import NoURL
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import (
         Any, BinaryIO, Callable, Collection, Dict,
         Iterator, IO, List, Optional, SupportsInt,
@@ -361,7 +361,7 @@ class OSFS(FS):
     # Optional Methods
     # --------------------------------------------------------
 
-    if typing.TYPE_CHECKING:
+    if False:  # typing.TYPE_CHECKING
         def opendir(self, path, factory=None):
             # type: (_O, Text, Optional[_OpendirFactory]) -> SubFS[_O]
             pass

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -42,11 +42,14 @@ from .errors import NoURL
 
 if typing.TYPE_CHECKING:
     from typing import (
-        Any, BinaryIO, Collection, Dict, Iterator, IO,
-        List, Optional, SupportsInt, Text, Tuple)
+        Any, BinaryIO, Callable, Collection, Dict,
+        Iterator, IO, List, Optional, SupportsInt,
+        Text, Tuple)
+    from .base import _OpendirFactory
     from .info import RawInfo
     from .subfs import SubFS
-    F = typing.TypeVar('F', bound='OSFS')
+
+    _O = typing.TypeVar('_O', bound='OSFS')
 
 
 log = logging.getLogger('fs.osfs')
@@ -285,12 +288,12 @@ class OSFS(FS):
             names = os.listdir(sys_path)
         return names
 
-    def makedir(self,               # type: F
+    def makedir(self,               # type: _O
                 path,               # type: Text
                 permissions=None,   # type: Optional[Permissions]
                 recreate=False      # type: bool
                 ):
-        # type: (...) -> SubFS[F]
+        # type: (...) -> SubFS[_O]
         self.check()
         mode = Permissions.get_mode(permissions)
         _path = self.validatepath(path)
@@ -357,6 +360,11 @@ class OSFS(FS):
     # --------------------------------------------------------
     # Optional Methods
     # --------------------------------------------------------
+
+    if typing.TYPE_CHECKING:
+        def opendir(self, path, factory=None):
+            # type: (_O, Text, Optional[_OpendirFactory]) -> SubFS[_O]
+            pass
 
     def getsyspath(self, path):
         # type: (Text) -> Text

--- a/fs/path.py
+++ b/fs/path.py
@@ -12,12 +12,12 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import re
+import typing
 
 from .errors import IllegalBackReference
 
-if False:  # typing imports
-    from typing import *
-
+if typing.TYPE_CHECKING:
+    from typing import List, Text, Tuple
 
 
 __all__ = [

--- a/fs/path.py
+++ b/fs/path.py
@@ -122,7 +122,7 @@ def recursepath(path, reverse=False):
 
     Arguments:
         path (str): A PyFilesystem path
-        reverse (bool, optional): Reverses the order of the paths
+        reverse (bool): Reverses the order of the paths
             (default `False`).
 
     Returns:

--- a/fs/path.py
+++ b/fs/path.py
@@ -16,7 +16,7 @@ import typing
 
 from .errors import IllegalBackReference
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import List, Text, Tuple
 
 

--- a/fs/path.py
+++ b/fs/path.py
@@ -565,7 +565,7 @@ def relativefrom(base, path):
             break
         common += 1
 
-    return '/'.join(['..'] * (len(base) - common) + path_parts[common:])
+    return '/'.join(['..'] * (len(base_parts) - common) + path_parts[common:])
 
 
 _WILD_CHARS = frozenset('*?[]!{}')

--- a/fs/path.py
+++ b/fs/path.py
@@ -15,6 +15,10 @@ import re
 
 from .errors import IllegalBackReference
 
+if False:  # typing imports
+    from typing import *
+
+
 
 __all__ = [
     "abspath",
@@ -47,6 +51,7 @@ _requires_normalization = re.compile(
 
 
 def normpath(path):
+    # type: (Text) -> Text
     """Normalize a path.
 
     This function simplifies a path by collapsing back-references
@@ -75,7 +80,7 @@ def normpath(path):
         return path.rstrip('/')
 
     prefix = '/' if path.startswith('/') else ''
-    components = []
+    components = []  # type: List[Text]
     try:
         for component in path.split('/'):
             if component in '..':  # True for '..', '.', and ''
@@ -91,6 +96,7 @@ def normpath(path):
 
 
 def iteratepath(path):
+    # type: (Text) -> List[Text]
     """Iterate over the individual components of a path.
 
     Arguments:
@@ -111,6 +117,7 @@ def iteratepath(path):
 
 
 def recursepath(path, reverse=False):
+    # type: (Text, bool) -> List[Text]
     """Get intermediate paths from the root to the given path.
 
     Arguments:
@@ -148,6 +155,7 @@ def recursepath(path, reverse=False):
 
 
 def isabs(path):
+    # type: (Text) -> bool
     """Check if a path is an absolute path.
 
     Arguments:
@@ -162,6 +170,7 @@ def isabs(path):
 
 
 def abspath(path):
+    # type: (Text) -> Text
     """Convert the given path to an absolute path.
 
     Since FS objects have no concept of a *current directory*, this
@@ -181,6 +190,7 @@ def abspath(path):
 
 
 def relpath(path):
+    # type: (Text) -> Text
     """Convert the given path to a relative path.
 
     This is the inverse of `abspath`, stripping a leading ``'/'`` from
@@ -201,6 +211,7 @@ def relpath(path):
 
 
 def join(*paths):
+    # type: (*Text) -> Text
     """Join any number of paths together.
 
     Arguments:
@@ -219,7 +230,7 @@ def join(*paths):
 
     """
     absolute = False
-    relpaths = []
+    relpaths = []       # type: List[Text]
     for p in paths:
         if p:
             if p[0] == '/':
@@ -234,6 +245,7 @@ def join(*paths):
 
 
 def combine(path1, path2):
+    # type: (Text, Text) -> Text
     """Join two paths together.
 
     This is faster than :func:`~fs.path.join`, but only works when the
@@ -258,6 +270,7 @@ def combine(path1, path2):
 
 
 def parts(path):
+    # type: (Text) -> List[Text]
     """Split a path in to its component parts.
 
     Arguments:
@@ -281,6 +294,7 @@ def parts(path):
 
 
 def split(path):
+    # type: (Text) -> Tuple[Text, Text]
     """Split a path into (head, tail) pair.
 
     This function splits a path into a pair (head, tail) where 'tail' is
@@ -308,6 +322,7 @@ def split(path):
 
 
 def splitext(path):
+    # type: (Text) -> Tuple[Text, Text]
     """Split the extension from the path.
 
     Arguments:
@@ -332,6 +347,7 @@ def splitext(path):
 
 
 def isdotfile(path):
+    # type: (Text) -> bool
     """Detect if a path references a dot file.
 
     Arguments:
@@ -353,6 +369,7 @@ def isdotfile(path):
 
 
 def dirname(path):
+    # type: (Text) -> Text
     """Return the parent directory of a path.
 
     This is always equivalent to the 'head' component of the value
@@ -377,6 +394,7 @@ def dirname(path):
 
 
 def basename(path):
+    # type: (Text) -> Text
     """Return the basename of the resource referenced by a path.
 
     This is always equivalent to the 'tail' component of the value
@@ -401,6 +419,7 @@ def basename(path):
 
 
 def issamedir(path1, path2):
+    # type: (Text, Text) -> bool
     """Check if two paths reference a resource in the same directory.
 
     Arguments:
@@ -421,6 +440,7 @@ def issamedir(path1, path2):
 
 
 def isbase(path1, path2):
+    # type: (Text, Text) -> bool
     """Check if ``path1`` is a base of ``path2``.
 
     Arguments:
@@ -441,6 +461,7 @@ def isbase(path1, path2):
 
 
 def isparent(path1, path2):
+    # type: (Text, Text) -> bool
     """Check if ``path1`` is a parent directory of ``path2``.
 
     Arguments:
@@ -474,6 +495,7 @@ def isparent(path1, path2):
 
 
 def forcedir(path):
+    # type: (Text) -> Text
     """Ensure the path ends with a trailing forward slash.
 
     Arguments:
@@ -497,6 +519,7 @@ def forcedir(path):
 
 
 def frombase(path1, path2):
+    # type: (Text, Text) -> Text
     """Get the final path of ``path2`` that isn't in ``path1``.
 
     Arguments:
@@ -517,6 +540,7 @@ def frombase(path1, path2):
 
 
 def relativefrom(base, path):
+    # type: (Text, Text) -> Text
     """Return a path relative from a given base path.
 
     Insert backrefs as appropriate to reach the path from the base.
@@ -532,22 +556,23 @@ def relativefrom(base, path):
     '../../baz/index.html'
 
     """
-    base = list(iteratepath(base))
-    path = list(iteratepath(path))
+    base_parts = list(iteratepath(base))
+    path_parts = list(iteratepath(path))
 
     common = 0
-    for component_a, component_b in zip(base, path):
+    for component_a, component_b in zip(base_parts, path_parts):
         if component_a != component_b:
             break
         common += 1
 
-    return '/'.join(['..'] * (len(base) - common) + path[common:])
+    return '/'.join(['..'] * (len(base) - common) + path_parts[common:])
 
 
 _WILD_CHARS = frozenset('*?[]!{}')
 
 
 def iswildcard(path):
+    # type: (Text) -> bool
     """Check if a path ends with a wildcard.
 
     Arguments:

--- a/fs/permissions.py
+++ b/fs/permissions.py
@@ -7,6 +7,10 @@ from __future__ import unicode_literals
 import six
 
 
+if False:  # typing imports
+    from typing import *
+
+
 def make_mode(init):
     """Make a mode integer from an initial value.
     """
@@ -80,14 +84,16 @@ class Permissions(object):
     _LINUX_PERMS_NAMES = [_name for _name, _mask in _LINUX_PERMS]
 
     def __init__(self,
-                 names=None,
-                 mode=None,
-                 user=None,
-                 group=None,
-                 other=None,
-                 sticky=None,
-                 setuid=None,
-                 setguid=None):
+                 names=None,    # type: Optional[Iterable[Text]]
+                 mode=None,     # type: Optional[int]
+                 user=None,     # type: Optional[Text]
+                 group=None,    # type: Optional[Text]
+                 other=None,    # type: Optional[Text]
+                 sticky=None,   # type: Optional[bool]
+                 setuid=None,   # type: Optional[bool]
+                 setguid=None   # type: Optional[bool]
+                 ):
+        # type: (...) -> None
         if names is not None:
             self._perms = set(names)
         elif mode is not None:
@@ -167,6 +173,7 @@ class Permissions(object):
 
     @classmethod
     def parse(cls, ls):
+        # type: (Text) -> Permissions
         """Parse permissions in Linux notation.
         """
         user = ls[:3]
@@ -176,12 +183,14 @@ class Permissions(object):
 
     @classmethod
     def load(cls, permissions):
+        # type: (List[Text]) -> Permissions
         """Load a serialized permissions object.
         """
         return cls(names=permissions)
 
     @classmethod
     def create(cls, init=None):
+        # type: (Union[int, Iterable[Text], None]) -> Permissions
         """Create a permissions object from an initial value.
 
         Arguments:
@@ -212,21 +221,25 @@ class Permissions(object):
 
     @classmethod
     def get_mode(cls, init):
+        # type: (Union[int, Iterable[Text], None]) -> int
         """Convert an initial value to a mode integer.
         """
         return cls.create(init).mode
 
     def copy(self):
+        # type: () -> Permissions
         """Make a copy of this permissions object.
         """
         return Permissions(names=list(self._perms))
 
     def dump(self):
+        # type: () -> List[Text]
         """Get a list suitable for serialization.
         """
         return sorted(self._perms)
 
     def as_str(self):
+        # type: () -> Text
         """Get a Linux-style string representation of permissions.
         """
         perms = [
@@ -281,6 +294,7 @@ class Permissions(object):
     setguid = _PermProperty('setguid')
 
     def add(self, *permissions):
+        # type: (*Text) -> None
         """Add permission(s).
 
         Arguments:
@@ -291,6 +305,7 @@ class Permissions(object):
         self._perms.update(permissions)
 
     def remove(self, *permissions):
+        # type: (*Text) -> None
         """Remove permission(s).
 
         Arguments:
@@ -301,6 +316,7 @@ class Permissions(object):
         self._perms.difference_update(permissions)
 
     def check(self, *permissions):
+        # type: (*Text) -> bool
         """Check if one or more permissions are enabled.
 
         Arguments:

--- a/fs/permissions.py
+++ b/fs/permissions.py
@@ -9,7 +9,7 @@ from typing import Container, Iterable, Text
 
 import six
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import (
         Iterator, List, Optional, Tuple, Type, Union)
 

--- a/fs/permissions.py
+++ b/fs/permissions.py
@@ -4,11 +4,13 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+from typing import Container, Iterable, Text
+
 import six
 
-
-if False:  # typing imports
-    from typing import *
+if typing.TYPE_CHECKING:
+    from typing import Iterator, List, Optional, Tuple, Union
 
 
 def make_mode(init):
@@ -20,7 +22,9 @@ def make_mode(init):
 class _PermProperty(object):
     """Creates simple properties to get/set permissions.
     """
+
     def __init__(self, name):
+        # type: (Text) -> None
         self._name = name
         self.__doc__ = "Boolean for '{}' permission.".format(name)
 
@@ -35,7 +39,7 @@ class _PermProperty(object):
 
 
 @six.python_2_unicode_compatible
-class Permissions(object):
+class Permissions(Container[Text], Iterable[Text]):
     """An abstraction for file system permissions.
 
     Permissions objects store information regarding the permissions
@@ -80,8 +84,8 @@ class Permissions(object):
         ('o_r', 4),
         ('o_w', 2),
         ('o_x', 1)
-    ]
-    _LINUX_PERMS_NAMES = [_name for _name, _mask in _LINUX_PERMS]
+    ]  # type: List[Tuple[Text, int]]
+    _LINUX_PERMS_NAMES = [_name for _name, _mask in _LINUX_PERMS]  # type: List[Text]
 
     def __init__(self,
                  names=None,    # type: Optional[Iterable[Text]]
@@ -116,6 +120,7 @@ class Permissions(object):
             self._perms.add('setguid')
 
     def __repr__(self):
+        # type: () -> Text
         if not self._perms.issubset(self._LINUX_PERMS_NAMES):
             _perms_str = ", ".join(
                 "'{}'".format(p) for p in sorted(self._perms)
@@ -153,22 +158,27 @@ class Permissions(object):
         return "Permissions({})".format(', '.join(args))
 
     def __str__(self):
+        # type: () -> Text
         return self.as_str()
 
     def __iter__(self):
+        # type: () -> Iterator[Text]
         return iter(self._perms)
 
     def __contains__(self, permission):
+        # type: (object) -> bool
         return permission in self._perms
 
     def __eq__(self, other):
+        # type: (object) -> bool
         if isinstance(other, Permissions):
-            names = other.dump()
+            names = other.dump()            # type: object
         else:
             names = other
         return self.dump() == names
 
     def __ne__(self, other):
+        # type: (object) -> bool
         return not self.__eq__(other)
 
     @classmethod
@@ -261,6 +271,7 @@ class Permissions(object):
 
     @property
     def mode(self):
+        # type: () -> int
         """`int`: mode integer.
         """
         mode = 0
@@ -271,6 +282,7 @@ class Permissions(object):
 
     @mode.setter
     def mode(self, mode):
+        # type: (int) -> None
         self._perms = {
             name
             for name, mask in self._LINUX_PERMS

--- a/fs/permissions.py
+++ b/fs/permissions.py
@@ -204,8 +204,8 @@ class Permissions(Container[Text], Iterable[Text]):
         """Create a permissions object from an initial value.
 
         Arguments:
-            init (int or list or None): May be None to use 0o777 permissions,
-                a mode integer, or a list of permission names.
+            init (int or list, optional): May be None to use `0o777`
+                permissions, a mode integer, or a list of permission names.
 
         Returns:
             int: mode integer that may be used for instance by `os.makedir`.

--- a/fs/permissions.py
+++ b/fs/permissions.py
@@ -10,10 +10,12 @@ from typing import Container, Iterable, Text
 import six
 
 if typing.TYPE_CHECKING:
-    from typing import Iterator, List, Optional, Tuple, Union
+    from typing import (
+        Iterator, List, Optional, Tuple, Type, Union)
 
 
 def make_mode(init):
+    # type: (Union[int, Iterable[Text], None]) -> int
     """Make a mode integer from an initial value.
     """
     return Permissions.get_mode(init)
@@ -29,9 +31,11 @@ class _PermProperty(object):
         self.__doc__ = "Boolean for '{}' permission.".format(name)
 
     def __get__(self, obj, obj_type=None):
+        # type: (Permissions, Optional[Type[Permissions]]) -> bool
         return self._name in obj
 
     def __set__(self, obj, value):
+        # type: (Permissions, bool) -> None
         if value:
             obj.add(self._name)
         else:
@@ -128,6 +132,7 @@ class Permissions(Container[Text], Iterable[Text]):
             return "Permissions(names=[{}])".format(_perms_str)
 
         def _check(perm, name):
+            # type: (Text, Text) -> Text
             return name if perm in self._perms else ''
 
         user = ''.join((

--- a/fs/subfs.py
+++ b/fs/subfs.py
@@ -8,7 +8,6 @@ import typing
 
 import six
 
-from .base import _FS
 from .wrapfs import WrapFS
 from .path import abspath, join, normpath, relpath
 
@@ -17,8 +16,11 @@ if typing.TYPE_CHECKING:
     from .base import FS
 
 
+_F = typing.TypeVar('_F', bound='FS', covariant=True)
+
+
 @six.python_2_unicode_compatible
-class SubFS(WrapFS[_FS], typing.Generic[_FS]):
+class SubFS(WrapFS[_F], typing.Generic[_F]):
     """A sub-directory on another filesystem.
 
     A SubFS is a filesystem object that maps to a sub-directory of
@@ -28,7 +30,7 @@ class SubFS(WrapFS[_FS], typing.Generic[_FS]):
     """
 
     def __init__(self, parent_fs, path):
-        # type: (_FS, Text) -> None
+        # type: (_F, Text) -> None
         super(SubFS, self).__init__(parent_fs)
         self._sub_dir = abspath(normpath(path))
 
@@ -48,16 +50,16 @@ class SubFS(WrapFS[_FS], typing.Generic[_FS]):
         )
 
     def delegate_fs(self):
-        # type: () -> _FS
+        # type: () -> _F
         return self._wrap_fs
 
     def delegate_path(self, path):
-        # type: (Text) -> Tuple[_FS, Text]
+        # type: (Text) -> Tuple[_F, Text]
         _path = join(self._sub_dir, relpath(normpath(path)))
         return self._wrap_fs, _path
 
 
-class ClosingSubFS(SubFS[_FS], typing.Generic[_FS]):
+class ClosingSubFS(SubFS[_F], typing.Generic[_F]):
     """A version of `SubFS` which closes its parent when closed.
     """
 

--- a/fs/subfs.py
+++ b/fs/subfs.py
@@ -11,7 +11,7 @@ import six
 from .wrapfs import WrapFS
 from .path import abspath, join, normpath, relpath
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Text, Tuple
     from .base import FS
 

--- a/fs/subfs.py
+++ b/fs/subfs.py
@@ -4,10 +4,16 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 import six
 
 from .wrapfs import WrapFS
 from .path import abspath, join, normpath, relpath
+
+if typing.TYPE_CHECKING:
+    from typing import Text, Tuple
+    from .base import FS
 
 
 @six.python_2_unicode_compatible
@@ -21,10 +27,12 @@ class SubFS(WrapFS):
     """
 
     def __init__(self, parent_fs, path):
+        # type: (FS, Text) -> None
         super(SubFS, self).__init__(parent_fs)
         self._sub_dir = abspath(normpath(path))
 
     def __repr__(self):
+        # type: () -> Text
         return "{}({!r}, {!r})".format(
             self.__class__.__name__,
             self._wrap_fs,
@@ -32,15 +40,18 @@ class SubFS(WrapFS):
         )
 
     def __str__(self):
+        # type: () -> Text
         return "{parent}{dir}".format(
             parent=self._wrap_fs,
             dir=self._sub_dir
         )
 
     def delegate_fs(self):
+        # type: () -> FS
         return self._wrap_fs
 
     def delegate_path(self, path):
+        # type: (Text) -> Tuple[FS, Text]
         _path = join(self._sub_dir, relpath(normpath(path)))
         return self._wrap_fs, _path
 
@@ -50,5 +61,6 @@ class ClosingSubFS(SubFS):
     """
 
     def close(self):
+        # type: () -> None
         self.delegate_fs().close()
         super(ClosingSubFS, self).close()

--- a/fs/subfs.py
+++ b/fs/subfs.py
@@ -8,6 +8,7 @@ import typing
 
 import six
 
+from .base import _FS
 from .wrapfs import WrapFS
 from .path import abspath, join, normpath, relpath
 
@@ -17,7 +18,7 @@ if typing.TYPE_CHECKING:
 
 
 @six.python_2_unicode_compatible
-class SubFS(WrapFS):
+class SubFS(WrapFS[_FS], typing.Generic[_FS]):
     """A sub-directory on another filesystem.
 
     A SubFS is a filesystem object that maps to a sub-directory of
@@ -27,7 +28,7 @@ class SubFS(WrapFS):
     """
 
     def __init__(self, parent_fs, path):
-        # type: (FS, Text) -> None
+        # type: (_FS, Text) -> None
         super(SubFS, self).__init__(parent_fs)
         self._sub_dir = abspath(normpath(path))
 
@@ -47,16 +48,16 @@ class SubFS(WrapFS):
         )
 
     def delegate_fs(self):
-        # type: () -> FS
+        # type: () -> _FS
         return self._wrap_fs
 
     def delegate_path(self, path):
-        # type: (Text) -> Tuple[FS, Text]
+        # type: (Text) -> Tuple[_FS, Text]
         _path = join(self._sub_dir, relpath(normpath(path)))
         return self._wrap_fs, _path
 
 
-class ClosingSubFS(SubFS):
+class ClosingSubFS(SubFS[_FS], typing.Generic[_FS]):
     """A version of `SubFS` which closes its parent when closed.
     """
 

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -368,6 +368,7 @@ class ReadTarFS(FS):
 
     def listdir(self, path):
         # type: (Text) -> List[Text]
+<<<<<<< HEAD
         _path = relpath(self.validatepath(path))
 
         if not self.gettype(path) is ResourceType.directory:
@@ -376,6 +377,22 @@ class ReadTarFS(FS):
         children = (frombase(_path, n) for n in self._directory if isbase(_path, n))
         content = (parts(child)[1] for child in children if relpath(child))
         return list(OrderedDict.fromkeys(content))
+=======
+        self.check()
+        _path = relpath(path)
+        info = self._directory.get(_path)
+        if _path:
+            if info is None:
+                raise errors.ResourceNotFound(path)
+            if not info.isdir():
+                raise errors.DirectoryExpected(path)
+        dir_list = [
+            basename(name)
+            for name in self._directory.keys()
+            if dirname(name) == _path
+        ]
+        return dir_list
+>>>>>>> Fix `makedir`, `makedirs` and `opendir` signatures where applicable
 
     def makedir(self,               # type: T
                 path,               # type: Text

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -23,7 +23,7 @@ from .path import dirname, relpath, basename, isbase, parts, frombase
 from .wrapfs import WrapFS
 from .permissions import Permissions
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from tarfile import TarInfo
     from typing import (
         Any, AnyStr, BinaryIO, Collection, Dict, List,
@@ -127,7 +127,7 @@ class TarFS(WrapFS):
         else:
             return ReadTarFS(file, encoding=encoding)
 
-    if typing.TYPE_CHECKING:
+    if False:  # typing.TYPE_CHECKING
         def __init__(self,
                      file,                         # type: Union[Text, BinaryIO]
                      write=False,                  # type: bool

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -368,7 +368,6 @@ class ReadTarFS(FS):
 
     def listdir(self, path):
         # type: (Text) -> List[Text]
-<<<<<<< HEAD
         _path = relpath(self.validatepath(path))
 
         if not self.gettype(path) is ResourceType.directory:
@@ -377,22 +376,6 @@ class ReadTarFS(FS):
         children = (frombase(_path, n) for n in self._directory if isbase(_path, n))
         content = (parts(child)[1] for child in children if relpath(child))
         return list(OrderedDict.fromkeys(content))
-=======
-        self.check()
-        _path = relpath(path)
-        info = self._directory.get(_path)
-        if _path:
-            if info is None:
-                raise errors.ResourceNotFound(path)
-            if not info.isdir():
-                raise errors.DirectoryExpected(path)
-        dir_list = [
-            basename(name)
-            for name in self._directory.keys()
-            if dirname(name) == _path
-        ]
-        return dir_list
->>>>>>> Fix `makedir`, `makedirs` and `opendir` signatures where applicable
 
     def makedir(self,               # type: T
                 path,               # type: Text

--- a/fs/tempfs.py
+++ b/fs/tempfs.py
@@ -32,12 +32,12 @@ class TempFS(OSFS):
     Arguments:
         identifier (str): A string to distinguish the directory within
             the OS temp location, used as part of the directory name.
-        temp_dir (str, optional): An OS path to your temp directory (leave
-            as `None` to auto-detect)
-        auto_clean (bool, optional): If `True` (the default), the directory
+        temp_dir (str, optional): An OS path to your temp directory
+            (leave as `None` to auto-detect)
+        auto_clean (bool): If `True` (the default), the directory
             contents will be wiped on close.
-        ignore_clean_errors (bool, optional): If `True` (the default), any
-            errors in the clean process will be suppressed. If `False`, they
+        ignore_clean_errors (bool): If `True` (the default), any errors
+            in the clean process will be suppressed. If `False`, they
             will be raised.
 
     """

--- a/fs/tempfs.py
+++ b/fs/tempfs.py
@@ -21,7 +21,7 @@ import six
 from . import errors
 from .osfs import OSFS
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import Optional, Text
 
 

--- a/fs/tempfs.py
+++ b/fs/tempfs.py
@@ -14,11 +14,15 @@ from __future__ import unicode_literals
 
 import shutil
 import tempfile
+import typing
 
 import six
 
 from . import errors
 from .osfs import OSFS
+
+if typing.TYPE_CHECKING:
+    from typing import Optional, Text
 
 
 @six.python_2_unicode_compatible
@@ -39,16 +43,18 @@ class TempFS(OSFS):
     """
 
     def __init__(self,
-                 identifier=None,
-                 temp_dir=None,
-                 auto_clean=True,
-                 ignore_clean_errors=True):
+                 identifier='__tempfs__',   # type: Text
+                 temp_dir=None,             # type: Optional[Text]
+                 auto_clean=True,           # type: bool
+                 ignore_clean_errors=True   # type: bool
+                 ):
+        # type: (...) -> None
         self.identifier = identifier
         self._auto_clean = auto_clean
         self._ignore_clean_errors = ignore_clean_errors
         self._cleaned = False
 
-        self.identifier = (identifier or '__tempfs__').replace('/', '-')
+        self.identifier = identifier.replace('/', '-')
 
         self._temp_dir = tempfile.mkdtemp(
             identifier or "fsTempFS",
@@ -57,17 +63,21 @@ class TempFS(OSFS):
         super(TempFS, self).__init__(self._temp_dir)
 
     def __repr__(self):
+        # type: () -> Text
         return "TempFS()"
 
     def __str__(self):
+        # type: () -> Text
         return "<tempfs '{}'>".format(self._temp_dir)
 
     def close(self):
+        # type: () -> None
         if self._auto_clean:
             self.clean()
         super(TempFS, self).close()
 
     def clean(self):
+        # type: () -> None
         """Clean (delete) temporary files created by this filesystem.
         """
         if self._cleaned:

--- a/fs/time.py
+++ b/fs/time.py
@@ -15,12 +15,14 @@ GMT = timezone('GMT')
 
 
 def datetime_to_epoch(d):
+    # type: (datetime) -> int
     """Convert datetime to epoch.
     """
     return timegm(d.utctimetuple())
 
 
 def epoch_to_datetime(t):
+    # type: (int) -> datetime
     """Convert epoch time to a UTC datetime.
     """
     return utclocalize(utcfromtimestamp(t)) if t is not None else None

--- a/fs/tools.py
+++ b/fs/tools.py
@@ -17,6 +17,7 @@ from .path import recursepath
 
 # type annotations
 if False:
+    from io import RawIOBase, IOBase
     from typing import *
     from .base import FS
 
@@ -40,7 +41,6 @@ def remove_empty(fs, path):
 
 
 def copy_file_data(src_file, dst_file, chunk_size=None):
-    # type: (IO, IO, Optional[int]) -> None
     """Copy data from one file object to another.
 
     Arguments:

--- a/fs/tools.py
+++ b/fs/tools.py
@@ -15,7 +15,7 @@ from .path import dirname
 from .path import normpath
 from .path import recursepath
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import IO, List, Optional, Text
     from .base import FS
 

--- a/fs/tools.py
+++ b/fs/tools.py
@@ -15,7 +15,14 @@ from .path import normpath
 from .path import recursepath
 
 
+# type annotations
+if False:
+    from typing import *
+    from .base import FS
+
+
 def remove_empty(fs, path):
+    # type: (FS, Text) -> None
     """Remove all empty parents.
 
     Arguments:
@@ -33,6 +40,7 @@ def remove_empty(fs, path):
 
 
 def copy_file_data(src_file, dst_file, chunk_size=None):
+    # type: (IO, IO, Optional[int]) -> None
     """Copy data from one file object to another.
 
     Arguments:
@@ -51,6 +59,7 @@ def copy_file_data(src_file, dst_file, chunk_size=None):
 
 
 def get_intermediate_dirs(fs, dir_path):
+    # type: (FS, Text) -> List[Text]
     """Get a list of non-existing intermediate directories.
 
     Arguments:

--- a/fs/tools.py
+++ b/fs/tools.py
@@ -45,7 +45,7 @@ def copy_file_data(src_file, dst_file, chunk_size=None):
     Arguments:
         src_file (io.IOBase): File open for reading.
         dst_file (io.IOBase): File open for writing.
-        chunk_size (int, optional): Number of bytes to copy at
+        chunk_size (int): Number of bytes to copy at
             a time (or `None` to use sensible default).
 
     """

--- a/fs/tools.py
+++ b/fs/tools.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import io
+import typing
 
 from . import errors
 from .errors import DirectoryNotEmpty
@@ -14,11 +15,8 @@ from .path import dirname
 from .path import normpath
 from .path import recursepath
 
-
-# type annotations
-if False:
-    from io import RawIOBase, IOBase
-    from typing import *
+if typing.TYPE_CHECKING:
+    from typing import IO, List, Optional, Text
     from .base import FS
 
 
@@ -41,6 +39,7 @@ def remove_empty(fs, path):
 
 
 def copy_file_data(src_file, dst_file, chunk_size=None):
+    # type: (IO, IO, Optional[int]) -> None
     """Copy data from one file object to another.
 
     Arguments:
@@ -50,11 +49,11 @@ def copy_file_data(src_file, dst_file, chunk_size=None):
             a time (or `None` to use sensible default).
 
     """
-    chunk_size = chunk_size or io.DEFAULT_BUFFER_SIZE
+    _chunk_size = chunk_size or io.DEFAULT_BUFFER_SIZE
     read = src_file.read
     write = dst_file.write
     # The 'or None' is so that it works with binary and text files
-    for chunk in iter(lambda: read(chunk_size) or None, None):
+    for chunk in iter(lambda: read(_chunk_size) or None, None):
         write(chunk)
 
 

--- a/fs/tree.py
+++ b/fs/tree.py
@@ -12,7 +12,7 @@ import typing
 
 from fs.path import abspath, join, normpath
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import List, Optional, Text, TextIO, Tuple
     from .base import FS
     from .info import Info

--- a/fs/tree.py
+++ b/fs/tree.py
@@ -8,19 +8,27 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import sys
+import typing
 
 from fs.path import abspath, join, normpath
 
+if typing.TYPE_CHECKING:
+    from typing import List, Optional, Text, TextIO, Tuple
+    from .base import FS
+    from .info import Info
+
 
 def render(fs,
-           path='/',
-           file=None,
-           encoding=None,
-           max_levels=5,
-           with_color=None,
-           dirs_first=True,
-           exclude=None,
-           filter=None):
+           path='/',            # type: Text
+           file=None,           # type: Optional[TextIO]
+           encoding=None,       # type: Optional[Text]
+           max_levels=5,        # type: int
+           with_color=None,     # type: Optional[bool]
+           dirs_first=True,     # type: bool
+           exclude=None,        # type: Optional[List[Text]]
+           filter=None          # type: Optional[List[Text]]
+           ):
+    # type: (...) -> Tuple[int, int]
     """Render a directory structure in to a pretty tree.
 
     Arguments:
@@ -69,11 +77,16 @@ def render(fs,
     line_indent = char_vertline + ' ' * 3
 
     def write(line):
+        # type: (Text) -> None
         """Write a line to the output.
         """
         print(line, file=file)
 
+    # FIXME(@althonos): define functions using `with_color` and
+    #      avoid checking `with_color` at every function call !
+
     def format_prefix(prefix):
+        # type: (Text) -> Text
         """Format the prefix lines.
         """
         if not with_color:
@@ -81,6 +94,7 @@ def render(fs,
         return '\x1b[32m%s\x1b[0m' % prefix
 
     def format_dirname(dirname):
+        # type: (Text) -> Text
         """Format a directory name.
         """
         if not with_color:
@@ -88,6 +102,7 @@ def render(fs,
         return '\x1b[1;34m%s\x1b[0m' % dirname
 
     def format_error(msg):
+        # type: (Text) -> Text
         """Format an error.
         """
         if not with_color:
@@ -95,6 +110,7 @@ def render(fs,
         return '\x1b[31m%s\x1b[0m' % msg
 
     def format_filename(fname):
+        # type: (Text) -> Text
         """Format a filename.
         """
         if not with_color:
@@ -104,11 +120,13 @@ def render(fs,
         return fname
 
     def sort_key_dirs_first(info):
+        # type: (Info) -> Tuple[bool, Text]
         """Get the info sort function with directories first.
         """
         return (not info.is_dir, info.name.lower())
 
     def sort_key(info):
+        # type: (Info) -> Text
         """Get the default info sort function using resource name.
         """
         return info.name.lower()
@@ -116,6 +134,7 @@ def render(fs,
     counts = {"dirs": 0, "files": 0}
 
     def format_directory(path, levels):
+        # type: (Text, List[bool]) -> None
         """Recursive directory function.
         """
         try:

--- a/fs/tree.py
+++ b/fs/tree.py
@@ -18,7 +18,7 @@ if typing.TYPE_CHECKING:
     from .info import Info
 
 
-def render(fs,
+def render(fs,                  # type: FS
            path='/',            # type: Text
            file=None,           # type: Optional[TextIO]
            encoding=None,       # type: Optional[Text]

--- a/fs/tree.py
+++ b/fs/tree.py
@@ -37,16 +37,16 @@ def render(fs,
             from (defaults to root folder, i.e. ``'/'``).
         file (io.IOBase): An open file-like object to render the
             tree, or `None` for stdout.
-        encoding (str or None): Unicode encoding, or `None` to
+        encoding (str, optional): Unicode encoding, or `None` to
             auto-detect.
-        max_levels (int or None): Maximum number of levels to
+        max_levels (int, optional): Maximum number of levels to
             display, or `None` for no maximum.
-        with_color (bool or None): Enable terminal color output,
+        with_color (bool, optional): Enable terminal color output,
             or `None` to auto-detect terminal.
         dirs_first (bool): Show directories first.
-        exclude (list or None): Option list of directory patterns
+        exclude (list, optional): Option list of directory patterns
             to exclude from the tree render.
-        filter (list or None): Optional list of files patterns to
+        filter (list, optional): Optional list of files patterns to
             match in the tree render.
 
     Returns:

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -20,7 +20,7 @@ from .path import abspath
 from .path import join
 from .path import normpath
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import (
         Any, Callable, Collection, Iterator, List,
         Optional, MutableMapping, Text, Tuple, Type)

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -25,6 +25,9 @@ Step = namedtuple('Step', 'path, dirs, files')
 """
 
 
+# TODO(@althonos): It could be a good idea to create an Abstract Base Class
+#                  BaseWalker (with methods walk, files, dirs and info) ?
+
 class Walker(object):
     """A walker object recursively lists directories in a filesystem.
 

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -444,7 +444,7 @@ class Walker(object):
                     yield dir_path, info
 
 
-class BoundWalker(object, typing.Generic[_F]):
+class BoundWalker(typing.Generic[_F]):
     """A class that binds a `Walker` instance to a `FS` instance.
 
     Arguments:

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -37,20 +37,21 @@ class Walker(object):
     """A walker object recursively lists directories in a filesystem.
 
     Arguments:
-        ignore_errors (bool, optional): If `True`, any errors reading
-            a directory will be ignored, otherwise exceptions will be
-            raised.
+        ignore_errors (bool): If `True`, any errors reading a
+            directory will be ignored, otherwise exceptions will
+            be raised.
         on_error (callable, optional): If ``ignore_errors`` is `False`,
             then this callable will be invoked for a path and the exception
             object. It should return `True` to ignore the error, or `False`
             to re-raise it.
-        search (str, optional): If ``'breadth'`` then the directory will be
+        search (str): If ``'breadth'`` then the directory will be
             walked *top down*. Set to ``'depth'`` to walk *bottom up*.
-        filter (list, optional): If supplied, this parameter should be a
-            list of filename patterns, e.g. ``['*.py']``. Files will only
-            be returned if the final component matches one of the patterns.
-        exclude_dirs (list, optional): A list of patterns that will be used
-            to filter out directories from the walk. e.g.
+        filter (list, optional): If supplied, this parameter should be
+            a list of filename patterns, e.g. ``['*.py']``. Files will
+            only be returned if the final component matches one of the
+            patterns.
+        exclude_dirs (list, optional): A list of patterns that will be
+            used to filter out directories from the walk. e.g.
             ``['*.svn', '*.git']``.
         max_depth (int, optional): Maximum directory depth to walk.
 
@@ -248,7 +249,7 @@ class Walker(object):
 
         Arguments:
             fs (FS): A filesystem instance.
-            path (str, optional): A path to a directory on the filesystem.
+            path (str): A path to a directory on the filesystem.
             namespaces (list, optional): A list of additional namespaces
                 to add to the `Info` objects.
 
@@ -290,7 +291,7 @@ class Walker(object):
 
         Arguments:
             fs (FS): A filesystem instance.
-            path (str, optional): A path to a directory on the filesystem.
+            path (str): A path to a directory on the filesystem.
 
         Yields:
             str: absolute path to files on the filesystem found
@@ -306,7 +307,7 @@ class Walker(object):
 
         Arguments:
             fs (FS): A filesystem instance.
-            path (str, optional): A path to a directory on the filesystem.
+            path (str): A path to a directory on the filesystem.
 
         Yields:
             str: absolute path to directories on the filesystem found
@@ -322,7 +323,7 @@ class Walker(object):
 
         Arguments:
             fs (FS): A filesystem instance.
-            path (str, optional): A path to a directory on the filesystem.
+            path (str): A path to a directory on the filesystem.
             namespaces (list, optional): A list of additional namespaces
                 to add to the `Info` objects.
 
@@ -397,7 +398,7 @@ class BoundWalker(object):
 
     Arguments:
         fs (FS): A filesystem instance.
-        walker_class (type, optional): A `~fs.walk.WalkerBase`
+        walker_class (type): A `~fs.walk.WalkerBase`
             sub-class. The default uses `~fs.walk.Walker`.
 
     You will typically not need to create instances of this class
@@ -435,7 +436,7 @@ class BoundWalker(object):
         """Walk the directory structure of a filesystem.
 
         Arguments:
-            path (str, optional):
+            path (str):
             namespaces (list, optional): A list of namespaces to include
                 in the resource information, e.g. ``['basic', 'access']``
                 (defaults to ``['basic']``).
@@ -552,7 +553,7 @@ class BoundWalker(object):
         """Walk a filesystem, yielding path and `Info` of resources.
 
         Arguments:
-            path (str, optional):
+            path (str): A path to a directory.
             namespaces (list, optional): A list of namespaces to include
                 in the resource information, e.g. ``['basic', 'access']``
                 (defaults to ``['basic']``).

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -20,6 +20,11 @@ from .path import join
 from .path import normpath
 
 
+if False:  # typing imports
+    from typing import *
+    from .info import Info
+
+
 Step = namedtuple('Step', 'path, dirs, files')
 """type: a *step* in a directory walk.
 """
@@ -267,12 +272,12 @@ class Walker(object):
 
         """
         _path = abspath(normpath(path))
-        dir_info = defaultdict(list)
+        dir_info = defaultdict(list)  # type: MutableMapping[Text, List[Info]]
         _walk = self._iter_walk(fs, _path, namespaces=namespaces)
         for dir_path, info in _walk:
             if info is None:
-                dirs = []
-                files = []
+                dirs = []       # type: List[Info]
+                files = []      # type: List[Info]
                 for _info in dir_info[dir_path]:
                     (dirs if _info.is_dir else files).append(_info)
                 yield Step(dir_path, dirs, files)
@@ -358,11 +363,12 @@ class Walker(object):
         # No recursion!
 
         def scan(path):
+            # type: (Text) -> Iterator[Info]
             """Perform scan."""
             return self._scan(fs, path, namespaces=namespaces)
 
+        stack = [(path, scan(path), None)]  # type: List[Tuple[Text, Iterator[Info], Optional[Tuple[Text, Info]]]]
         depth = self._calculate_depth(path)
-        stack = [(path, scan(path), None)]
         push = stack.append
 
         while stack:

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -5,17 +5,19 @@
 from __future__ import unicode_literals
 
 import re
+import typing
 from functools import partial
 
 from .lrucache import LRUCache
 
+if typing.TYPE_CHECKING:  # typing imports
+    from typing import (
+        Callable, Iterable, MutableMapping, Text,
+        Tuple, Pattern)
 
-if False:  # typing imports
-    from typing import *
 
 _MAXCACHE = 1000
 _PATTERN_CACHE = LRUCache(_MAXCACHE)  # type: MutableMapping[Tuple[Text, bool], Pattern]
-
 
 
 def match(pattern, name):

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -17,7 +17,7 @@ if typing.TYPE_CHECKING:  # typing imports
 
 
 _MAXCACHE = 1000
-_PATTERN_CACHE = LRUCache(_MAXCACHE)  # type: MutableMapping[Tuple[Text, bool], Pattern]
+_PATTERN_CACHE = LRUCache(_MAXCACHE)  # type: LRUCache[Tuple[Text, bool], Pattern]
 
 
 def match(pattern, name):

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -9,16 +9,22 @@ from functools import partial
 
 from .lrucache import LRUCache
 
+
+if False:  # typing imports
+    from typing import Iterable, Text, Callable
+
 _MAXCACHE = 1000
 _PATTERN_CACHE = LRUCache(_MAXCACHE)
 
 
+
 def match(pattern, name):
+    # type: (Text, Text) -> bool
     """Test whether a name matches a wildcard pattern.
 
     Arguments:
         pattern (str): A wildcard pattern, e.g. ``"*.py"``.
-        name (bool): A filename.
+        name (str): A filename.
 
     Returns:
         bool: `True` if the filename matches the pattern.
@@ -33,6 +39,7 @@ def match(pattern, name):
 
 
 def imatch(pattern, name):
+    # type: (Text, Text) -> bool
     """Test whether a name matches a wildcard pattern (case insensitive).
 
     Arguments:
@@ -53,6 +60,7 @@ def imatch(pattern, name):
 
 
 def match_any(patterns, name):
+    # type: (Iterable[Text], Text) -> bool
     """Test if a name matches any of a list of patterns.
 
     Will return `True` if ``patterns`` is an empty list.
@@ -72,6 +80,7 @@ def match_any(patterns, name):
 
 
 def imatch_any(patterns, name):
+    # type: (Iterable[Text], Text) -> bool
     """Test if a name matches any of a list of patterns (case insensitive).
 
     Will return `True` if ``patterns`` is an empty list.
@@ -91,6 +100,7 @@ def imatch_any(patterns, name):
 
 
 def get_matcher(patterns, case_sensitive):
+    # type: (Iterable[Text], bool) -> Callable[[Text], bool]
     """Get a callable that matches names against the given patterns.
 
     Arguments:
@@ -121,6 +131,7 @@ def get_matcher(patterns, case_sensitive):
 
 
 def _translate(pattern, case_sensitive=True):
+    # type: (Text, bool) -> Text
     """Translate a wildcard pattern to a regular expression.
 
     There is no way to quote meta-characters.

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -140,8 +140,8 @@ def _translate(pattern, case_sensitive=True):
 
     Arguments:
         pattern (str): A wildcard pattern.
-        case_sensitive (bool, optional): Set to `False` to use a
-            case insensitive regex (default `True`).
+        case_sensitive (bool): Set to `False` to use a case
+            insensitive regex (default `True`).
 
     Returns:
         str: A regex equivalent to the given pattern.

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -11,10 +11,10 @@ from .lrucache import LRUCache
 
 
 if False:  # typing imports
-    from typing import Iterable, Text, Callable
+    from typing import *
 
 _MAXCACHE = 1000
-_PATTERN_CACHE = LRUCache(_MAXCACHE)
+_PATTERN_CACHE = LRUCache(_MAXCACHE)  # type: MutableMapping[Tuple[Text, bool], Pattern]
 
 
 

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -10,7 +10,7 @@ from functools import partial
 
 from .lrucache import LRUCache
 
-if typing.TYPE_CHECKING:  # typing imports
+if False:  # typing.TYPE_CHECKING
     from typing import (
         Callable, Iterable, MutableMapping, Text,
         Tuple, Pattern)

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -16,16 +16,17 @@ Here's an example that opens a filesystem then makes it *read only*::
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 from .wrapfs import WrapFS
 from .path import abspath, normpath, split
 from .errors import ResourceReadOnly, ResourceNotFound
 from .info import Info
 from .mode import check_writable
 
-
-if False:  # typing imports
+if typing.TYPE_CHECKING:
     from datetime import datetime
-    from typing import *
+    from typing import Dict, Text, Tuple
     from .base import FS
     from .info import Info
     from .permissions import Permissions

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -163,6 +163,7 @@ class WrapReadOnly(WrapFS[_FS], typing.Generic[_FS]):
                    errors=None,         # type: Optional[Text]
                    newline=''           # type: Text
                    ):
+        # type: (...) -> None
         self.check()
         raise ResourceReadOnly(path)
 
@@ -214,6 +215,7 @@ class WrapReadOnly(WrapFS[_FS], typing.Generic[_FS]):
                 errors=None,        # type: Optional[Text]
                 newline=''          # type: Text
                 ):
+        # type: (...) -> None
         self.check()
         raise ResourceReadOnly(path)
 
@@ -251,7 +253,7 @@ class WrapReadOnly(WrapFS[_FS], typing.Generic[_FS]):
              line_buffering=False,     # type: bool
              **options                 # type: Any
              ):
-        # type(...) -> IO
+        # type: (...) -> IO
         self.check()
         if check_writable(mode):
             raise ResourceReadOnly(path)

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals
 
 import typing
 
-from .base import _FS
 from .wrapfs import WrapFS
 from .path import abspath, normpath, split
 from .errors import ResourceReadOnly, ResourceNotFound
@@ -34,11 +33,15 @@ if typing.TYPE_CHECKING:
     from .info import Info, RawInfo
     from .subfs import SubFS
     from .permissions import Permissions
-    W = typing.TypeVar("W", bound='WrapFS')
+
+
+_W = typing.TypeVar("_W", bound='WrapFS')
+_T = typing.TypeVar('_T', bound='FS')
+_F = typing.TypeVar('_F', bound='FS', covariant=True)
 
 
 def read_only(fs):
-    # type: (_FS) -> WrapReadOnly[_FS]
+    # type: (_T) -> WrapReadOnly[_T]
     """Make a read-only filesystem.
 
     Arguments:
@@ -52,7 +55,7 @@ def read_only(fs):
 
 
 def cache_directory(fs):
-    # type: (_FS) -> WrapCachedDir[_FS]
+    # type: (_T) -> WrapCachedDir[_T]
     """Make a filesystem that caches directory information.
 
     Arguments:
@@ -66,7 +69,7 @@ def cache_directory(fs):
     return WrapCachedDir(fs)
 
 
-class WrapCachedDir(WrapFS[_FS], typing.Generic[_FS]):
+class WrapCachedDir(WrapFS[_F], typing.Generic[_F]):
     """Caches filesystem directory information.
 
     This filesystem caches directory information retrieved from a
@@ -84,7 +87,7 @@ class WrapCachedDir(WrapFS[_FS], typing.Generic[_FS]):
     wrap_name = 'cached-dir'
 
     def __init__(self, wrap_fs):
-        # type: (_FS) -> None
+        # type: (_F) -> None
         super(WrapCachedDir, self).__init__(wrap_fs)
         self._cache = {}  # type: Dict[Tuple[Text, frozenset], Dict[Text, Info]]
 
@@ -141,7 +144,7 @@ class WrapCachedDir(WrapFS[_FS], typing.Generic[_FS]):
         return not self.getinfo(path).is_dir
 
 
-class WrapReadOnly(WrapFS[_FS], typing.Generic[_FS]):
+class WrapReadOnly(WrapFS[_F], typing.Generic[_F]):
     """Makes a Filesystem read-only.
 
     Any call that would would write data or modify the filesystem in any way
@@ -167,12 +170,12 @@ class WrapReadOnly(WrapFS[_FS], typing.Generic[_FS]):
         self.check()
         raise ResourceReadOnly(path)
 
-    def makedir(self,               # type: W
+    def makedir(self,               # type: _W
                 path,               # type: Text
                 permissions=None,   # type: Optional[Permissions]
                 recreate=False      # type: bool
                 ):
-        # type: (...) -> SubFS[W]
+        # type: (...) -> SubFS[_W]
         self.check()
         raise ResourceReadOnly(path)
 
@@ -234,12 +237,12 @@ class WrapReadOnly(WrapFS[_FS], typing.Generic[_FS]):
         self.check()
         raise ResourceReadOnly(path)
 
-    def makedirs(self,                  # type: W
+    def makedirs(self,                  # type: _W
                  path,                  # type: Text
                  permissions=None,      # type: Optional[Permissions]
                  recreate=False         # type: bool
                  ):
-        # type: (...) -> SubFS[W]
+        # type: (...) -> SubFS[_W]
         self.check()
         raise ResourceReadOnly(path)
 

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -232,8 +232,12 @@ class WrapReadOnly(WrapFS[_FS], typing.Generic[_FS]):
         self.check()
         raise ResourceReadOnly(path)
 
-    def makedirs(self, path, recreate=False, mode=0o777):
-        # type: (W, Text, bool, int) -> SubFS[W]
+    def makedirs(self,                  # type: W
+                 path,                  # type: Text
+                 permissions=None,      # type: Optional[Permissions]
+                 recreate=False         # type: bool
+                 ):
+        # type: (...) -> SubFS[W]
         self.check()
         raise ResourceReadOnly(path)
 

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -24,7 +24,7 @@ from .errors import ResourceReadOnly, ResourceNotFound
 from .info import Info
 from .mode import check_writable
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from datetime import datetime
     from typing import (
         Any, BinaryIO, Collection, Dict, Iterator, IO,

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -23,7 +23,16 @@ from .info import Info
 from .mode import check_writable
 
 
+if False:  # typing imports
+    from datetime import datetime
+    from typing import *
+    from .base import FS
+    from .info import Info
+    from .permissions import Permissions
+
+
 def read_only(fs):
+    # type: (FS) -> WrapReadOnly
     """Make a read-only filesystem.
 
     Arguments:
@@ -37,6 +46,7 @@ def read_only(fs):
 
 
 def cache_directory(fs):
+    # type: (FS) -> WrapCachedDir
     """Make a filesystem that caches directory information.
 
     Arguments:
@@ -68,10 +78,16 @@ class WrapCachedDir(WrapFS):
     wrap_name = 'cached-dir'
 
     def __init__(self, wrap_fs):
+        # type: (FS) -> None
         super(WrapCachedDir, self).__init__(wrap_fs)
-        self._cache = {}
+        self._cache = {}  # type: Dict[Tuple[Text, frozenset], Dict[Text, Info]]
 
-    def scandir(self, path, namespaces=None, page=None):
+    def scandir(self,
+                path,               # type: Text
+                namespaces=None,    # type: Optional[Collection[Text]]
+                page=None           # type: Optional[Tuple[int, int]]
+                ):
+        # type: (...) -> Iterator[Info]
         _path = abspath(normpath(path))
         cache_key = (_path, frozenset(namespaces or ()))
         if cache_key not in self._cache:
@@ -85,7 +101,8 @@ class WrapCachedDir(WrapFS):
         gen_scandir = iter(self._cache[cache_key].values())
         return gen_scandir
 
-    def getinfo(self, path, *namespaces):
+    def getinfo(self, path, namespaces=None):
+        # type: (Text, Optional[Collection[Text]]) -> Info
         _path = abspath(normpath(path))
         if _path == '/':
             return Info({
@@ -108,9 +125,13 @@ class WrapCachedDir(WrapFS):
         return info
 
     def isdir(self, path):
+        # type: (Text) -> bool
+        # FIXME(@althonos): this raises an error on non-existing file !
         return self.getinfo(path).is_dir
 
     def isfile(self, path):
+        # type: (Text) -> bool
+        # FIXME(@althonos): this raises an error on non-existing file !
         return not self.getinfo(path).is_dir
 
 
@@ -125,23 +146,32 @@ class WrapReadOnly(WrapFS):
     wrap_name = 'read-only'
 
     def appendbytes(self, path, data):
+        # type: (Text, bytes) -> None
         self.check()
         raise ResourceReadOnly(path)
 
-    def appendtext(self, path, text,
-                   encoding='utf-8', errors=None, newline=''):
+    def appendtext(self,
+                   path,                # type: Text
+                   text,                # type: Text
+                   encoding='utf-8',    # type: Text
+                   errors=None,         # type: Optional[Text]
+                   newline=''           # type: Text
+                   ):
         self.check()
         raise ResourceReadOnly(path)
 
     def makedir(self, path, permissions=None, recreate=False):
+        # type: (Text, Optional[Permissions], bool) -> FS
         self.check()
         raise ResourceReadOnly(path)
 
     def move(self, src_path, dst_path, overwrite=False):
+        # type: (Text, Text, bool) -> None
         self.check()
         raise ResourceReadOnly(dst_path)
 
     def openbin(self, path, mode='r', buffering=-1, **options):
+        # type: (Text, Text, int, **Any) -> BinaryIO
         self.check()
         if check_writable(mode):
             raise ResourceReadOnly(path)
@@ -153,51 +183,61 @@ class WrapReadOnly(WrapFS):
         )
 
     def remove(self, path):
+        # type: (Text) -> None
         self.check()
         raise ResourceReadOnly(path)
 
     def removedir(self, path):
+        # type: (Text) -> None
         self.check()
         raise ResourceReadOnly(path)
 
     def setinfo(self, path, info):
+        # type: (Text, dict) -> None
         self.check()
         raise ResourceReadOnly(path)
 
     def settext(self,
-                path,
-                contents,
-                encoding='utf-8',
-                errors=None,
-                newline=''):
+                path,               # type: Text
+                contents,           # type: Text
+                encoding='utf-8',   # type: Text
+                errors=None,        # type: Optional[Text]
+                newline=''          # type: Text
+                ):
         self.check()
         raise ResourceReadOnly(path)
 
     def settimes(self, path, accessed=None, modified=None):
+        # type: (Text, Optional[datetime], Optional[datetime]) -> None
         self.check()
         raise ResourceReadOnly(path)
 
     def copy(self, src_path, dst_path, overwrite=False):
+        # type: (Text, Text, bool) -> None
         self.check()
         raise ResourceReadOnly(dst_path)
 
     def create(self, path, wipe=False):
+        # type: (Text, bool) -> bool
         self.check()
         raise ResourceReadOnly(path)
 
     def makedirs(self, path, recreate=False, mode=0o777):
+        # type: (Text, bool, int) -> None
         self.check()
         raise ResourceReadOnly(path)
 
     def open(self,
-             path,
-             mode='r',
-             buffering=-1,
-             encoding=None,
-             errors=None,
-             newline='',
-             line_buffering=False,
-             **options):
+             path,                     # type: Text
+             mode='r',                 # type: Text
+             buffering=-1,             # type: int
+             encoding=None,            # type: Optional[Text]
+             errors=None,              # type: Optional[Text]
+             newline='',               # type: Text
+             line_buffering=False,     # type: bool
+             **options                 # type: Any
+             ):
+        # type(...) -> IO
         self.check()
         if check_writable(mode):
             raise ResourceReadOnly(path)
@@ -213,22 +253,27 @@ class WrapReadOnly(WrapFS):
         )
 
     def setbytes(self, path, contents):
+        # type: (Text, bytes) -> None
         self.check()
         raise ResourceReadOnly(path)
 
     def setbinfile(self, path, file):
+        # type: (Text, BinaryIO) -> None
         self.check()
         raise ResourceReadOnly(path)
 
     def setfile(self,
-                path,
-                file,
-                encoding=None,
-                errors=None,
-                newline=''):
+                path,           # type: Text
+                file,           # type: IO
+                encoding=None,  # type: Optional[Text]
+                errors=None,    # type: Optional[Text]
+                newline=''      # type: Text
+                ):
+        # type: (...) -> None
         self.check()
         raise ResourceReadOnly(path)
 
     def touch(self, path):
+        # type: (Text) -> None
         self.check()
         raise ResourceReadOnly(path)

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -16,7 +16,7 @@ from .move import move_file
 from .path import abspath, normpath
 from .error_tools import unwrap_errors
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from datetime import datetime
     from threading import RLock
     from typing import (

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -323,7 +323,7 @@ class WrapFS(FS, typing.Generic[_F]):
         return meta
 
     def getsize(self, path):
-        # type: (Text) -> Optional[int]
+        # type: (Text) -> int
         self.check()
         _fs, _path = self.delegate_path(path)
         with unwrap_errors(path):

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -23,12 +23,14 @@ if False:  # typing.TYPE_CHECKING
         Any, AnyStr, BinaryIO, Callable, Collection, Dict,
         Iterator, Iterable, IO, List, Mapping, Optional,
         Text, TextIO, Tuple, Union)
-    from .base import _OpendirFactory
     from .enums import ResourceType
     from .info import RawInfo
     from .permissions import Permissions
     from .subfs import SubFS
     from .walk import BoundWalker
+
+    _T = typing.TypeVar('_T', bound='FS')
+    _OpendirFactory = Callable[[_T, Text], SubFS[_T]]
 
 
 _F = typing.TypeVar('_F', bound='FS', covariant=True)

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -14,6 +14,12 @@ from .path import abspath, normpath
 from .error_tools import unwrap_errors
 
 
+if False:  # typing imports
+    from typing import Optional, Text, Tuple
+    from .base import FS
+
+
+
 @six.python_2_unicode_compatible
 class WrapFS(FS):
     """A proxy for a filesystem object.
@@ -24,9 +30,10 @@ class WrapFS(FS):
 
     """
 
-    wrap_name = None
+    wrap_name = None    # type: Optional[Text]
 
     def __init__(self, wrap_fs):
+        # type: (FS) -> None
         self._wrap_fs = wrap_fs
         super(WrapFS, self).__init__()
 
@@ -51,6 +58,7 @@ class WrapFS(FS):
         return _str
 
     def delegate_path(self, path):
+        # type: (Text) -> Tuple[FS, Text]
         """Encode a path for proxied filesystem.
 
         Arguments:
@@ -63,6 +71,7 @@ class WrapFS(FS):
         return self._wrap_fs, path
 
     def delegate_fs(self):
+        # type: () -> FS
         """Get the proxied filesystem.
 
         This method should return a filesystem for methods not
@@ -401,4 +410,3 @@ class WrapFS(FS):
     @property
     def walk(self):
         return self._wrap_fs.walker_class.bind(self)
-

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -200,7 +200,7 @@ class WriteZipFS(WrapFS):
         self.encoding = encoding
         self._temp_fs_url = temp_fs
         self._temp_fs = open_fs(temp_fs)
-        self._meta = self._temp_fs.getmeta().copy()
+        self._meta = dict(self._temp_fs.getmeta())  # type: ignore
         super(WriteZipFS, self).__init__(self._temp_fs)
 
     def __repr__(self):

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -19,7 +19,7 @@ from .iotools import RawWrapper
 from .permissions import Permissions
 from .memoryfs import MemoryFS
 from .opener import open_fs
-from .path import dirname, normpath, relpath
+from .path import dirname, forcedir, normpath, relpath
 from .time import datetime_to_epoch
 from .wrapfs import WrapFS
 
@@ -300,15 +300,12 @@ class ReadZipFS(FS):
         # type: (Text) -> str
         """Convert a path to a zip file name.
         """
+        path = relpath(normpath(path))
         if self._directory.isdir(path):
-            _path = relpath(normpath(path)) + '/'
-        else:
-            _path = relpath(normpath(path))
-        return (                                # type: ignore
-            _path.encode(self.encoding)
-            if six.PY2 else
-            _path
-        )
+            path = forcedir(path)
+        if six.PY2:
+            return path.encode(self.encoding)
+        return path
 
     @property
     def _directory(self):

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -144,12 +144,12 @@ class ZipFS(WrapFS):
 
     Arguments:
         file (str or io.IOBase): An OS filename, or an open file object.
-        write (bool, optional): Set to `True` to write a new zip file, or
-            `False` (default) to read an existing zip file.
-        compression (str, optional): Compression to use (one of the constants
+        write (bool): Set to `True` to write a new zip file, or `False`
+            (default) to read an existing zip file.
+        compression (int): Compression to use (one of the constants
             defined in the `zipfile` module in the stdlib).
-        temp_fs (str, optional): An FS URL for the temporary
-            filesystem used to store data prior to zipping.
+        temp_fs (str): An FS URL for the temporary filesystem used to
+            store data prior to zipping.
 
     """
 
@@ -245,7 +245,7 @@ class WriteZipFS(WrapFS):
         Arguments:
             file (str or io.IOBase, optional): Destination file, may be
                 a file name or an open file handle.
-            compression (str, optional): Compression to use (one of the
+            compression (int, optional): Compression to use (one of the
                 constants defined in the `zipfile` module in the stdlib).
             encoding (str, optional): The character encoding to use
                 (default uses the encoding defined in

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -28,6 +28,8 @@ if typing.TYPE_CHECKING:
         Any, BinaryIO, Collection, Dict, List, Optional,
         SupportsInt, Text, Tuple, Union)
     from .info import RawInfo
+    from .subfs import SubFS
+    R = typing.TypeVar("R", bound="ReadZipFS")
 
 
 class _ZipExtFile(RawWrapper):
@@ -400,8 +402,12 @@ class ReadZipFS(FS):
         self.check()
         return self._directory.listdir(path)
 
-    def makedir(self, path, permissions=None, recreate=False):
-        # type: (Text, Optional[Permissions], bool) -> FS
+    def makedir(self,               # type: R
+                path,               # type: Text
+                permissions=None,   # type: Optional[Permissions]
+                recreate=False      # type: bool
+                ):
+        # type: (...) -> SubFS[R]
         self.check()
         raise errors.ResourceReadOnly(path)
 

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -49,7 +49,7 @@ class _ZipExtFile(RawWrapper):
 
     def read1(self, size=-1):
         # type: (int) -> bytes
-        buf = self._f.read1(-1 if size is None else size)
+        buf = self._f.read1(-1 if size is None else size)   # type: ignore
         self._pos += len(buf)
         return buf
 
@@ -101,7 +101,7 @@ class _ZipExtFile(RawWrapper):
             )
 
         if offset < self._pos:
-            self._f = self._zip.open(self.name)
+            self._f = self._zip.open(self.name)  # type: ignore
             self._pos = 0
         self.read(offset - self._pos)
         return self._pos

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -23,7 +23,7 @@ from .path import dirname, forcedir, normpath, relpath
 from .time import datetime_to_epoch
 from .wrapfs import WrapFS
 
-if typing.TYPE_CHECKING:
+if False:  # typing.TYPE_CHECKING
     from typing import (
         Any, BinaryIO, Collection, Dict, List, Optional,
         SupportsInt, Text, Tuple, Union)
@@ -171,7 +171,7 @@ class ZipFS(WrapFS):
         else:
             return ReadZipFS(file, encoding=encoding)
 
-    if typing.TYPE_CHECKING:
+    if False:  # typing.TYPE_CHECKING
         def __init__(self,
                      file,                              # type: Union[Text, BinaryIO]
                      write=False,                       # type: bool

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Credits
 -------
 
 * [Will McGugan](https://github.com/willmcgugan)
-* [Martin Larralde](https://github.com/althonos) for TarFS
+* [Martin Larralde](https://github.com/althonos)
 * [Giampaolo](https://github.com/gpcimino) for `copy_if_newer` and ftp fixes.
 
 PyFilesystem2 owes a massive debt of gratitude to the following

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ enum34==1.1.6 ; python_version < '3.4'
 pytz
 setuptools
 six==1.10.0
+typing==3.6.4 ; python_version < '3.5'

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,9 @@ inherit = false
 ignore = D102,D105,D200,D203,D213,D406,D407
 match-dir = (?!tests)(?!docs)[^\.].*
 match = (?!test)(?!setup)[^\._].*\.py
+
+[coverage:report]
+show_missing = true
+exclude_lines =
+        pragma: no cover
+        if False

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ match = (?!test)(?!setup)[^\._].*\.py
 show_missing = true
 exclude_lines =
         pragma: no cover
-        if typing.TYPE_CHECKING
+        typing.TYPE_CHECKING
 
 [mypy]
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,4 +14,4 @@ match = (?!test)(?!setup)[^\._].*\.py
 show_missing = true
 exclude_lines =
         pragma: no cover
-        if False
+        if typing.TYPE_CHECKING

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,20 @@ show_missing = true
 exclude_lines =
         pragma: no cover
         if typing.TYPE_CHECKING
+
+[mypy]
+ignore_missing_imports = true
+
+[mypy-fs.*]
+disallow_any_decorated = false
+disallow_any_generics = false
+disallow_any_unimported = true
+disallow_subclassing_any = true
+disallow_untyped_calls = false
+disallow_untyped_defs = false
+ignore_missing_imports = false
+warn_unused_ignores = false
+warn_return_any = false
+
+[mypy-fs.test]
+disallow_untyped_defs = false

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
     install_requires=REQUIREMENTS,
     extras_require={
         "scandir :python_version < '3.5'": ['scandir~=1.5'],
-        ":python_version < '3.4'": ['enum34~=1.1.6']
+        ":python_version < '3.4'": ['enum34~=1.1.6'],
+        ":python_version < '3.5'": ['typing~=3.6'],
     },
     entry_points={'fs.opener': [
         'ftp  = fs.opener.ftpfs:FTPOpener',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     extras_require={
         "scandir :python_version < '3.5'": ['scandir~=1.5'],
         ":python_version < '3.4'": ['enum34~=1.1.6'],
-        ":python_version < '3.5'": ['typing~=3.6'],
+        ":python_version < '3.6'": ['typing~=3.6'],
     },
     entry_points={'fs.opener': [
         'ftp  = fs.opener.ftpfs:FTPOpener',


### PR DESCRIPTION
Hi Will,

this is not really a PR for now, but just a notice that I'm working on adding typechecks to Pyfilesystem2.

I have tried them in a [side project of mine](https://github.com/althonos/InstaLooter) (which I also ported to use Pyfilesystem, mind you :wink:), and I think it should be interesting to have them for both finding bugs and for the end users to use type checkers as well. Since `fs` is actually quite strongly-typed this should not be *extremely* difficult (I hope I won't be deleting this sentence in a month).

I've added types to the `FS` base class, and just by doing that I was able to find the following bug (which is, IMO, the main perk of using them):

```
fs/appfs.py:48: error: Cannot assign to a method
```

*I'm also updating docstrings when I can, since I was a bit too excited to put *optional* everywhere; it should be used only to denote `None` is an acceptable value for an argument, not that a argument is a default argument !*

## Errors

* `fs.appfs`: overwriting `create` method with attribute in `AppFS.__init__` (**FIXED**)
* `WrapReadOnly.makedirs` arguments are not in the same order as in `FS.makedirs` (**FIXED**)
* `Info.__eq__` only works with objects that have a `raw` attribute (**FIXED**)
* `FTPFS.create` should return something, but doesn't (**FIXED**)
* `Info.size` is advertised to be always int, but can be `None` sometimes (**FIXED**, return type of `getsize` is `int`)
* `WrapFS` does not respect some `FS` signatures (**FIXED**)
* `WrapFS.filterdir` have wrong parameters order and type (**FIXED**)