### PR TITLE
added hash method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - IllegalBackReference had mangled error message
 
+### Added
+
+- FS.hash method
+
 ## [2.2.1] - 2018-01-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.2.2] - Unreleased
+## [2.3.0] - 2018-01-30
 
 ### Fixed
 

--- a/docs/source/implementers.rst
+++ b/docs/source/implementers.rst
@@ -130,8 +130,9 @@ These methods SHOULD NOT be implemented.
 
 Implementing these is highly unlikely to be worthwhile.
 
+* :meth:`~fs.base.FS.check`
 * :meth:`~fs.base.FS.getbasic`
 * :meth:`~fs.base.FS.getdetails`
-* :meth:`~fs.base.FS.check`
+* :meth:`~fs.base.FS.hash`
 * :meth:`~fs.base.FS.match`
 * :meth:`~fs.base.FS.tree`

--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -25,6 +25,7 @@ The following is a complete list of methods on PyFilesystem objects.
 * :meth:`~fs.base.FS.gettype` Get the type of a resource.
 * :meth:`~fs.base.FS.geturl` Get a URL to a resource, if one exists.
 * :meth:`~fs.base.FS.hassyspath` Check if a resource maps to the OS filesystem.
+* :meth:`~fs.base.FS.hash` Get the hash of a file's contents.
 * :meth:`~fs.base.FS.hasurl` Check if a resource has a URL.
 * :meth:`~fs.base.FS.isclosed` Check if the filesystem is closed.
 * :meth:`~fs.base.FS.isempty` Check if a directory is empty.

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.2.2a0"
+__version__ = "2.2.2a1"

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.3.0a1"
+__version__ = "2.3.0"

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.2.2a1"
+__version__ = "2.3.0a1"

--- a/fs/base.py
+++ b/fs/base.py
@@ -1604,13 +1604,13 @@ class FS(object):
 
         render(self, **kwargs)
 
-    def hash(self, path, name="md5"):
+    def hash(self, path, name):
         # type: (Text, Text) -> Text
         """Get the hash of a file's contents.
 
         Arguments:
             path(str): A path on the filesystem.
-            name(str): One of the algorithms supported by the hashlib module, defaults to `"md5"`
+            name(str): One of the algorithms supported by the hashlib module, e.g. `"md5"`
 
         Returns:
             str: The hex digest of the hash.

--- a/fs/base.py
+++ b/fs/base.py
@@ -66,6 +66,7 @@ __all__ = ["FS"]
 def _new_name(method, old_name):
     """Return a method with a deprecation warning."""
     # Looks suspiciously like a decorator, but isn't!
+
     @wraps(method)
     def _method(*args, **kwargs):
         warnings.warn(
@@ -75,6 +76,14 @@ def _new_name(method, old_name):
             DeprecationWarning,
         )
         return method(*args, **kwargs)
+
+    _method.__doc__ += """
+        Note:
+            .. deprecated:: 2.2.0
+                Please use `~{}`
+""".format(
+        method.__name__
+    )
 
     return _method
 

--- a/fs/base.py
+++ b/fs/base.py
@@ -1615,6 +1615,9 @@ class FS(object):
         Returns:
             str: The hex digest of the hash.
 
+        Raises:
+            fs.errors.UnsupportedHash: If the requested hash is not supported.
+
         """
         _path = self.validatepath(path)
         try:

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -364,3 +364,12 @@ class IllegalBackReference(ValueError):
 
     def __reduce__(self):
         return type(self), (self.path,)
+
+
+class UnsupportedHash(ValueError):
+    """The requested hash algorithm is not supported.
+
+    This exception will be thrown if a hash algorithm is requested that is
+    not supported by hashlib.
+
+    """

--- a/fs/info.py
+++ b/fs/info.py
@@ -45,6 +45,8 @@ class Info(object):
 
     """
 
+    __slots__ = ["raw", "_to_datetime", "namespaces"]
+
     def __init__(self, raw_info, to_datetime=epoch_to_datetime):
         # type: (RawInfo, ToDatetime) -> None
         """Create a resource info object from a raw info dict.

--- a/fs/test.py
+++ b/fs/test.py
@@ -1834,3 +1834,10 @@ class FSTestCases(object):
     def test_glob(self):
         self.assertIsInstance(self.fs.glob, glob.BoundGlobber)
 
+    def test_hash(self):
+        self.fs.writebytes("hashme.txt", b"foobar" * 1024)
+        self.assertEqual(
+            self.fs.hash("md5", "hashme.txt"), "9fff4bb103ab8ce4619064109c54cb9c"
+        )
+        with self.assertRaises(errors.UnsupportedHash):
+            self.fs.hash("nohash", "hashme.txt")

--- a/fs/test.py
+++ b/fs/test.py
@@ -1839,5 +1839,6 @@ class FSTestCases(object):
         self.assertEqual(
             self.fs.hash("hashme.txt", "md5"), "9fff4bb103ab8ce4619064109c54cb9c"
         )
+        self.assertEqual(self.fs.hash("hashme.txt"), "9fff4bb103ab8ce4619064109c54cb9c")
         with self.assertRaises(errors.UnsupportedHash):
             self.fs.hash("hashme.txt", "nohash")

--- a/fs/test.py
+++ b/fs/test.py
@@ -1839,6 +1839,5 @@ class FSTestCases(object):
         self.assertEqual(
             self.fs.hash("hashme.txt", "md5"), "9fff4bb103ab8ce4619064109c54cb9c"
         )
-        self.assertEqual(self.fs.hash("hashme.txt"), "9fff4bb103ab8ce4619064109c54cb9c")
         with self.assertRaises(errors.UnsupportedHash):
             self.fs.hash("hashme.txt", "nohash")

--- a/fs/test.py
+++ b/fs/test.py
@@ -1837,7 +1837,7 @@ class FSTestCases(object):
     def test_hash(self):
         self.fs.writebytes("hashme.txt", b"foobar" * 1024)
         self.assertEqual(
-            self.fs.hash("md5", "hashme.txt"), "9fff4bb103ab8ce4619064109c54cb9c"
+            self.fs.hash("hashme.txt", "md5"), "9fff4bb103ab8ce4619064109c54cb9c"
         )
         with self.assertRaises(errors.UnsupportedHash):
-            self.fs.hash("nohash", "hashme.txt")
+            self.fs.hash("hashme.txt", "nohash")

--- a/tests/test_new_name.py
+++ b/tests/test_new_name.py
@@ -9,6 +9,7 @@ from fs.base import _new_name
 
 class TestNewNameDecorator(unittest.TestCase):
     def double(self, n):
+        "Double a number"
         return n * 2
 
     times_2 = _new_name(double, "times_2")


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [X] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Added FS.hash, a utility method to calculate the hash of a file, since its a fairly common requirement.

Wasn't certain if this belonged in the 'helper' methods or 'optional' methods. Settled on 'helper' because if a filesystem did expose a hash somehow, it could be exposed via FS.getinfo. 
