### PR TITLE
add expand_vars flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.7] - Unreleased
+
+### Added
+
+- Flag to OSFS to disable env var expansion
+
 ## [2.4.6] - 2019-06-08
 
 ### Added

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.4.6"
+__version__ = "2.4.7"

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -91,6 +91,8 @@ class OSFS(FS):
         create_mode (int): The permissions that will be used to create
             the directory if ``create`` is `True` and the path doesn't
             exist, defaults to ``0o777``.
+        expand_vars(bool): If `True` (the default) environment variables of
+            the form $name or ${name} will be expanded.
 
     Raises:
         `fs.errors.CreateFailed`: If ``root_path`` does not
@@ -108,6 +110,7 @@ class OSFS(FS):
         root_path,  # type: Text
         create=False,  # type: bool
         create_mode=0o777,  # type: SupportsInt
+        expand_vars=True,  # type: bool
     ):
         # type: (...) -> None
         """Create an OSFS instance.
@@ -118,7 +121,9 @@ class OSFS(FS):
         self.root_path = root_path
         _drive, _root_path = os.path.splitdrive(fsdecode(fspath(root_path)))
         _root_path = _drive + (_root_path or "/") if _drive else _root_path
-        _root_path = os.path.expanduser(os.path.expandvars(_root_path))
+        _root_path = os.path.expanduser(
+            os.path.expandvars(_root_path) if expand_vars else _root_path
+        )
         _root_path = os.path.normpath(os.path.abspath(_root_path))
         self._root_path = _root_path
 

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -69,6 +69,16 @@ class TestOSFS(FSTestCases, unittest.TestCase):
         with self.assertRaises(errors.CreateFailed):
             fs = osfs.OSFS("/does/not/exists/")
 
+    def test_expand_vars(self):
+        self.fs.makedir("TYRIONLANISTER")
+        self.fs.makedir("$FOO")
+        path = self.fs.getsyspath("$FOO")
+        os.environ["FOO"] = "TYRIONLANISTER"
+        fs1 = osfs.OSFS(path)
+        fs2 = osfs.OSFS(path, expand_vars=False)
+        self.assertIn("TYRIONLANISTER", fs1.getsyspath("/"))
+        self.assertNotIn("TYRIONLANISTER", fs2.getsyspath("/"))
+
     @unittest.skipIf(osfs.sendfile is None, "sendfile not supported")
     def test_copy_sendfile(self):
         # try copying using sendfile


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Added an expand_vars flag to OSFS constructor to disable env var expansion.
