### PR TITLE
fix for backref error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.2] - Unreleased
+
+### Fixed
+
+- IllegalBackReference had mangled error message
+
 ## [2.2.1] - 2018-01-06
 
 ### Fixed

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.2.1"
+__version__ = "2.2.2a0"

--- a/fs/path.py
+++ b/fs/path.py
@@ -66,7 +66,7 @@ def normpath(path):
         >>> normpath("foo/../../bar")
         Traceback (most recent call last)
             ...
-        IllegalBackReference: Too many backrefs in 'foo/../../bar'
+        IllegalBackReference: path 'foo/../../bar' contains back-references outside of filesystem"
 
     """
     if path in "/":
@@ -86,7 +86,7 @@ def normpath(path):
             else:
                 components.append(component)
     except IndexError:
-        raise IllegalBackReference("Too many backrefs in '{}'".format(path))
+        raise IllegalBackReference(path)
     return prefix + "/".join(components)
 
 


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

The `IllegalBackReference` exception has the following mangled error message:

```
fs.errors.IllegalBackReference: path 'Too many backrefs in '../foo'' contains back-references outside of filesystem
```
This was because `normpath` was passing in its own error rather than the path.

Fixed message is clearer:

```
fs.errors.IllegalBackReference: path '../foo' contains back-references outside of filesystem
```
