### PR TITLE
Fix wrong type in `test_open_files`

### DIFF
--- a/fs/test.py
+++ b/fs/test.py
@@ -877,7 +877,7 @@ class FSTestCases(object):
                 [b'Hello\n', b'World\n']
             )
             with self.assertRaises(IOError):
-                f.write('no')
+                f.write(b'no')
         self.assertTrue(f.closed)
 
         with self.fs.open('text', 'r') as f:


### PR DESCRIPTION
Hi Will,

this small(est) PR intends to fix a possible bug with the test case, where `f.write('no')` could possibly fail with a `TypeError` (since `f` is open in binary mode) before raising the expected `IOError`.