### PR TITLE
implementation of glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.0] - Unreleased
+
+### Added
+
+- fs.glob support
+
 ## [2.0.27] - 2018-08-05
 
 ### Fixed
@@ -159,6 +165,7 @@ No changes, pushed wrong branch to PyPi.
 ## [2.0.8] - 2017-08-13
 
 ### Added
+
 - Lstat info namespace
 - Link info namespace
 - FS.islink method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.1.0] - Unreleased
+## [2.1.0] - 2018-08-12
 
 ### Added
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -302,3 +302,5 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+napoleon_include_special_with_doc = True

--- a/docs/source/globbing.rst
+++ b/docs/source/globbing.rst
@@ -1,0 +1,56 @@
+.. _globbing:
+
+Globbing
+========
+
+Globbinng is the process of matching paths according to the rules used
+by the Unix shell.
+
+Generally speaking, you can think of a glob pattern as a path containing
+one or more wildcard patterns. For instance ``"*.py"`` is a valid glob
+pattern that will match all Python files in the current directory.
+
+
+Matching Files and Directories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``*``
+    Matches all files in the current directory.
+``*.py``
+    Matches all .py file in the current directory.
+``*.py?``
+    Matches all .py files and .pyi, .pyc etc in the currenct directory.
+``project/*.py``
+    Matches all .py files in a directory called ``project``.
+``*/*.py``
+    Matches all .py files in any sub directory.
+``**/*.py``
+    Recursively matches all .py files.
+
+
+Matching Directories
+~~~~~~~~~~~~~~~~~~~~
+
+You can specify that you only want to match a directory by appending
+a forward slash to the pattern.
+
+``**/.git/``
+    Recursively matches all the git directories.
+
+
+Glob Interface
+==============
+
+PyFilesystem supports globbing via the ``glob`` object on every FS instance.
+Here's how you might use it to find all the Python files in your filesystem::
+
+    for path, info in my_fs.glob("**/*.py"):
+        print(path)
+
+If you call ``.glob`` with a pattern it will return an iterator of every
+path and corresponding :class:`~fs.info.Info` object of any matching path.
+
+
+Glob Methods
+~~~~~~~~~~~~
+

--- a/docs/source/globbing.rst
+++ b/docs/source/globbing.rst
@@ -40,8 +40,8 @@ Here's a summary of glob patterns:
     Recursively matches all the git directories.
 
 
-Glob Interface
-~~~~~~~~~~~~~~
+Interface
+~~~~~~~~~
 
 PyFilesystem supports globbing via the ``glob`` attribute on every FS
 instance, which is an instance of :class:`~fs.glob.BoundGlobber`. Here's
@@ -55,8 +55,8 @@ path and corresponding :class:`~fs.info.Info` for each matched file and
 directory.
 
 
-Glob Methods
-~~~~~~~~~~~~
+Batch Methods
+~~~~~~~~~~~~~
 
 In addition to iterating over the results, you can also call methods on
 the :class:`~fs.glob.Globber` which apply to every matched path.

--- a/docs/source/globbing.rst
+++ b/docs/source/globbing.rst
@@ -47,12 +47,14 @@ PyFilesystem supports globbing via the ``glob`` attribute on every FS
 instance, which is an instance of :class:`~fs.glob.BoundGlobber`. Here's
 how you might use it to find all the Python files in your filesystem::
 
-    for path, info in my_fs.glob("**/*.py"):
-        print(path)
+    for match in my_fs.glob("**/*.py"):
+        print(f"{match.path} is {match.info.size} bytes long")
 
-Calling ``.glob`` with a pattern will return an iterator of every
-path and corresponding :class:`~fs.info.Info` for each matched file and
-directory.
+Calling ``.glob`` with a pattern will return an iterator of
+:class:`~fs.glob.GlobMatch` named tuples for each matching file or
+directory. A  glob match contains two attributes; ``path`` which is the
+full path in the filesystem, and ``info`` which is an
+:class:`fs.info.Info` info object for the matched resource.
 
 
 Batch Methods

--- a/docs/source/globbing.rst
+++ b/docs/source/globbing.rst
@@ -3,16 +3,26 @@
 Globbing
 ========
 
-Globbinng is the process of matching paths according to the rules used
+Globbing is the process of matching paths according to the rules used
 by the Unix shell.
 
 Generally speaking, you can think of a glob pattern as a path containing
-one or more wildcard patterns. For instance ``"*.py"`` is a valid glob
-pattern that will match all Python files in the current directory.
+one or more wildcard patterns, separated by forward slashes.
 
 
 Matching Files and Directories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In a glob pattern, A ``*`` means match anything text in a filename. A ``?``
+matches any single character. A ``**`` matches any number of subdirectories,
+making the glob *recusrive*. If the glob pattern ends in a ``/``, it will
+only match directory paths, otherwise it will match files and directories.
+
+.. note::
+    A recursive glob requires that PyFilesystem scan a lot of files,
+    and can potentially be slow for large (or network based) filesystems.
+
+Here's a summary of glob patterns:
 
 ``*``
     Matches all files in the current directory.
@@ -26,31 +36,35 @@ Matching Files and Directories
     Matches all .py files in any sub directory.
 ``**/*.py``
     Recursively matches all .py files.
-
-
-Matching Directories
-~~~~~~~~~~~~~~~~~~~~
-
-You can specify that you only want to match a directory by appending
-a forward slash to the pattern.
-
 ``**/.git/``
     Recursively matches all the git directories.
 
 
 Glob Interface
-==============
+~~~~~~~~~~~~~~
 
-PyFilesystem supports globbing via the ``glob`` object on every FS instance.
-Here's how you might use it to find all the Python files in your filesystem::
+PyFilesystem supports globbing via the ``glob`` attribute on every FS
+instance, which is an instance of :class:`~fs.glob.BoundGlobber`. Here's
+how you might use it to find all the Python files in your filesystem::
 
     for path, info in my_fs.glob("**/*.py"):
         print(path)
 
-If you call ``.glob`` with a pattern it will return an iterator of every
-path and corresponding :class:`~fs.info.Info` object of any matching path.
+Calling ``.glob`` with a pattern will return an iterator of every
+path and corresponding :class:`~fs.info.Info` for each matched file and
+directory.
 
 
 Glob Methods
 ~~~~~~~~~~~~
+
+In addition to iterating over the results, you can also call methods on
+the :class:`~fs.glob.Globber` which apply to every matched path.
+
+For instance, here is how you can use glob to remove all ``.pyc`` files
+from a project directory::
+
+    >>> import fs
+    >>> fs.open_fs('~/projects/my_project').glob('**/*.pyc').remove()
+    29
 

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -196,6 +196,20 @@ The ``walk`` attribute on FS objects is instance of a :class:`~fs.walk.BoundWalk
 
 See :ref:`walking` for more information on walking directories.
 
+Globbing
+~~~~~~~~
+
+*Globbing* is a slightly higher level way of scanning filesystem. Paths can be filtered by a *glob* pattern, which is similar to a wildcard (such as *.py), but can match multiple levels of a directory structure.
+
+Here's an example of globbing, which removes all the ``.pyc`` files in your project directory::
+
+    >>> from fs import open_fs
+    >>> open_fs('~/project').glob('**/*.pyc').remove()
+    62
+
+See :ref:`globbing` for more information.
+
+
 Moving and Copying
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -199,7 +199,7 @@ See :ref:`walking` for more information on walking directories.
 Globbing
 ~~~~~~~~
 
-*Globbing* is a slightly higher level way of scanning filesystem. Paths can be filtered by a *glob* pattern, which is similar to a wildcard (such as *.py), but can match multiple levels of a directory structure.
+Closely related to walking a filesystem is *Globbing*, which is a slightly higher level way of scanning filesystems. Paths can be filtered by a *glob* pattern, which is similar to a wildcard (such as ``*.py``), but can match multiple levels of a directory structure.
 
 Here's an example of globbing, which removes all the ``.pyc`` files in your project directory::
 

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -199,7 +199,7 @@ See :ref:`walking` for more information on walking directories.
 Globbing
 ~~~~~~~~
 
-Closely related to walking a filesystem is *Globbing*, which is a slightly higher level way of scanning filesystems. Paths can be filtered by a *glob* pattern, which is similar to a wildcard (such as ``*.py``), but can match multiple levels of a directory structure.
+Closely related to walking a filesystem is *globbing*, which is a slightly higher level way of scanning filesystems. Paths can be filtered by a *glob* pattern, which is similar to a wildcard (such as ``*.py``), but can match multiple levels of a directory structure.
 
 Here's an example of globbing, which removes all the ``.pyc`` files in your project directory::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,7 @@ Contents:
    info.rst
    openers.rst
    walking.rst
+   globbing.rst
    builtin.rst
    implementers.rst
    extension.rst

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -9,6 +9,7 @@ Reference
    reference/copy.rst
    reference/enums.rst
    reference/errors.rst
+   reference/glob.rst
    reference/info_objects.rst
    reference/filesize.rst
    reference/mirror.rst

--- a/docs/source/reference/glob.rst
+++ b/docs/source/reference/glob.rst
@@ -1,0 +1,5 @@
+fs.glob
+=======
+
+.. automodule:: fs.glob
+    :members:

--- a/fs/_bulk.py
+++ b/fs/_bulk.py
@@ -78,6 +78,7 @@ class Copier(object):
         # type: (int) -> None
         if num_workers < 0:
             raise ValueError("num_workers must be >= 0")
+        self.num_workers = num_workers
         self.queue = None  # type: Optional[Queue[_Task]]
         self.workers = []  # type: List[_Worker]
         self.errors = []  # type: List[Exception]

--- a/fs/_bulk.py
+++ b/fs/_bulk.py
@@ -78,7 +78,6 @@ class Copier(object):
         # type: (int) -> None
         if num_workers < 0:
             raise ValueError("num_workers must be >= 0")
-        self.num_workers = num_workers
         self.queue = None  # type: Optional[Queue[_Task]]
         self.workers = []  # type: List[_Worker]
         self.errors = []  # type: List[Exception]

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.0.27"
+__version__ = "2.1.0"

--- a/fs/base.py
+++ b/fs/base.py
@@ -30,6 +30,7 @@ from . import move
 from . import tools
 from . import walk
 from . import wildcard
+from .glob import Globber
 from .mode import validate_open_mode
 from .path import abspath
 from .path import join
@@ -107,6 +108,12 @@ class FS(object):
         """Close filesystem on exit.
         """
         self.close()
+
+    @property
+    def glob(self):
+        """`~fs.glob.GLobber`: a globber object..
+        """
+        return Globber(self)
 
     @property
     def walk(self):

--- a/fs/base.py
+++ b/fs/base.py
@@ -111,7 +111,7 @@ class FS(object):
 
     @property
     def glob(self):
-        """`~fs.glob.GLobber`: a globber object..
+        """`~fs.glob.Globber`: a globber object..
         """
         return Globber(self)
 

--- a/fs/base.py
+++ b/fs/base.py
@@ -6,35 +6,23 @@ can work with any of the supported filesystems.
 
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, print_function, unicode_literals
 
 import abc
+import itertools
 import os
 import threading
 import time
 import typing
-from functools import partial
-
 from contextlib import closing
-import itertools
+from functools import partial
 
 import six
 
-from . import copy
-from . import errors
-from . import fsencode
-from . import iotools
-from . import move
-from . import tools
-from . import walk
-from . import wildcard
-from .glob import Globber
+from . import copy, errors, fsencode, iotools, move, tools, walk, wildcard
+from .glob import BoundGlobber
 from .mode import validate_open_mode
-from .path import abspath
-from .path import join
-from .path import normpath
+from .path import abspath, join, normpath
 from .time import datetime_to_epoch
 from .walk import Walker
 
@@ -111,9 +99,9 @@ class FS(object):
 
     @property
     def glob(self):
-        """`~fs.glob.Globber`: a globber object..
+        """`~fs.glob.BoundGlobber`: a globber object..
         """
-        return Globber(self)
+        return BoundGlobber(self)
 
     @property
     def walk(self):

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -71,7 +71,7 @@ def copy_fs_if_newer(
         on_copy (callable):A function callback called after a single file copy
             is executed. Expected signature is ``(src_fs, src_path, dst_fs,
             dst_path)``.
-         workers (int): Use `worker` threads to copy data, or ``0`` (default) for
+        workers (int): Use ``worker`` threads to copy data, or ``0`` (default) for
             a single-threaded copy.
 
     """
@@ -269,7 +269,7 @@ def copy_dir(
         on_copy (callable, optional):  A function callback called after
             a single file copy is executed. Expected signature is
             ``(src_fs, src_path, dst_fs, dst_path)``.
-        workers (int): Use `worker` threads to copy data, or ``0`` (default) for
+        workers (int): Use ``worker`` threads to copy data, or ``0`` (default) for
             a single-threaded copy.
 
     """
@@ -330,7 +330,7 @@ def copy_dir_if_newer(
         on_copy (callable, optional):  A function callback called after
             a single file copy is executed. Expected signature is
             ``(src_fs, src_path, dst_fs, dst_path)``.
-        workers (int): Use `worker` threads to copy data, or ``0`` (default) for
+        workers (int): Use ``worker`` threads to copy data, or ``0`` (default) for
             a single-threaded copy.
 
     """

--- a/fs/glob.py
+++ b/fs/glob.py
@@ -3,9 +3,15 @@ from __future__ import unicode_literals
 from collections import namedtuple
 import re
 
+from .lrucache import LRUCache
 from ._repr import make_repr
 from . import path
 from . import wildcard
+
+
+_PATTERN_CACHE = LRUCache(
+    1000
+)  # type: LRUCache[Tuple[Text, bool], Tuple[int, bool, Pattern]]
 
 
 Counts = namedtuple("Counts", ["files", "directories", "data"])
@@ -30,9 +36,7 @@ def _translate_glob(pattern, case_sensitive=True):
                 "/" + wildcard._translate(component, case_sensitive=case_sensitive)
             )
         levels += 1
-    re_glob = (
-        "(?ms)" + "".join(re_patterns) + ("/\Z" if pattern.endswith("/") else "\Z")
-    )
+    re_glob = "(?ms)^" + "".join(re_patterns) + ("/$" if pattern.endswith("/") else "$")
     return (
         levels,
         recursive,
@@ -40,30 +44,55 @@ def _translate_glob(pattern, case_sensitive=True):
     )
 
 
-def _glob(fs, pattern, search="breadth", path="/", namespaces=None, case_sensitive=True):
-    levels, recursive, _re_glob = _translate_glob(
-        pattern, case_sensitive=case_sensitive
-    )
-    for path, info in fs.walk.info(
-        path=path,
-        namespaces=namespaces,
-        max_depth=None if recursive else levels,
-        search=search,
+def match(pattern, path):
+    try:
+        levels, recursive, re_pattern = _PATTERN_CACHE[(pattern, True)]
+    except KeyError:
+        levels, recursive, re_pattern = _translate_glob(pattern, case_sensitive=True)
+        _PATTERN_CACHE[(pattern, True)] = (levels, recursive, re_pattern)
+    return bool(re_pattern.match(path))
+
+
+def imatch(pattern, path):
+    try:
+        levels, recursive, re_pattern = _PATTERN_CACHE[(pattern, False)]
+    except KeyError:
+        levels, recursive, re_pattern = _translate_glob(pattern, case_sensitive=True)
+        _PATTERN_CACHE[(pattern, False)] = (levels, recursive, re_pattern)
+    return bool(re_pattern.match(path))
+
+
+class Globber(object):
+    """A generator of glob results.
+
+        Arguments:
+            fs (~fs.base.FS): A filesystem object
+            pattern (str): A glob pattern, e.g. ``"**/*.py"`
+            namespaces (list): A list of additional info namespaces.
+            case_sensitive (bool): If ``True``, the path matching will be
+                case *sensitive* i.e. ``"FOO.py"`` and ``"foo.py"`` will
+                be different, otherwise path matching will be case *insensitive*.
+            exclude_dirs (list): A list of patterns to exclude when searching,
+                e.g. ``["*.git"]``.
+
+    """
+
+    def __init__(
+        self,
+        fs,
+        pattern,
+        path="/",
+        namespaces=None,
+        case_sensitive=True,
+        exclude_dirs=None,
     ):
-        if info.is_dir:
-            path += "/"
-        if _re_glob.match(path):
-            yield path, info
-
-
-class GlobGenerator(object):
-    def __init__(self, fs, pattern, path="/", namespaces=None, case_sensitive=True):
-        # type: (FS, str, str, Optional[List[str]], bool) -> None
+        # type: (FS, str, str, Optional[List[str]], bool, Optional[List[str]]) -> None
         self.fs = fs
         self.pattern = pattern
         self.path = path
         self.namespaces = namespaces
         self.case_sensitive = case_sensitive
+        self.exclude_dirs = exclude_dirs
 
     def __repr__(self):
         return make_repr(
@@ -73,41 +102,56 @@ class GlobGenerator(object):
             path=(self.path, "/"),
             namespaces=(self.namespaces, None),
             case_sensitive=(self.case_sensitive, True),
+            exclude_dirs=(self.exclude_dirs, None),
         )
 
     def _make_iter(self, search="breadth", namespaces=None):
-        # type: (str) -> Iterator[str, Tuple[str, Info]]
-        return _glob(
-            self.fs,
-            self.pattern,
-            search=search,
+        try:
+            levels, recursive, re_pattern = _PATTERN_CACHE[
+                (self.pattern, self.case_sensitive)
+            ]
+        except KeyError:
+            levels, recursive, re_pattern = _translate_glob(
+                self.pattern, case_sensitive=self.case_sensitive
+            )
+
+        for path, info in self.fs.walk.info(
             path=self.path,
             namespaces=namespaces or self.namespaces,
-            case_sensitive=self.case_sensitive,
-        )
+            max_depth=None if recursive else levels,
+            search=search,
+            exclude_dirs=self.exclude_dirs,
+        ):
+            if info.is_dir:
+                path += "/"
+            if re_pattern.match(path):
+                yield path, info
 
     def __iter__(self):
         # type: () -> Iterator[Tuple[str, Info]]
         return self._make_iter()
 
-    def files(self):
-        # type: () -> Iterator[str]
-        for path, info in self:
-            if info.is_dir:
-                yield path
-
-    def dirs(self):
-        # type: () -> Iterator[str]
-        for path, info in self:
-            if info.is_file:
-                yield path
-
     def count(self):
+        """Count files / directories / data in matched paths.
+
+        Example::
+
+            counts = Globber(my_fs, '*.py').counts()
+            print(f"files={counts.files}")
+            print(f"directories={counts.directories}")
+            print(f"data={count.data} bytes")
+
+        Returns:
+            `~Counts`: A named tuple containing results.
+
+
+
+        """
         # type: () -> Counts
         directories = 0
         files = 0
         data = 0
-        for path, info in self._make_iter(namespaces=['details']):
+        for path, info in self._make_iter(namespaces=["details"]):
             if info.is_dir:
                 directories += 1
             else:
@@ -130,7 +174,7 @@ class GlobGenerator(object):
     def remove(self):
         # type: () -> int
         removes = 0
-        for path, info in self._make_iter(search='depth'):
+        for path, info in self._make_iter(search="depth"):
             if info.is_dir:
                 self.fs.removetree(path)
             else:
@@ -139,7 +183,14 @@ class GlobGenerator(object):
         return removes
 
 
-class Globber(object):
+class BoundGlobber(object):
+    """An object which searches a filesystem for paths matching a *glob*
+    pattern.
+
+    Arguments:
+        fs (FS): A filesystem object.
+
+    """
     __slots__ = ["fs"]
 
     def __init__(self, fs):
@@ -149,25 +200,32 @@ class Globber(object):
     def __repr__(self):
         return make_repr(self.__class__.__name__, self.fs)
 
-    def __call__(self, pattern, path="/", namespaces=None, case_sensitive=True):
-        # type: (str, str, Optional[List[str]], bool) -> GlobGenerator
-        return GlobGenerator(self.fs, pattern, path, namespaces, case_sensitive)
+    def __call__(
+        self, pattern, path="/", namespaces=None, case_sensitive=True, exclude_dirs=None
+    ):
+        """A generator of glob results.
+
+        Arguments:
+            pattern (str): A glob pattern, e.g. ``"**/*.py"``
+            namespaces (list): A list of additional info namespaces.
+            case_sensitive (bool): If ``True``, the path matching will be
+                case *sensitive* i.e. ``"FOO.py"`` and ``"foo.py"`` will
+                be different, otherwise path matching will be case **insensitive**.
+            exclude_dirs (list): A list of patterns to exclude when searching,
+                e.g. ``["*.git"]``.
+
+        Returns:
+            ~fs.flob.Globber: An object that may be iterated over,
+                yielding tuples of ``(path, info)`` for matching paths.
 
 
-if __name__ == "__main__":  # pragma: no cover
-
-    from fs import open_fs
-
-    m = open_fs("~/projects/moya")
-
-    print(m.glob)
-
-    print(m.glob("*.py"))
-
-    for info, path in m.glob("*/*.py"):
-        print(info)
-
-    print(m.glob("**/*.py").count())
-
-    print(m.glob("*/*.py").count_lines())
-
+        """
+        # type: (str, str, Optional[List[str]], bool, Optional[List[str]]) -> Globber
+        return GlobMatcher(
+            self.fs,
+            pattern,
+            path,
+            namespaces=namespaces,
+            case_sensitive=case_sensitive,
+            exclude_dirs=exclude_dirs,
+        )

--- a/fs/glob.py
+++ b/fs/glob.py
@@ -1,0 +1,115 @@
+from __future__ import unicode_literals
+
+import re
+
+from ._repr import make_repr
+from . import path
+from . import wildcard
+
+
+def _translate_glob(pattern, case_sensitive=True):
+    levels = 0
+    recursive = False
+    re_patterns = [""]
+    for component in path.iteratepath(pattern):
+        if component == "**":
+            re_patterns.append(".*/?")
+            recursive = True
+        else:
+            re_patterns.append(
+                "/" + wildcard._translate(component, case_sensitive=case_sensitive)
+            )
+        levels += 1
+    re_glob = (
+        "(?ms)" + "".join(re_patterns) + ("/\Z" if pattern.endswith("/") else "\Z")
+    )
+    return (
+        levels,
+        recursive,
+        re.compile(re_glob, re.IGNORECASE if case_sensitive else None),
+    )
+
+
+def _glob(fs, pattern, path="/", namespaces=None, case_sensitive=True):
+    levels, recursive, _re_glob = _translate_glob(
+        pattern, case_sensitive=case_sensitive
+    )
+    for path, info in fs.walk.info(
+        path=path, namespaces=namespaces, max_depth=None if recursive else levels
+    ):
+        if info.is_dir:
+            path += "/"
+        if _re_glob.match(path):
+            yield path, info
+
+
+class GlobGenerator(object):
+    def __init__(self, fs, pattern, path='/', namespaces=None, case_sensitive=True):
+        self.fs = fs
+        self.pattern = pattern
+        self.path = path
+        self.namespaces = namespaces
+        self.case_sensitive = case_sensitive
+
+    def __repr__(self):
+        return make_repr(
+            self.__class__.__name__,
+            self.fs,
+            self.pattern,
+            path=(self.path, '/'),
+            namespaces=(self.namespaces, None),
+            case_sensitive=(self.case_sensitive, True),
+        )
+
+    def __iter__(self):
+        for path, info in _glob(
+            self.fs,
+            self.pattern,
+            path=self.path,
+            namespaces=self.namespaces,
+            case_sensitive=self.case_sensitive,
+        ):
+            yield path, info
+
+    def count(self):
+        size = 0
+        for path, info in _glob(
+            self.fs,
+            self.pattern,
+            path=self.path,
+            namespaces=['details'],
+            case_sensitive=self.case_sensitive,
+        ):
+            size += info.size
+        return size
+
+
+class Globber(object):
+
+    __slots__ = ["fs"]
+
+    def __init__(self, fs):
+        self.fs = fs
+
+    def __repr__(self):
+        return make_repr(self.__class__.__name__, self.fs)
+
+    def __call__(self, pattern, path="/", namespaces=None, case_sensitive=True):
+        return GlobGenerator(self.fs, pattern, path, namespaces, case_sensitive)
+
+
+if __name__ == "__main__":
+
+    from fs import open_fs
+
+    m = open_fs("~/projects/moya")
+
+    print(m.glob)
+
+    print(m.glob('*.py'))
+
+    for info, path in m.glob('*/*.py'):
+        print(info)
+
+    print(m.glob('**/*.py').count())
+

--- a/fs/glob.py
+++ b/fs/glob.py
@@ -36,7 +36,7 @@ def _translate_glob(pattern, case_sensitive=True):
     return (
         levels,
         recursive,
-        re.compile(re_glob, re.IGNORECASE if case_sensitive else None),
+        re.compile(re_glob, 0 if case_sensitive else re.IGNORECASE),
     )
 
 
@@ -102,7 +102,7 @@ class GlobGenerator(object):
                 directories += 1
             else:
                 files += 1
-                data += info.size
+            data += info.size
         return Counts(directories=directories, files=files, data=data)
 
     def count_lines(self):
@@ -122,7 +122,7 @@ class GlobGenerator(object):
         removes = 0
         for path, info in self:
             if info.is_dir:
-                self.fs.removedir(path)
+                self.fs.removetree(path)
             else:
                 self.fs.remove(path)
             removes += 1
@@ -145,7 +145,7 @@ class Globber(object):
         return GlobGenerator(self.fs, pattern, path, namespaces, case_sensitive)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
 
     from fs import open_fs
 

--- a/fs/glob.py
+++ b/fs/glob.py
@@ -48,7 +48,7 @@ def _glob(fs, pattern, path="/", namespaces=None, case_sensitive=True):
         path=path,
         namespaces=namespaces,
         max_depth=None if recursive else levels,
-        search="depth" if pattern.endswith("/") else "breadth",
+        search="depth",
     ):
         if info.is_dir:
             path += "/"
@@ -85,6 +85,16 @@ class GlobGenerator(object):
             case_sensitive=self.case_sensitive,
         ):
             yield path, info
+
+    def files(self):
+        for path, info in self:
+            if info.is_dir:
+                yield path
+
+    def dirs(self):
+        for path, info in self:
+            if info.is_file:
+                yield path
 
     def count(self):
         # type: () -> Counts

--- a/fs/glob.py
+++ b/fs/glob.py
@@ -9,7 +9,7 @@ from . import wildcard
 
 
 Counts = namedtuple("Counts", ["files", "directories", "data"])
-
+LineCounts = namedtuple("LineCounts", ["lines", "non_blank"])
 
 if False:  # typing.TYPE_CHECKING
     from typing import Iterator, List, Optional, Tuple
@@ -87,7 +87,7 @@ class GlobGenerator(object):
             yield path, info
 
     def count(self):
-        # type: () -> Tuple[int, int, int]
+        # type: () -> Counts
         directories = 0
         files = 0
         data = 0
@@ -104,6 +104,18 @@ class GlobGenerator(object):
                 files += 1
                 data += info.size
         return Counts(directories=directories, files=files, data=data)
+
+    def count_lines(self):
+        # type: () -> LineCounts
+        lines = 0
+        non_blank = 0
+        for path, info in self:
+            if info.is_file:
+                for line in self.fs.open(path):
+                    lines += 1
+                    if line.rstrip():
+                        non_blank += 1
+        return LineCounts(lines=lines, non_blank=non_blank)
 
     def remove(self):
         # type: () -> int
@@ -147,4 +159,6 @@ if __name__ == "__main__":
         print(info)
 
     print(m.glob("**/*.py").count())
+
+    print(m.glob("*/*.py").count_lines())
 

--- a/fs/glob.py
+++ b/fs/glob.py
@@ -5,7 +5,7 @@ import re
 
 from .lrucache import LRUCache
 from ._repr import make_repr
-from . import path
+from .path import iteratepath
 from . import wildcard
 
 
@@ -27,7 +27,7 @@ def _translate_glob(pattern, case_sensitive=True):
     levels = 0
     recursive = False
     re_patterns = [""]
-    for component in path.iteratepath(pattern):
+    for component in iteratepath(pattern):
         if component == "**":
             re_patterns.append(".*/?")
             recursive = True
@@ -161,6 +161,7 @@ class Globber(object):
         return self._make_iter()
 
     def count(self):
+        # type: () -> Counts
         """Count files / directories / data in matched paths.
 
         Example:
@@ -172,7 +173,6 @@ class Globber(object):
             `~Counts`: A named tuple containing results.
 
         """
-        # type: () -> Counts
         directories = 0
         files = 0
         data = 0
@@ -185,6 +185,7 @@ class Globber(object):
         return Counts(directories=directories, files=files, data=data)
 
     def count_lines(self):
+        # type: () -> LineCounts
         """Count the lines in the matched files.
 
         Returns:
@@ -197,7 +198,6 @@ class Globber(object):
 
         """
 
-        # type: () -> LineCounts
         lines = 0
         non_blank = 0
         for path, info in self._make_iter():
@@ -209,6 +209,7 @@ class Globber(object):
         return LineCounts(lines=lines, non_blank=non_blank)
 
     def remove(self):
+        # type: () -> int
         """Removed all matched paths.
 
         Returns:
@@ -220,7 +221,6 @@ class Globber(object):
             29
 
         """
-        # type: () -> int
         removes = 0
         for path, info in self._make_iter(search="depth"):
             if info.is_dir:
@@ -254,6 +254,7 @@ class BoundGlobber(object):
     def __call__(
         self, pattern, path="/", namespaces=None, case_sensitive=True, exclude_dirs=None
     ):
+        # type: (str, str, Optional[List[str]], bool, Optional[List[str]]) -> Globber
         """A generator of glob results.
 
         Arguments:
@@ -272,7 +273,6 @@ class BoundGlobber(object):
 
 
         """
-        # type: (str, str, Optional[List[str]], bool, Optional[List[str]]) -> Globber
         return Globber(
             self.fs,
             pattern,

--- a/fs/test.py
+++ b/fs/test.py
@@ -1801,5 +1801,5 @@ class FSTestCases(object):
     def test_glob(self):
         self.assertIsInstance(
             self.fs.glob,
-            glob.Globber
+            glob.BoundGlobber
         )

--- a/fs/test.py
+++ b/fs/test.py
@@ -22,6 +22,7 @@ import fs.move
 from fs import ResourceType, Seek
 from fs import errors
 from fs import walk
+from fs import Glob
 from fs.opener import open_fs
 from fs.subfs import ClosingSubFS, SubFS
 
@@ -1796,3 +1797,9 @@ class FSTestCases(object):
         self.assert_isdir("foo")
         self.assert_isdir("Foo")
         self.assert_isfile("fOO")
+
+    def test_glob(self):
+        self.assertIsInstance(
+            self.fs.glob,
+            glob.Globber
+        )

--- a/fs/test.py
+++ b/fs/test.py
@@ -22,7 +22,7 @@ import fs.move
 from fs import ResourceType, Seek
 from fs import errors
 from fs import walk
-from fs import Glob
+from fs import glob
 from fs.opener import open_fs
 from fs.subfs import ClosingSubFS, SubFS
 

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -15,8 +15,7 @@ if False:  # typing.TYPE_CHECKING
     from typing import Callable, Iterable, MutableMapping, Text, Tuple, Pattern
 
 
-_MAXCACHE = 1000
-_PATTERN_CACHE = LRUCache(_MAXCACHE)  # type: LRUCache[Tuple[Text, bool], Pattern]
+_PATTERN_CACHE = LRUCache(1000)  # type: LRUCache[Tuple[Text, bool], Pattern]
 
 
 def match(pattern, name):
@@ -106,7 +105,7 @@ def get_matcher(patterns, case_sensitive):
     Arguments:
         patterns (list): A list of wildcard pattern. e.g. ``["*.py",
             "*.pyc"]``
-        case_sensitive (bool): If `True`, then the callable will be case
+        case_sensitive (bool): If ``True``, then the callable will be case
             sensitive, otherwise it will be case insensitive.
 
     Returns:

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -33,7 +33,7 @@ def match(pattern, name):
     try:
         re_pat = _PATTERN_CACHE[(pattern, True)]
     except KeyError:
-        res = "(?ms)" + _translate(pattern) + '\Z'
+        res = "(?ms)" + _translate(pattern) + r'\Z'
         _PATTERN_CACHE[(pattern, True)] = re_pat = re.compile(res)
     return re_pat.match(name) is not None
 
@@ -53,7 +53,7 @@ def imatch(pattern, name):
     try:
         re_pat = _PATTERN_CACHE[(pattern, False)]
     except KeyError:
-        res = "(?ms)" + _translate(pattern, case_sensitive=False) + '\Z'
+        res = "(?ms)" + _translate(pattern, case_sensitive=False) + r'\Z'
         _PATTERN_CACHE[(pattern, False)] = re_pat = re.compile(res, re.IGNORECASE)
     return re_pat.match(name) is not None
 

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -2,13 +2,14 @@
 """
 # Adapted from https://hg.python.org/cpython/file/2.7/Lib/fnmatch.py
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 import re
 import typing
 from functools import partial
 
 from .lrucache import LRUCache
+from . import path
 
 if False:  # typing.TYPE_CHECKING
     from typing import Callable, Iterable, MutableMapping, Text, Tuple, Pattern
@@ -33,7 +34,7 @@ def match(pattern, name):
     try:
         re_pat = _PATTERN_CACHE[(pattern, True)]
     except KeyError:
-        res = _translate(pattern)
+        res = "(?ms)" + _translate(pattern) + '\Z'
         _PATTERN_CACHE[(pattern, True)] = re_pat = re.compile(res)
     return re_pat.match(name) is not None
 
@@ -53,7 +54,7 @@ def imatch(pattern, name):
     try:
         re_pat = _PATTERN_CACHE[(pattern, False)]
     except KeyError:
-        res = _translate(pattern, case_sensitive=False)
+        res = "(?ms)" + _translate(pattern, case_sensitive=False) + '\Z'
         _PATTERN_CACHE[(pattern, False)] = re_pat = re.compile(res, re.IGNORECASE)
     return re_pat.match(name) is not None
 
@@ -152,7 +153,7 @@ def _translate(pattern, case_sensitive=True):
         c = pattern[i]
         i = i + 1
         if c == "*":
-            res = res + ".*"
+            res = res + "[^/]*"
         elif c == "?":
             res = res + "."
         elif c == "[":
@@ -175,4 +176,4 @@ def _translate(pattern, case_sensitive=True):
                 res = "%s[%s]" % (res, stuff)
         else:
             res = res + re.escape(c)
-    return res + "\Z(?ms)"
+    return res

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-appdirs==1.4.0
+appdirs~=1.4.3
 backports.os==0.1.1;  python_version == '2.7'
 enum34==1.1.6 ; python_version < '3.4'
 pytz

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -29,6 +29,12 @@ class TestCopy(unittest.TestCase):
             self.assertTrue(dst_fs.isdir("foo/bar"))
             self.assertTrue(dst_fs.isfile("test.txt"))
 
+    def test_copy_value_error(self):
+        src_fs = open_fs("mem://")
+        dst_fs = open_fs("mem://")
+        with self.assertRaises(ValueError):
+            fs.copy.copy_fs(src_fs, dst_ds, workers=-1)
+
     def test_copy_dir(self):
         src_fs = open_fs("mem://")
         src_fs.makedirs("foo/bar")

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -33,7 +33,7 @@ class TestCopy(unittest.TestCase):
         src_fs = open_fs("mem://")
         dst_fs = open_fs("mem://")
         with self.assertRaises(ValueError):
-            fs.copy.copy_fs(src_fs, dst_ds, workers=-1)
+            fs.copy.copy_fs(src_fs, dst_fs, workers=-1)
 
     def test_copy_dir(self):
         src_fs = open_fs("mem://")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -30,6 +30,7 @@ class TestErrors(unittest.TestCase):
             [errors.NoURL, "some_path", "some_purpose"],
             [errors.Unsupported],
             [errors.IllegalBackReference, "path"],
+            [errors.MissingInfoNamespace, "path"]
         ]
         try:
             pool = multiprocessing.Pool(1)

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -46,47 +46,47 @@ class TestGlob(unittest.TestCase):
             self.assertEqual(glob.match(pattern, path), expected)
 
     def test_count_1dir(self):
-        globber = glob.Globber(self.fs)
+        globber = glob.BoundGlobber(self.fs)
         counts = globber("*.py").count()
         self.assertEqual(counts, glob.Counts(files=3, directories=0, data=12))
         repr(globber("*.py"))
 
     def test_count_2dir(self):
-        globber = glob.Globber(self.fs)
+        globber = glob.BoundGlobber(self.fs)
         counts = globber("*/*.py").count()
         self.assertEqual(counts, glob.Counts(files=1, directories=0, data=22))
 
     def test_count_recurse_dir(self):
-        globber = glob.Globber(self.fs)
+        globber = glob.BoundGlobber(self.fs)
         counts = globber("**/*.py").count()
         self.assertEqual(counts, glob.Counts(files=5, directories=0, data=43))
 
     def test_count_lines(self):
-        globber = glob.Globber(self.fs)
+        globber = glob.BoundGlobber(self.fs)
         line_counts = globber("**/*.py").count_lines()
         self.assertEqual(line_counts, glob.LineCounts(lines=3, non_blank=3))
 
     def test_count_dirs(self):
-        globber = glob.Globber(self.fs)
+        globber = glob.BoundGlobber(self.fs)
         counts = globber("**/?/").count()
         self.assertEqual(counts, glob.Counts(files=0, directories=3, data=0))
 
     def test_count_all(self):
-        globber = glob.Globber(self.fs)
+        globber = glob.BoundGlobber(self.fs)
         counts = globber("**").count()
         self.assertEqual(counts, glob.Counts(files=6, directories=4, data=43))
         counts = globber("**/").count()
         self.assertEqual(counts, glob.Counts(files=0, directories=4, data=0))
 
     def test_remove(self):
-        globber = glob.Globber(self.fs)
+        globber = glob.BoundGlobber(self.fs)
         self.assertTrue(self.fs.exists("egg/foo.pyc"))
         removed_count = globber("**/*.pyc").remove()
         self.assertEqual(removed_count, 1)
         self.assertFalse(self.fs.exists("egg/foo.pyc"))
 
     def test_remove_dir(self):
-        globber = glob.Globber(self.fs)
+        globber = glob.BoundGlobber(self.fs)
         self.assertTrue(self.fs.exists("egg/foo.pyc"))
         removed_count = globber("**/?/").remove()
         self.assertEqual(removed_count, 3)
@@ -94,6 +94,6 @@ class TestGlob(unittest.TestCase):
         self.assertTrue(self.fs.exists("egg"))
 
     def test_remove_all(self):
-        globber = glob.Globber(self.fs)
+        globber = glob.BoundGlobber(self.fs)
         globber("**").remove()
         self.assertEqual(sorted(self.fs.listdir("/")), [])

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -7,91 +7,93 @@ from fs import open_fs
 
 
 class TestGlob(unittest.TestCase):
-
     def setUp(self):
-        fs = self.fs = open_fs('mem://')
-        fs.settext('foo.py', 'Hello, World')
-        fs.touch('bar.py')
-        fs.touch('baz.py')
-        fs.makedirs('egg')
-        fs.settext('egg/foo.py', 'from fs import open_fs')
-        fs.touch('egg/foo.pyc')
-        fs.makedirs('a/b/c/').settext('foo.py', 'import fs')
+        fs = self.fs = open_fs("mem://")
+        fs.settext("foo.py", "Hello, World")
+        fs.touch("bar.py")
+        fs.touch("baz.py")
+        fs.makedirs("egg")
+        fs.settext("egg/foo.py", "from fs import open_fs")
+        fs.touch("egg/foo.pyc")
+        fs.makedirs("a/b/c/").settext("foo.py", "import fs")
         repr(fs.glob)
+
+    def test_match(self):
+        tests = [
+            ("*.?y", "/test.py", True),
+            ("*.py", "/test.py", True),
+            ("*.py", "/test.pc", False),
+            ("*.py", "/foo/test.py", False),
+            ("foo/*.py", "/foo/test.py", True),
+            ("foo/*.py", "/bar/foo/test.py", False),
+            ("?oo/*.py", "/foo/test.py", True),
+            ("*/*.py", "/foo/test.py", True),
+            ("foo/*.py", "/bar/foo/test.py", False),
+            ("**/foo/*.py", "/bar/foo/test.py", True),
+            ("foo/**/bar/*.py", "/foo/bar/test.py", True),
+            ("foo/**/bar/*.py", "/foo/baz/egg/bar/test.py", True),
+            ("foo/**/bar/*.py", "/foo/baz/egg/bar/egg/test.py", False),
+            ("**", "/test.py", True),
+            ("**", "/test", True),
+            ("**", "/test/", True),
+            ("**/", "/test/", True),
+            ("**/", "/test.py", False),
+        ]
+        for pattern, path, expected in tests:
+            self.assertEqual(glob.match(pattern, path), expected)
+        # Run a second time to test cache
+        for pattern, path, expected in tests:
+            self.assertEqual(glob.match(pattern, path), expected)
 
     def test_count_1dir(self):
         globber = glob.Globber(self.fs)
-        counts = globber('*.py').count()
-        self.assertEqual(
-            counts,
-            glob.Counts(files=3, directories=0, data=12)
-        )
-        repr(globber('*.py'))
+        counts = globber("*.py").count()
+        self.assertEqual(counts, glob.Counts(files=3, directories=0, data=12))
+        repr(globber("*.py"))
 
     def test_count_2dir(self):
         globber = glob.Globber(self.fs)
-        counts = globber('*/*.py').count()
-        self.assertEqual(
-            counts,
-            glob.Counts(files=1, directories=0, data=22)
-        )
+        counts = globber("*/*.py").count()
+        self.assertEqual(counts, glob.Counts(files=1, directories=0, data=22))
 
     def test_count_recurse_dir(self):
         globber = glob.Globber(self.fs)
-        counts = globber('**/*.py').count()
-        self.assertEqual(
-            counts,
-            glob.Counts(files=5, directories=0, data=43)
-        )
+        counts = globber("**/*.py").count()
+        self.assertEqual(counts, glob.Counts(files=5, directories=0, data=43))
 
     def test_count_lines(self):
         globber = glob.Globber(self.fs)
-        line_counts = globber('**/*.py').count_lines()
-        self.assertEqual(
-            line_counts,
-            glob.LineCounts(lines=3, non_blank=3)
-        )
+        line_counts = globber("**/*.py").count_lines()
+        self.assertEqual(line_counts, glob.LineCounts(lines=3, non_blank=3))
 
     def test_count_dirs(self):
         globber = glob.Globber(self.fs)
-        counts = globber('**/?/').count()
-        self.assertEqual(
-            counts,
-            glob.Counts(files=0, directories=3, data=0)
-        )
+        counts = globber("**/?/").count()
+        self.assertEqual(counts, glob.Counts(files=0, directories=3, data=0))
 
     def test_count_all(self):
         globber = glob.Globber(self.fs)
-        counts = globber('**').count()
-        self.assertEqual(
-            counts,
-            glob.Counts(files=6, directories=4, data=43)
-        )
-        counts = globber('**/').count()
-        self.assertEqual(
-            counts,
-            glob.Counts(files=0, directories=4, data=0)
-        )
+        counts = globber("**").count()
+        self.assertEqual(counts, glob.Counts(files=6, directories=4, data=43))
+        counts = globber("**/").count()
+        self.assertEqual(counts, glob.Counts(files=0, directories=4, data=0))
 
     def test_remove(self):
         globber = glob.Globber(self.fs)
-        self.assertTrue(self.fs.exists('egg/foo.pyc'))
-        removed_count = globber('**/*.pyc').remove()
+        self.assertTrue(self.fs.exists("egg/foo.pyc"))
+        removed_count = globber("**/*.pyc").remove()
         self.assertEqual(removed_count, 1)
-        self.assertFalse(self.fs.exists('egg/foo.pyc'))
+        self.assertFalse(self.fs.exists("egg/foo.pyc"))
 
     def test_remove_dir(self):
         globber = glob.Globber(self.fs)
-        self.assertTrue(self.fs.exists('egg/foo.pyc'))
-        removed_count = globber('**/?/').remove()
+        self.assertTrue(self.fs.exists("egg/foo.pyc"))
+        removed_count = globber("**/?/").remove()
         self.assertEqual(removed_count, 3)
-        self.assertFalse(self.fs.exists('a'))
-        self.assertTrue(self.fs.exists('egg'))
+        self.assertFalse(self.fs.exists("a"))
+        self.assertTrue(self.fs.exists("egg"))
 
     def test_remove_all(self):
         globber = glob.Globber(self.fs)
-        globber('**').remove()
-        self.assertEqual(
-            sorted(self.fs.listdir('/')),
-            []
-        )
+        globber("**").remove()
+        self.assertEqual(sorted(self.fs.listdir("/")), [])

--- a/tests/test_glob.py
+++ b/tests/test_glob.py
@@ -1,0 +1,97 @@
+from __future__ import unicode_literals
+
+import unittest
+
+from fs import glob
+from fs import open_fs
+
+
+class TestGlob(unittest.TestCase):
+
+    def setUp(self):
+        fs = self.fs = open_fs('mem://')
+        fs.settext('foo.py', 'Hello, World')
+        fs.touch('bar.py')
+        fs.touch('baz.py')
+        fs.makedirs('egg')
+        fs.settext('egg/foo.py', 'from fs import open_fs')
+        fs.touch('egg/foo.pyc')
+        fs.makedirs('a/b/c/').settext('foo.py', 'import fs')
+        repr(fs.glob)
+
+    def test_count_1dir(self):
+        globber = glob.Globber(self.fs)
+        counts = globber('*.py').count()
+        self.assertEqual(
+            counts,
+            glob.Counts(files=3, directories=0, data=12)
+        )
+        repr(globber('*.py'))
+
+    def test_count_2dir(self):
+        globber = glob.Globber(self.fs)
+        counts = globber('*/*.py').count()
+        self.assertEqual(
+            counts,
+            glob.Counts(files=1, directories=0, data=22)
+        )
+
+    def test_count_recurse_dir(self):
+        globber = glob.Globber(self.fs)
+        counts = globber('**/*.py').count()
+        self.assertEqual(
+            counts,
+            glob.Counts(files=5, directories=0, data=43)
+        )
+
+    def test_count_lines(self):
+        globber = glob.Globber(self.fs)
+        line_counts = globber('**/*.py').count_lines()
+        self.assertEqual(
+            line_counts,
+            glob.LineCounts(lines=3, non_blank=3)
+        )
+
+    def test_count_dirs(self):
+        globber = glob.Globber(self.fs)
+        counts = globber('**/?/').count()
+        self.assertEqual(
+            counts,
+            glob.Counts(files=0, directories=3, data=0)
+        )
+
+    def test_count_all(self):
+        globber = glob.Globber(self.fs)
+        counts = globber('**').count()
+        self.assertEqual(
+            counts,
+            glob.Counts(files=6, directories=4, data=43)
+        )
+        counts = globber('**/').count()
+        self.assertEqual(
+            counts,
+            glob.Counts(files=0, directories=4, data=0)
+        )
+
+    def test_remove(self):
+        globber = glob.Globber(self.fs)
+        self.assertTrue(self.fs.exists('egg/foo.pyc'))
+        removed_count = globber('**/*.pyc').remove()
+        self.assertEqual(removed_count, 1)
+        self.assertFalse(self.fs.exists('egg/foo.pyc'))
+
+    def test_remove_dir(self):
+        globber = glob.Globber(self.fs)
+        self.assertTrue(self.fs.exists('egg/foo.pyc'))
+        removed_count = globber('**/?/').remove()
+        self.assertEqual(removed_count, 3)
+        self.assertFalse(self.fs.exists('a'))
+        self.assertTrue(self.fs.exists('egg'))
+
+    def test_remove_all(self):
+        globber = glob.Globber(self.fs)
+        globber('**').remove()
+        self.assertEqual(
+            sorted(self.fs.listdir('/')),
+            []
+        )


### PR DESCRIPTION
# WIP

An implementation of 'glob' for Pyfilesystem.

This finds all Python files in the root directory:

```python
for path, info my_fs.glob("*.py"):
    print(path)
```

This finds all Python files in sub directories:

```python
for path, info my_fs.glob("*/*.py"):
    print(path)
```

This finds all Python files recursively:

```python
for path, info my_fs.glob("**/*.py"):
    print(path)
```

This finds all the .git directories:

```python
for path, info in my_fs.glob("**/.git/"):
    print(path)
```

Similar to `walk`, `glob` is a callable object, which you can either iterate over or call its methods.

This counts the number of bytes in Python files recursively:

```python
print(my_fs.glob("**/*.py").count())
```

This removes all `pyc` file recursively:

```python
my_fs.glob("**/*.pyc").remove()
```

Many other combinations are possible, I'm sure.

All of this can be done already, but its a nice syntactical sugar IMHO.
