### PR TITLE
minor improvements and cleanup at fs.test.test_listdir

### DIFF
--- a/fs/test.py
+++ b/fs/test.py
@@ -543,14 +543,13 @@ class FSTestCases(object):
         self.assertEqual(self.fs.listdir("."), [])
         self.assertEqual(self.fs.listdir("./"), [])
 
-        # Make a few files
+        # Make a few objects
         self.fs.setbytes("foo", b"egg")
         self.fs.setbytes("bar", b"egg")
-        self.fs.setbytes("baz", b"egg")
+        self.fs.makedir("baz")
 
-        # Check paths are unicode
-        for name in self.fs.listdir("/"):
-            self.assertIsInstance(name, six.text_type)
+        # This should not be listed
+        self.fs.setbytes("baz/egg", b"egg")
 
         # Check list works
         six.assertCountEqual(self, self.fs.listdir("/"), ["foo", "bar", "baz"])


### PR DESCRIPTION
Few minor improvement of `fs.test.test_listdir`:

1. Listing over files _and_ a directory. This would have caught a bug I int in my GCSFS implementation: A `fs.listdir`on the new example would have resulted in `["foo", "bar", "baz/"]` which is incorrect.
2. Added a file in a subdirectory which should not be listed (easy mistake when trying to implement an object store where every "list" is actually a "walk"). This was caught by other unit tests but I think the check makes sense here.
3. The unicode check was duplicated, the same check is done a few lines further down