### PR TITLE
Fix `registry.install` not returning decorated class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- `Registry.install` returns its argument.
+
 ## [2.2.0] - 2018-01-01
 
 A few methods have been renamed for greater clarity (but functionality remains the same).

--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -71,12 +71,12 @@ class Registry(object):
                 class ArchiveOpener(Opener):
                     protocols = ['zip', 'tar']
         """
-        if not isinstance(opener, Opener):
-            opener = opener()
-        assert isinstance(opener, Opener), "Opener instance required"
-        assert opener.protocols, "must list one or more protocols"
-        for protocol in opener.protocols:
-            self._protocols[protocol] = opener
+        _opener = opener if isinstance(opener, Opener) else opener()
+        assert isinstance(_opener, Opener), "Opener instance required"
+        assert _opener.protocols, "must list one or more protocols"
+        for protocol in _opener.protocols:
+            self._protocols[protocol] = _opener
+        return opener
 
     @property
     def protocols(self):


### PR DESCRIPTION
# PyFilesystem Pull Request

Thank you for your pull request!

## Type of changes

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation / docstrings
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code
- [x] I've updated CHANGELOG.md
- [x] I accept that @willmcgugan may be pedantic in the code review

## Description

I made sure `Registry.install` returns its argument, otherwise it would not be possible to use it as a decorator as demonstrated in the docstring.
