### PR TITLE
Spelling: s/compliment/complement/

### DIFF
--- a/docs/source/walking.rst
+++ b/docs/source/walking.rst
@@ -41,7 +41,7 @@ The ``walk`` attribute may appear to be a method, but is in fact a callable obje
     for path in home_fs.walk.files(filter=['*.py']):
         print('Python file: {}'.format(path))
 
-The compliment to ``files`` is :meth:`~fs.walk.BoundWalker.dirs` which returns paths to just the directories (and ignoring the files). Here's an example::
+The complement to ``files`` is :meth:`~fs.walk.BoundWalker.dirs` which returns paths to just the directories (and ignoring the files). Here's an example::
 
     for dir_path in home_fs.walk.dirs():
         print("{!r} contains sub-directory {}".format(home_fs, dir_path))

--- a/fs/base.py
+++ b/fs/base.py
@@ -281,7 +281,7 @@ class FS(object):
         # type: (Text, RawInfo) -> None
         """Set info on a resource.
 
-        This method is the compliment to `~fs.base.FS.getinfo`
+        This method is the complement to `~fs.base.FS.getinfo`
         and is used to set info values on a resource.
 
         Arguments:


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

I noticed a spelling error in the docs: "complement" was misspelled as "compliment".