### PR TITLE
Fix `case_sensitive` bug #192

### DIFF
--- a/fs/base.py
+++ b/fs/base.py
@@ -1552,9 +1552,9 @@ class FS(object):
             return True
         if isinstance(patterns, six.text_type):
             raise TypeError('patterns must be a list or sequence')
-        case_sensitive = typing.cast(
-            bool, self.getmeta().get('case_sensitive', True))
-        matcher = wildcard.get_matcher(patterns, case_sensitive)
+        case_insensitive = typing.cast(
+            bool, self.getmeta().get('case_insensitive', False))
+        matcher = wildcard.get_matcher(patterns, case_insensitive)
         return matcher(name)
 
     def tree(self, **kwargs):

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -55,7 +55,7 @@ def imatch(pattern, name):
     try:
         re_pat = _PATTERN_CACHE[(pattern, False)]
     except KeyError:
-        res = _translate(pattern, case_sensitive=False)
+        res = _translate(pattern, case_insensitive=True)
         _PATTERN_CACHE[(pattern, False)] = re_pat =\
             re.compile(res, re.IGNORECASE)
     return re_pat.match(name) is not None
@@ -101,15 +101,15 @@ def imatch_any(patterns, name):
     return any(imatch(pattern, name) for pattern in patterns)
 
 
-def get_matcher(patterns, case_sensitive):
+def get_matcher(patterns, case_insensitive):
     # type: (Iterable[Text], bool) -> Callable[[Text], bool]
     """Get a callable that matches names against the given patterns.
 
     Arguments:
         patterns (list): A list of wildcard pattern. e.g. ``["*.py",
             "*.pyc"]``
-        case_sensitive (bool): If `True`, then the callable will be case
-            sensitive, otherwise it will be case insensitive.
+        case_insensitive (bool): If `True`, then the callable will be case
+            insensitive, otherwise it will be case sensitive.
 
     Returns:
         callable: a matcher that will return `True` if the name given as
@@ -126,13 +126,13 @@ def get_matcher(patterns, case_sensitive):
     """
     if not patterns:
         return lambda name: True
-    if case_sensitive:
-        return partial(match_any, patterns)
-    else:
+    if case_insensitive:
         return partial(imatch_any, patterns)
+    else:
+        return partial(match_any, patterns)
 
 
-def _translate(pattern, case_sensitive=True):
+def _translate(pattern, case_insensitive=False):
     # type: (Text, bool) -> Text
     """Translate a wildcard pattern to a regular expression.
 
@@ -140,14 +140,14 @@ def _translate(pattern, case_sensitive=True):
 
     Arguments:
         pattern (str): A wildcard pattern.
-        case_sensitive (bool): Set to `False` to use a case
-            insensitive regex (default `True`).
+        case_insensitive (bool): Set to `True` to use a case
+            insensitive regex (default `False`).
 
     Returns:
         str: A regex equivalent to the given pattern.
 
     """
-    if not case_sensitive:
+    if case_insensitive:
         pattern = pattern.lower()
     i, n = 0, len(pattern)
     res = ''

--- a/tests/test_wildcard.py
+++ b/tests/test_wildcard.py
@@ -36,11 +36,11 @@ class TestFNMatch(unittest.TestCase):
         self.assertTrue(wildcard.imatch_any(['*.py', '*.pyc'], 'FOO.pyc'))
 
     def test_get_matcher(self):
-        matcher = wildcard.get_matcher([], True)
+        matcher = wildcard.get_matcher([], False)
         self.assertTrue(matcher('foo.py'))
-        matcher = wildcard.get_matcher(['*.py'], True)
+        matcher = wildcard.get_matcher(['*.py'], False)
         self.assertTrue(matcher('foo.py'))
         self.assertFalse(matcher('foo.PY'))
-        matcher = wildcard.get_matcher(['*.py'], False)
+        matcher = wildcard.get_matcher(['*.py'], True)
         self.assertTrue(matcher('foo.py'))
         self.assertTrue(matcher('FOO.py'))


### PR DESCRIPTION
Fixes bug in `get_matcher` logic that referenced `case_sensitive` rather than `case_insensitive`.

To maintain consistency, I refactored all references of `case_sensitive` to `case_insensitive`, inverting defaults, inputs and docstrings as appropriate.