### PR TITLE
check invalid encoding in OSFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.3.1] - 2019
+## [2.3.1] - 2019-02-10
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.3.0] - 2018-01-30
+## [2.3.1] - 2019
+
+### Fixed
+
+- Add encoding check in OSFS.validatepath
+
+## [2.3.0] - 2019-01-30
 
 ### Fixed
 
@@ -15,13 +21,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - FS.hash method
 
-## [2.2.1] - 2018-01-06
+## [2.2.1] - 2019-01-06
 
 ### Fixed
 
 - `Registry.install` returns its argument.
 
-## [2.2.0] - 2018-01-01
+## [2.2.0] - 2019-01-01
 
 A few methods have been renamed for greater clarity (but functionality remains the same).
 

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.3.0"
+__version__ = "2.3.1a0"

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.3.1a0"
+__version__ = "2.3.1"

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -636,7 +636,7 @@ class OSFS(FS):
         except UnicodeEncodeError as error:
             raise errors.InvalidCharsInPath(
                 path,
-                msg="path '{path}' could not be encoded for the filesystem; {error}".format(
+                msg="path '{path}' could not be encoded for the filesystem (check LANG env var); {error}".format(
                     path=path, error=error
                 ),
             )

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -627,3 +627,17 @@ class OSFS(FS):
                 if accessed is not None or modified is not None:
                     with convert_os_errors("setinfo", path):
                         os.utime(sys_path, (accessed, modified))
+
+    def validatepath(self, path):
+        # type: (Text) -> Text
+        """Check path may be encoded, in addition to usual checks."""
+        try:
+            fsencode(path)
+        except UnicodeEncodeError as error:
+            raise errors.InvalidCharsInPath(
+                path,
+                msg="path '{path}' could not be encoded for the filesystem; {error}".format(
+                    path=path, error=error
+                ),
+            )
+        return super(OSFS, self).validatepath(path)

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -68,23 +68,23 @@ class TestOSFS(FSTestCases, unittest.TestCase):
         with self.assertRaises(errors.CreateFailed):
             fs = osfs.OSFS("/does/not/exists/")
 
-    @unittest.skipIf(osfs.sendfile is None, 'sendfile not supported')
+    @unittest.skipIf(osfs.sendfile is None, "sendfile not supported")
     def test_copy_sendfile(self):
         # try copying using sendfile
-        with mock.patch.object(osfs, 'sendfile') as sendfile:
-            sendfile.side_effect = OSError(errno.ENOTSUP, 'sendfile not supported')
+        with mock.patch.object(osfs, "sendfile") as sendfile:
+            sendfile.side_effect = OSError(errno.ENOTSUP, "sendfile not supported")
             self.test_copy()
         # check other errors are transmitted
-        self.fs.touch('foo')
-        with mock.patch.object(osfs, 'sendfile') as sendfile:
+        self.fs.touch("foo")
+        with mock.patch.object(osfs, "sendfile") as sendfile:
             sendfile.side_effect = OSError(errno.EWOULDBLOCK)
             with self.assertRaises(OSError):
-                self.fs.copy('foo', 'foo_copy')
+                self.fs.copy("foo", "foo_copy")
         # check parent exist and is dir
         with self.assertRaises(errors.ResourceNotFound):
-            self.fs.copy('foo', 'spam/eggs')
+            self.fs.copy("foo", "spam/eggs")
         with self.assertRaises(errors.DirectoryExpected):
-            self.fs.copy('foo', 'foo_copy/foo')
+            self.fs.copy("foo", "foo_copy/foo")
 
     def test_create(self):
         """Test create=True"""
@@ -131,3 +131,12 @@ class TestOSFS(FSTestCases, unittest.TestCase):
         bar_info = self.fs.getinfo("bar", namespaces=["link", "lstat"])
         self.assertIn("link", bar_info.raw)
         self.assertIn("lstat", bar_info.raw)
+
+    def test_validatepath(self):
+        """Check validatepath detects bad encodings."""
+
+        with mock.patch("fs.osfs.fsencode") as fsencode:
+            fsencode.side_effect = lambda error: "–".encode("ascii")
+            with self.assertRaises(errors.InvalidCharsInPath):
+                with self.fs.open("13 – Marked Register.pdf", "wb") as fh:
+                    fh.write(b"foo")

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import unicode_literals
 
 import errno


### PR DESCRIPTION
# WIP

## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

When there are encoding issues in OSFS, a unicode decode error is raised. This can often be cryptic and breaks the promise that FS objects raise FS errors.

I've customized `OSFS.validatepath` to attempt a `fsencode` and raise a `InvalidCharsInPath` error when encoding fails. The error message also suggest to look at the env var LANG, which is a likely cause of encoding fails.
