### PR TITLE
Implement OSFS.copy using sendfile or shutil.copy

### DIFF
--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -418,12 +418,12 @@ class OSFS(FS):
                 # attempt using sendfile
                 try:
                     # initialise variables to pass to sendfile
-                    sent = maxsize = 2**31 - 1
-                    offset = 0
                     # open files to obtain a file descriptor
                     with io.open(_src_sys, 'r') as src:
                         with io.open(_dst_sys, 'w') as dst:
                             fd_src, fd_dst = src.fileno(), dst.fileno()
+                            sent = maxsize = os.fstat(fd_src).st_size
+                            offset = 0
                             while sent > 0:
                                 sent = sendfile(fd_dst, fd_src, offset, maxsize)
                                 offset += sent

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -29,6 +29,12 @@ except ImportError:
     except ImportError:  # pragma: no cover
         scandir = None
 
+# NB: backport of https://bugs.python.org/issue33671 patch
+try:
+    import pyfastcopy
+except ImportError:  # pragma: no cover
+    pass
+
 from . import errors
 from .errors import FileExists
 from .base import FS

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     install_requires=REQUIREMENTS,
     extras_require={
         "scandir :python_version < '3.5'": ['scandir~=1.5'],
+        "pyfastcopy :python_version < '3.8'": ['pyfastcopy~=1.0'],
         ":python_version < '3.4'": ['enum34~=1.1.6'],
         ":python_version < '3.6'": ['typing~=3.6'],
         ":python_version < '3.0'": ['backports.os~=0.1']

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     install_requires=REQUIREMENTS,
     extras_require={
         "scandir :python_version < '3.5'": ['scandir~=1.5'],
-        "pyfastcopy :python_version < '3.8'": ['pyfastcopy~=1.0'],
         ":python_version < '3.4'": ['enum34~=1.1.6'],
         ":python_version < '3.6'": ['typing~=3.6'],
         ":python_version < '3.0'": ['backports.os~=0.1']

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -80,6 +80,11 @@ class TestOSFS(FSTestCases, unittest.TestCase):
             sendfile.side_effect = OSError(errno.EWOULDBLOCK)
             with self.assertRaises(OSError):
                 self.fs.copy('foo', 'foo_copy')
+        # check parent exist and is dir
+        with self.assertRaises(errors.ResourceNotFound):
+            self.fs.copy('foo', 'spam/eggs')
+        with self.assertRaises(errors.DirectoryExpected):
+            self.fs.copy('foo', 'foo_copy/foo')
 
     def test_create(self):
         """Test create=True"""

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import errno
 import io
 import os
 import mock
@@ -13,7 +14,6 @@ from fs.path import relpath
 from fs import errors
 
 from fs.test import FSTestCases
-
 
 from six import text_type
 
@@ -67,6 +67,19 @@ class TestOSFS(FSTestCases, unittest.TestCase):
     def test_not_exists(self):
         with self.assertRaises(errors.CreateFailed):
             fs = osfs.OSFS("/does/not/exists/")
+
+    @unittest.skipIf(osfs.sendfile is None, 'sendfile not supported')
+    def test_copy_sendfile(self):
+        # try copying using sendfile
+        with mock.patch.object(osfs, 'sendfile') as sendfile:
+            sendfile.side_effect = OSError(errno.ENOTSUP, 'sendfile not supported')
+            self.test_copy()
+        # check other errors are transmitted
+        self.fs.touch('foo')
+        with mock.patch.object(osfs, 'sendfile') as sendfile:
+            sendfile.side_effect = OSError(errno.EWOULDBLOCK)
+            with self.assertRaises(OSError):
+                self.fs.copy('foo', 'foo_copy')
 
     def test_create(self):
         """Test create=True"""


### PR DESCRIPTION
Hi Will,

while toying with the `sendfile` syscall I noticed that it could also be used to copy files on the OS filesystem quicker than with a chunk copy, and of course people already patched the `shutil` module to use it (see [python#33671](https://bugs.python.org/issue33671)). 

I backported the patch of [`pyfastcopy`](https://pypi.org/project/pyfastcopy/) so that `OSFS.copy` will use `sendfile` if it is available (as either `os.sendfile` or `sendfile.sendfile` from [`pysendfile`](https://pypi.org/project/pysendfile)) and falling back to `shutil.copyfile` if it is not supported on the local platform.

It may also be a good idea to use `sendfile` and `shutil.copy` in `fs.copy.copy_file` and `fs.copy.copy_file_internal` if both source and destination files have a syspath. Tell me what you think so I could get that done before merging !

(I'm also working on getting `FTPFS.setbinfile` use `sendfile` but I'll add a separate PR for that because it needs more boilerplate to ensure compatibility on all platforms and Python versions).

