### PR TITLE
Fix parameter docs for `FS.settext`

### DIFF
--- a/fs/base.py
+++ b/fs/base.py
@@ -1368,7 +1368,8 @@ class FS(object):
         """Create or replace a file with text.
 
         Arguments:
-            contents (str): A path on the filesystem.
+            path (str): Destination path on the filesystem.
+            contents (str): Text to be written.
             encoding (str, optional): Encoding of destination file
                 (defaults to ``'ut-8'``).
             errors (str, optional): How encoding errors should be treated


### PR DESCRIPTION
Match with the docs for `FS.setbytes` because they're different versions
of essentially the same thing: setX to a file, so `path` is exactly the same
and `contents` is adapted for this function.