### PR TITLE
Enforce `PyYAML < 4` when testing against Python3.3

### DIFF
--- a/testrequirements.txt
+++ b/testrequirements.txt
@@ -2,6 +2,7 @@ appdirs~=1.4.0
 coverage
 mock
 pyftpdlib==1.5.2
+PyYAML<4.1          ;   python_version == '3.3'
 python-coveralls
 pytz==2016.7
 nose


### PR DESCRIPTION
Attempted fix of #180.