### PR TITLE
fix for tarfs '.' exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Restored deprecated `setfile` method with deprecation warning to change to `writefile`
 - Fixed exception when a tarfile contains a path called '.' https://github.com/PyFilesystem/pyfilesystem2/issues/275
+- Made TarFS directory loading lazy
 
 ## [2.4.4] - 2019-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Restored deprecated `setfile` method with deprecation warning to change to `writefile`
+- Fixed exception when a tarfile contains a path called '.' https://github.com/PyFilesystem/pyfilesystem2/issues/275
 
 ## [2.4.4] - 2019-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed exception when a tarfile contains a path called '.' https://github.com/PyFilesystem/pyfilesystem2/issues/275
 - Made TarFS directory loading lazy
 
+### Changed
+
+- Removed case_insensitive meta value from OSFS meta on OSX. normcase check doesn't work on OSX (https://stackoverflow.com/questions/7870041/check-if-file-system-is-case-insensitive-in-python)
+
 ## [2.4.4] - 2019-02-23
 
 ### Fixed

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.4.5a0"
+__version__ = "2.4.5"

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -143,6 +143,10 @@ class OSFS(FS):
             "virtual": False,
         }
 
+        if platform.system() == "Darwin":
+            # Test doesn't work on OSX
+            del _meta["case_insensitive"]
+
         if _WINDOWS_PLATFORM:  # pragma: no cover
             _meta["invalid_path_chars"] = (
                 "".join(six.unichr(n) for n in range(31)) + '\\:*?"<>|'

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -144,7 +144,8 @@ class OSFS(FS):
         }
 
         if platform.system() == "Darwin":
-            # Test doesn't work on OSX
+            # Standard test doesn't work on OSX.
+            # Best we can say is we don't know.
             del _meta["case_insensitive"]
 
         if _WINDOWS_PLATFORM:  # pragma: no cover

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -279,10 +279,9 @@ class ReadTarFS(FS):
         """Lazy directory cache."""
         if self._directory_cache is None:
             _decode = self._decode
+            _directory = ((_decode(info.name).strip("/"), info) for info in self._tar)
             self._directory_cache = OrderedDict(
-                (_decode(info.name).strip("/"), info)
-                for info in self._tar
-                if normpath(info.name)
+                (name, info) for name, info in _directory if normpath(name)
             )
         return self._directory_cache
 

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -20,7 +20,7 @@ from .enums import ResourceType
 from .info import Info
 from .iotools import RawWrapper
 from .opener import open_fs
-from .path import dirname, relpath, basename, isbase, parts, frombase
+from .path import dirname, relpath, basename, isbase, normpath, parts, frombase
 from .wrapfs import WrapFS
 from .permissions import Permissions
 
@@ -272,9 +272,19 @@ class ReadTarFS(FS):
         else:
             self._tar = tarfile.open(fileobj=file, mode="r")
 
-        self._directory = OrderedDict(
-            (relpath(self._decode(info.name)).rstrip("/"), info) for info in self._tar
-        )
+        self._directory_cache = None
+
+    @property
+    def _directory(self):
+        """Lazy directory cache."""
+        if self._directory_cache is None:
+            _decode = self._decode
+            self._directory_cache = OrderedDict(
+                (_decode(info.name).strip("/"), info)
+                for info in self._tar
+                if normpath(info.name)
+            )
+        return self._directory_cache
 
     def __repr__(self):
         # type: () -> Text

--- a/tests/test_tarfs.py
+++ b/tests/test_tarfs.py
@@ -188,6 +188,30 @@ class TestReadTarFS(ArchiveTestCases, unittest.TestCase):
         self.assertTrue(top.get("tar", "is_file"))
 
 
+class TestBrokenDir(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpfs = open_fs("temp://tarfstest")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmpfs.close()
+
+    def setUp(self):
+        self.tempfile = self.tmpfs.open("test.tar", "wb+")
+        with tarfile.open(mode="w", fileobj=self.tempfile) as tf:
+            tf.addfile(tarfile.TarInfo("."), io.StringIO)
+        self.tempfile.seek(0)
+        self.fs = tarfs.TarFS(self.tempfile)
+
+    def tearDown(self):
+        self.fs.close()
+        self.tempfile.close()
+
+    def test_listdir(self):
+        self.assertEqual(self.fs.listdir("/"), [])
+
+
 class TestImplicitDirectories(unittest.TestCase):
     """Regression tests for #160.
     """


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fix exception when opening tar files (https://github.com/PyFilesystem/pyfilesystem2/issues/275)

