### PR TITLE
Call `self.ftp.voidresp()` before closing `write_conn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Incomplete FTPFile.write when using `workers`  @geoffjukes
 
 ## [2.1.2] - 20180-11-10
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Credits
 * [Will McGugan](https://github.com/willmcgugan)
 * [Martin Larralde](https://github.com/althonos)
 * [Giampaolo](https://github.com/gpcimino) for `copy_if_newer` and ftp fixes.
+* [Geoff Jukes](https://github.com/geoffjukes) for ftp fixes
 
 PyFilesystem2 owes a massive debt of gratitude to the following
 developers who contributed code and ideas to the original version.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Credits
 * [Will McGugan](https://github.com/willmcgugan)
 * [Martin Larralde](https://github.com/althonos)
 * [Giampaolo](https://github.com/gpcimino) for `copy_if_newer` and ftp fixes.
-* [Geoff Jukes](https://github.com/geoffjukes) for ftp fixes
+* [Geoff Jukes](https://github.com/geoffjukes) for ftp fixes.
 
 PyFilesystem2 owes a massive debt of gratitude to the following
 developers who contributed code and ideas to the original version.

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -190,6 +190,7 @@ class FTPFile(io.RawIOBase):
                     if self._write_conn is not None:
                         self._write_conn.close()
                         self._write_conn = None
+                        self.ftp.voidresp()  # Ensure last write completed
                     if self._read_conn is not None:
                         self._read_conn.close()
                         self._read_conn = None


### PR DESCRIPTION
Calling `self.ftp.voidresp()` before closing the FTPFile `write_conn` ensures that the last `write` operation completes before the connection is closed.
Solves #240 