### PR TITLE
Revert back to manual registry installation (fix #228)

### DIFF
--- a/fs/opener/__init__.py
+++ b/fs/opener/__init__.py
@@ -10,6 +10,9 @@ from .base import Opener
 from .parse import parse_fs_url as parse
 from .registry import registry
 
+# Import opener modules so that `registry.install` if called on each opener
+from . import appfs, ftpfs, memoryfs, osfs, tarfs, tempfs, zipfs
+
 # Alias functions defined as Registry methods
 open_fs = registry.open_fs
 open = registry.open

--- a/fs/opener/appfs.py
+++ b/fs/opener/appfs.py
@@ -35,6 +35,7 @@ class AppFSOpener(Opener):
         create,  # type: bool
         cwd,  # type: Text
     ):
+        # type: (...) -> Union[_AppFS, SubFS[_AppFS]]
 
         from ..subfs import ClosingSubFS
         from .. import appfs
@@ -49,7 +50,6 @@ class AppFSOpener(Opener):
                 "userlog": appfs.UserLogFS,
             }
 
-        # type: (...) -> Union[_AppFS, SubFS[_AppFS]]
         fs_class = self._protocol_mapping[parse_result.protocol]
         resource, delim, path = parse_result.resource.partition("/")
         tokens = resource.split(":", 3)

--- a/fs/opener/appfs.py
+++ b/fs/opener/appfs.py
@@ -9,9 +9,8 @@ from __future__ import unicode_literals
 import typing
 
 from .base import Opener
+from .registry import registry
 from .errors import OpenerError
-from ..subfs import ClosingSubFS
-from .. import appfs
 
 if False:  # typing.TYPE_CHECKING
     from typing import Text, Union
@@ -20,20 +19,13 @@ if False:  # typing.TYPE_CHECKING
     from ..subfs import SubFS
 
 
+@registry.install
 class AppFSOpener(Opener):
     """``AppFS`` opener.
     """
 
     protocols = ["userdata", "userconf", "sitedata", "siteconf", "usercache", "userlog"]
-
-    _protocol_mapping = {
-        "userdata": appfs.UserDataFS,
-        "userconf": appfs.UserConfigFS,
-        "sitedata": appfs.SiteDataFS,
-        "siteconf": appfs.SiteConfigFS,
-        "usercache": appfs.UserCacheFS,
-        "userlog": appfs.UserLogFS,
-    }
+    _protocol_mapping = None
 
     def open_fs(
         self,
@@ -43,6 +35,20 @@ class AppFSOpener(Opener):
         create,  # type: bool
         cwd,  # type: Text
     ):
+
+        from ..subfs import ClosingSubFS
+        from .. import appfs
+
+        if self._protocol_mapping is None:
+            self._protocol_mapping = {
+                "userdata": appfs.UserDataFS,
+                "userconf": appfs.UserConfigFS,
+                "sitedata": appfs.SiteDataFS,
+                "siteconf": appfs.SiteConfigFS,
+                "usercache": appfs.UserCacheFS,
+                "userlog": appfs.UserLogFS,
+            }
+
         # type: (...) -> Union[_AppFS, SubFS[_AppFS]]
         fs_class = self._protocol_mapping[parse_result.protocol]
         resource, delim, path = parse_result.resource.partition("/")

--- a/fs/opener/ftpfs.py
+++ b/fs/opener/ftpfs.py
@@ -11,6 +11,7 @@ import six
 import typing
 
 from .base import Opener
+from .registry import registry
 from ..errors import FSError, CreateFailed
 
 if False:  # typing.TYPE_CHECKING
@@ -20,6 +21,7 @@ if False:  # typing.TYPE_CHECKING
     from .parse import ParseResult
 
 
+@registry.install
 class FTPOpener(Opener):
     """`FTPFS` opener.
     """

--- a/fs/opener/memoryfs.py
+++ b/fs/opener/memoryfs.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import typing
 
 from .base import Opener
+from .registry import registry
 
 if False:  # typing.TYPE_CHECKING
     from typing import Text
@@ -16,6 +17,7 @@ if False:  # typing.TYPE_CHECKING
     from ..memoryfs import MemoryFS
 
 
+@registry.install
 class MemOpener(Opener):
     """`MemoryFS` opener.
     """

--- a/fs/opener/osfs.py
+++ b/fs/opener/osfs.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import typing
 
 from .base import Opener
+from .registry import registry
 
 if False:  # typing.TYPE_CHECKING
     from typing import Text
@@ -16,6 +17,7 @@ if False:  # typing.TYPE_CHECKING
     from ..osfs import OSFS
 
 
+@registry.install
 class OSFSOpener(Opener):
     """`OSFS` opener.
     """

--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -100,8 +100,9 @@ class Registry(object):
         protocol = protocol or self.default_opener
 
         if self.load_extern:
-            entry_point = next(pkg_resources.iter_entry_points(
-                "fs.opener", protocol), None)
+            entry_point = next(
+                pkg_resources.iter_entry_points("fs.opener", protocol), None
+            )
         else:
             entry_point = None
 
@@ -111,21 +112,27 @@ class Registry(object):
             if protocol in self._protocols:
                 opener_instance = self._protocols[protocol]
             else:
-                raise UnsupportedProtocol("protocol '{}' is not supported".format(protocol))
+                raise UnsupportedProtocol(
+                    "protocol '{}' is not supported".format(protocol)
+                )
 
         # If an entry point was found in an extension, attempt to load it
         else:
             try:
                 opener = entry_point.load()
             except Exception as exception:
-                raise EntryPointError("could not load entry point; {}".format(exception))
+                raise EntryPointError(
+                    "could not load entry point; {}".format(exception)
+                )
             if not issubclass(opener, Opener):
                 raise EntryPointError("entry point did not return an opener")
 
             try:
                 opener_instance = opener()
             except Exception as exception:
-                raise EntryPointError("could not instantiate opener; {}".format(exception))
+                raise EntryPointError(
+                    "could not instantiate opener; {}".format(exception)
+                )
 
         return opener_instance
 
@@ -255,8 +262,7 @@ class Registry(object):
         if isinstance(fs_url, FS):
             yield fs_url
         else:
-            _fs = self.open_fs(fs_url, create=create,
-                               writeable=writeable, cwd=cwd)
+            _fs = self.open_fs(fs_url, create=create, writeable=writeable, cwd=cwd)
             try:
                 yield _fs
             except:

--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -27,7 +27,7 @@ class Registry(object):
     """
 
     def __init__(self, default_opener="osfs", load_extern=False):
-        # type: (Text) -> None
+        # type: (Text, bool) -> None
         """Create a registry object.
 
         Arguments:

--- a/fs/opener/tarfs.py
+++ b/fs/opener/tarfs.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import typing
 
 from .base import Opener
+from .registry import registry
 from .errors import NotWriteable
 
 if False:  # typing.TYPE_CHECKING
@@ -17,6 +18,7 @@ if False:  # typing.TYPE_CHECKING
     from ..tarfs import TarFS
 
 
+@registry.install
 class TarOpener(Opener):
     """`TarFS` opener.
     """

--- a/fs/opener/tempfs.py
+++ b/fs/opener/tempfs.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import typing
 
 from .base import Opener
+from .registry import registry
 
 if False:  # typing.TYPE_CHECKING
     from typing import Text
@@ -16,6 +17,7 @@ if False:  # typing.TYPE_CHECKING
     from ..tempfs import TempFS
 
 
+@registry.install
 class TempOpener(Opener):
     """`TempFS` opener.
     """

--- a/fs/opener/zipfs.py
+++ b/fs/opener/zipfs.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 import typing
 
 from .base import Opener
+from .registry import registry
 from .errors import NotWriteable
 
 if False:  # typing.TYPE_CHECKING
@@ -17,6 +18,7 @@ if False:  # typing.TYPE_CHECKING
     from ..zipfs import ZipFS
 
 
+@registry.install
 class ZipOpener(Opener):
     """`ZipFS` opener.
     """

--- a/setup.py
+++ b/setup.py
@@ -39,22 +39,6 @@ setup(
         ":python_version < '3.6'": ['typing~=3.6'],
         ":python_version < '3.0'": ['backports.os~=0.1']
     },
-    entry_points={'fs.opener': [
-        'ftp  = fs.opener.ftpfs:FTPOpener',
-        'file = fs.opener.osfs:OSFSOpener',
-        'osfs = fs.opener.osfs:OSFSOpener',
-        'mem  = fs.opener.memoryfs:MemOpener',
-        'tar  = fs.opener.tarfs:TarOpener',
-        'temp = fs.opener.tempfs:TempOpener',
-        'zip  = fs.opener.zipfs:ZipOpener',
-
-        'userdata = fs.opener.appfs:AppFSOpener',
-        'userconf = fs.opener.appfs:AppFSOpener',
-        'sitedata = fs.opener.appfs:AppFSOpener',
-        'siteconf = fs.opener.appfs:AppFSOpener',
-        'usercache = fs.opener.appfs:AppFSOpener',
-        'userlog = fs.opener.appfs:AppFSOpener',
-    ]},
     license="MIT",
     name='fs',
     packages=find_packages(exclude=("tests",)),

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import os
 import mock
+import sys
 import tempfile
 import unittest
 import pkg_resources
@@ -100,15 +101,18 @@ class TestParse(unittest.TestCase):
 
 
 class TestRegistry(unittest.TestCase):
+
     def test_registry_protocols(self):
-        # Check registry.protocols list the names of all available entry points
-
-        protocols = [
-            entry_point.name
-            for entry_point in pkg_resources.iter_entry_points("fs.opener")
+        # Check registry.protocols list the names of all available extension
+        extensions = [
+            pkg_resources.EntryPoint("proto1", "mod1"),
+            pkg_resources.EntryPoint("proto2", "mod2"),
         ]
+        m = mock.MagicMock(return_value=extensions)
+        with mock.patch.object(sys.modules['pkg_resources'], 'iter_entry_points', new=m):
+            self.assertIn("proto1", opener.registry.protocols)
+            self.assertIn("proto2", opener.registry.protocols)
 
-        self.assertEqual(sorted(protocols), sorted(opener.registry.protocols))
 
     def test_unknown_protocol(self):
         with self.assertRaises(errors.UnsupportedProtocol):

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -101,7 +101,6 @@ class TestParse(unittest.TestCase):
 
 
 class TestRegistry(unittest.TestCase):
-
     def test_registry_protocols(self):
         # Check registry.protocols list the names of all available extension
         extensions = [
@@ -109,10 +108,11 @@ class TestRegistry(unittest.TestCase):
             pkg_resources.EntryPoint("proto2", "mod2"),
         ]
         m = mock.MagicMock(return_value=extensions)
-        with mock.patch.object(sys.modules['pkg_resources'], 'iter_entry_points', new=m):
+        with mock.patch.object(
+            sys.modules["pkg_resources"], "iter_entry_points", new=m
+        ):
             self.assertIn("proto1", opener.registry.protocols)
             self.assertIn("proto2", opener.registry.protocols)
-
 
     def test_unknown_protocol(self):
         with self.assertRaises(errors.UnsupportedProtocol):


### PR DESCRIPTION
Hi @willmcgugan, hi @justvanrossum,

this PR reverts back to the original Pyfilesystem2 opener behaviour, and manually installs openers from the `fs.opener` module. Additional extensions are loaded, and take priority over builtin filesystems (i.e. if an extension defines `tar` then it is used instead of the `fs.opener.tarfs.TarOpener`).

I added an optional kwarg to `Registry`, so that a `Registry` can disable loading external filesystems.  But because of variable shadowing, no `Registry` instance can be created outside of the `fs.opener.registry` module anyway (well, it's still possible through `sys.modules`).

Tests still passed on my machine with `fs.sshfs` installed.