### PR TITLE
Added hash method to wrapfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.1] - 2019-02-20
+
+### Fixed
+
+- Fixed hash method missing from WrapFS
+
 ## [2.4.0] - 2019-02-15
 
 ### Added

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.4.0"
+__version__ = "2.4.1"

--- a/fs/test.py
+++ b/fs/test.py
@@ -1835,9 +1835,15 @@ class FSTestCases(object):
         self.assertIsInstance(self.fs.glob, glob.BoundGlobber)
 
     def test_hash(self):
-        self.fs.writebytes("hashme.txt", b"foobar" * 1024)
+        self.fs.makedir("foo").writebytes("hashme.txt", b"foobar" * 1024)
         self.assertEqual(
-            self.fs.hash("hashme.txt", "md5"), "9fff4bb103ab8ce4619064109c54cb9c"
+            self.fs.hash("foo/hashme.txt", "md5"), "9fff4bb103ab8ce4619064109c54cb9c"
         )
         with self.assertRaises(errors.UnsupportedHash):
-            self.fs.hash("hashme.txt", "nohash")
+            self.fs.hash("foo/hashme.txt", "nohash")
+
+        with self.fs.opendir("foo") as foo_fs:
+            self.assertEqual(
+                foo_fs.hash("hashme.txt", "md5"), "9fff4bb103ab8ce4619064109c54cb9c"
+            )
+

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -491,6 +491,13 @@ class WrapFS(FS, typing.Generic[_F]):
         path = abspath(normpath(path))
         return path
 
+    def hash(self, path, name):
+        # type: (Text, Text) -> Text
+        self.check()
+        _fs, _path = self.delegate_path(path)
+        with unwrap_errors(path):
+            return _fs.hash(_path, name)
+
     @property
     def walk(self):
         # type: () -> BoundWalker


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

WrapFS didn't contain the new 'hash' method. I think the only consequence of this would have been potentially incorrect error messages in exceptions.