### PR TITLE
Make filesystems pickleable

### DIFF
--- a/fs/base.py
+++ b/fs/base.py
@@ -94,6 +94,15 @@ class FS(object):
         """
         self.close()
 
+    def __getstate__(self):
+        out = self.__dict__.copy()
+        out.pop('_lock', None)
+        return out
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._lock = threading.RLock()
+
     @property
     def walk(self):
         # type: (_F) -> BoundWalker[_F]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import pickle
 import unittest
 
 try:
@@ -69,3 +70,7 @@ class TestBase(unittest.TestCase):
 
         with self.assertRaises(errors.InvalidPath):
             self.fs.validatepath('0123456789A')
+
+    def test_ispickleable(self):
+        fs2 = pickle.loads(pickle.dumps(self.fs))
+        assert isinstance(fs2, TestFS)


### PR DESCRIPTION
The presence of a thread lock in the filesystem makes is unpickleable. It can be recreated at each unpickling for each new instance, instead.
Note that all state is carried over from one instance to the other - but it should be up to the FS implementations to decide how to pickle themselves, not the base class.