### PR TITLE
Fix `AppFS` failing to create missing dirs even on `create=True`

### DIFF
--- a/fs/opener/appfs.py
+++ b/fs/opener/appfs.py
@@ -61,6 +61,8 @@ class AppFSOpener(Opener):
         app_fs = fs_class(appname, author=author, version=version, create=create)
 
         if delim:
+            if create:
+                app_fs.makedir(path, recreate=True)
             return app_fs.opendir(path, factory=ClosingSubFS)
 
         return app_fs


### PR DESCRIPTION
Currently, `AppFS` won't create a new subdirectory even if `create` is set to `True`. Minimal failing example:

```python
import fs
fs.open_fs("userdata://fs:willmcgugan/test", create=True)
```

As a side note: maybe the `fs.base.FS.makedir` and `fs.base.FS.makedirs` could also take a `factory` argument like `fs.base.FS.opendir` does !