### PR TITLE
Fix type annotation of `fs.open_fs`

### DIFF
--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -140,7 +140,7 @@ class Registry(object):
 
     def open_fs(
         self,
-        fs_url,  # type: Text
+        fs_url,  # type: Union[FS, Text]
         writeable=False,  # type: bool
         create=False,  # type: bool
         cwd=".",  # type: Text


### PR DESCRIPTION
Just noticed this as my `mypy` was complaining in another project because I passed an `FS` instance to `fs.open_fs`.