### PR TITLE
Use os.O_RDWR for exclusive mode in Python 2.7

### DIFF
--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -668,8 +668,8 @@ class FTPFS(FS):
             else:
                 if info.is_dir:
                     raise errors.FileExpected(path)
-            if _mode.exclusive:
-                raise errors.FileExists(path)
+                if _mode.exclusive:
+                    raise errors.FileExists(path)
             ftp_file = FTPFile(self, _path, mode)
         return ftp_file  # type: ignore
 

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -321,8 +321,8 @@ class OSFS(FS):
         _path = self.validatepath(path)
         sys_path = self._to_sys_path(_path)
         with convert_os_errors("openbin", path):
-            if six.PY2 and _mode.exclusive and self.exists(path):
-                raise errors.FileExists(path)
+            if six.PY2 and _mode.exclusive:
+                sys_path = os.open(sys_path, os.O_RDWR | os.O_CREAT | os.O_EXCL)
             binary_file = io.open(
                 sys_path, mode=_mode.to_platform_bin(), buffering=buffering, **options
             )
@@ -416,7 +416,7 @@ class OSFS(FS):
         sys_path = self._to_sys_path(_path)
         with convert_os_errors("open", path):
             if six.PY2 and _mode.exclusive:
-                sys_path = os.open(sys_path, os.O_CREAT | os.O_EXCL)
+                sys_path = os.open(sys_path, os.O_RDWR | os.O_CREAT | os.O_EXCL)
             _encoding = encoding or "utf-8"
             return io.open(
                 sys_path,

--- a/fs/test.py
+++ b/fs/test.py
@@ -712,10 +712,6 @@ class FSTestCases(object):
             f.write(text)
         self.assertTrue(f.closed)
 
-        with self.assertRaises(errors.FileExists):
-            with self.fs.open("foo/hello", "xt") as f:
-                pass
-
         # Read it back
         with self.fs.open("foo/hello", "rt") as f:
             self.assertIsInstance(f, io.IOBase)
@@ -970,6 +966,20 @@ class FSTestCases(object):
         # Opening with a invalid mode
         with self.assertRaises(ValueError):
             self.fs.openbin("foo.bin", "h")
+
+    def test_open_exclusive(self):
+        with self.fs.open("some_file", "x") as f:
+            f.write("bananas")
+
+        with self.assertRaises(errors.FileExists):
+            self.fs.open("some_file", "x")
+
+    def test_openbin_exclusive(self):
+        with self.fs.openbin("some_file", "x") as f:
+            f.write("bananas")
+
+        with self.assertRaises(errors.FileExists):
+            self.fs.openbin("some_file", "x")
 
     def test_opendir(self):
         # Make a simple directory structure

--- a/fs/test.py
+++ b/fs/test.py
@@ -968,18 +968,18 @@ class FSTestCases(object):
             self.fs.openbin("foo.bin", "h")
 
     def test_open_exclusive(self):
-        with self.fs.open("some_file", "x") as f:
+        with self.fs.open("test_open_exclusive", "x") as f:
             f.write("bananas")
 
         with self.assertRaises(errors.FileExists):
-            self.fs.open("some_file", "x")
+            self.fs.open("test_open_exclusive", "x")
 
     def test_openbin_exclusive(self):
-        with self.fs.openbin("some_file", "x") as f:
-            f.write("bananas")
+        with self.fs.openbin("test_openbin_exclusive", "x") as f:
+            f.write(b"bananas")
 
         with self.assertRaises(errors.FileExists):
-            self.fs.openbin("some_file", "x")
+            self.fs.openbin("test_openbin_exclusive", "x")
 
     def test_opendir(self):
         # Make a simple directory structure


### PR DESCRIPTION
Also doing the exclusive thing properly in openbin.

(#182)

I think the OS_RDWR behaviour is correct since if you specify `x` mode, you can't specify `r` or `w`. So it implies both. I'm pretty sure this is what Python 3 does so the `fs` package API should be consistent in both versions of Python here.