### PR TITLE
Fix `test_entry_point_create_error` (fix #185)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,21 @@
+sudo: false
 language: python
 
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-
-os:
-  - linux
+matrix:
+  include:
+  - python: "2.7"
+    env: SETUPTOOLS=setuptools
+  - python: "3.3"
+    env: SETUPTOOLS=setuptools~=39.2
+  - python: "3.4"
+    env: SETUPTOOLS=setuptools
+  - python: "3.5"
+    env: SETUPTOOLS=setuptools
+  - python: "3.6"
+    env: SETUPTOOLS=setuptools
 
 before_install:
-  - pip install setuptools pip -U
+  - pip install $SETUPTOOLS pip -U
   - pip --version
   - pip install -r testrequirements.txt
   - pip freeze


### PR DESCRIPTION
Proposed fix for #185 :

Instead of monkey patching `issubclass` for it to accept `MagicMock` as an `Opener` subclass, I create a mock opener that raises a `ValueError` on instantiation. Less dirty, and works on Python 3.7.