### PR TITLE
Added support for user/passwd in ftp_url().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.8] - 2019-06-11
+
+### Changed
+
+- `geturl` will return URL with user/password if needed @zmej-serow
+
 ## [2.4.7] - 2019-06-08
 
 ### Added
@@ -15,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Implemented geturl in FTPFS @zmej-serow
+- Implemented `geturl` in FTPFS @zmej-serow
 
 ### Fixed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@ Many thanks to the following developers for contributing to this project:
 - [Giampaolo](https://github.com/gpcimino)
 - [Martin Larralde](https://github.com/althonos)
 - [Will McGugan](https://github.com/willmcgugan)
+- [Zmej Serow](https://github.com/zmej-serow)

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -440,11 +440,9 @@ class FTPFS(FS):
     def ftp_url(self):
         # type: () -> Text
         """Get the FTP url this filesystem will open."""
-        url = (
-            "ftp://{}".format(self.host)
-            if self.port == 21
-            else "ftp://{}:{}".format(self.host, self.port)
-        )
+        _host_part = self.host if self.port == 21 else "{}:{}".format(self.host, self.port)
+        _user_part = "" if self.user == "anonymous" or self.user is None else "{}:{}@".format(self.user, self.passwd)
+        url = "ftp://{}{}".format(_user_part, _host_part)
         return url
 
     @property

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -165,16 +165,23 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
         os.mkdir(self._temp_path)
         super(TestFTPFS, self).tearDown()
 
+    @property
+    def _get_url_start(self):
+        if self.user == "anonymous":
+            return "ftp://127.0.0.1"
+        else:
+            return "ftp://{}:{}@127.0.0.1".format(self.user, self.pasw)
+
     def test_ftp_url(self):
-        self.assertTrue(self.fs.ftp_url.startswith("ftp://127.0.0.1"))
+        self.assertTrue(self.fs.ftp_url.startswith(self._get_url_start))
         
     def test_geturl(self):
         self.fs.makedir("foo")
         self.fs.create("bar")
         self.fs.create("foo/bar")
-        self.assertTrue(self.fs.geturl('foo') == "ftp://127.0.0.1:{}/foo".format(self.server.port))
-        self.assertTrue(self.fs.geturl('bar') == "ftp://127.0.0.1:{}/bar".format(self.server.port))
-        self.assertTrue(self.fs.geturl('foo/bar') == "ftp://127.0.0.1:{}/foo/bar".format(self.server.port))
+        self.assertTrue(self.fs.geturl('foo') == "{}:{}/foo".format(self._get_url_start, self.server.port))
+        self.assertTrue(self.fs.geturl('bar') == "{}:{}/bar".format(self._get_url_start, self.server.port))
+        self.assertTrue(self.fs.geturl('foo/bar') == "{}:{}/foo/bar".format(self._get_url_start, self.server.port))
 
     def test_host(self):
         self.assertEqual(self.fs.host, self.server.host)

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -166,7 +166,7 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
         super(TestFTPFS, self).tearDown()
 
     def test_ftp_url(self):
-        self.assertTrue(self.fs.ftp_url.startswith("ftp://{}:{}@{}".format(self.user, self.pasw, self.server.host)))
+        self.assertEqual(self.fs.ftp_url, "ftp://{}:{}@{}:{}".format(self.user, self.pasw, self.server.host, self.server.port))
         
     def test_geturl(self):
         self.fs.makedir("foo")
@@ -300,7 +300,7 @@ class TestAnonFTPFS(FSTestCases, unittest.TestCase):
         super(TestAnonFTPFS, self).tearDown()
 
     def test_ftp_url(self):
-        self.assertTrue(self.fs.ftp_url.startswith("ftp://{}".format(self.server.host)))
+        self.assertEqual(self.fs.ftp_url, "ftp://{}:{}".format(self.server.host, self.server.port))
 
     def test_geturl(self):
         self.fs.makedir("foo")

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -166,20 +166,20 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
         super(TestFTPFS, self).tearDown()
 
     def test_ftp_url(self):
-        self.assertTrue(self.fs.ftp_url.startswith("ftp://{}:{}@127.0.0.1".format(self.user, self.pasw)))
+        self.assertTrue(self.fs.ftp_url.startswith("ftp://{}:{}@{}".format(self.user, self.pasw, self.server.host)))
         
     def test_geturl(self):
         self.fs.makedir("foo")
         self.fs.create("bar")
         self.fs.create("foo/bar")
         self.assertTrue(
-            self.fs.geturl('foo') == "ftp://{}:{}@127.0.0.1:{}/foo".format(self.user, self.pasw, self.server.port)
+            self.fs.geturl('foo') == "ftp://{}:{}@{}:{}/foo".format(self.user, self.pasw, self.server.host, self.server.port)
         )
         self.assertTrue(
-            self.fs.geturl('bar') == "ftp://{}:{}@127.0.0.1:{}/bar".format(self.user, self.pasw, self.server.port)
+            self.fs.geturl('bar') == "ftp://{}:{}@{}:{}/bar".format(self.user, self.pasw, self.server.host, self.server.port)
         )
         self.assertTrue(
-            self.fs.geturl('foo/bar') == "ftp://{}:{}@127.0.0.1:{}/foo/bar".format(self.user, self.pasw, self.server.port)
+            self.fs.geturl('foo/bar') == "ftp://{}:{}@{}:{}/foo/bar".format(self.user, self.pasw, self.server.host, self.server.port)
         )
 
     def test_host(self):
@@ -300,12 +300,12 @@ class TestAnonFTPFS(FSTestCases, unittest.TestCase):
         super(TestAnonFTPFS, self).tearDown()
 
     def test_ftp_url(self):
-        self.assertTrue(self.fs.ftp_url.startswith("ftp://127.0.0.1"))
+        self.assertTrue(self.fs.ftp_url.startswith("ftp://{}".format(self.server.host)))
 
     def test_geturl(self):
         self.fs.makedir("foo")
         self.fs.create("bar")
         self.fs.create("foo/bar")
-        self.assertTrue(self.fs.geturl('foo') == "ftp://127.0.0.1:{}/foo".format(self.server.port))
-        self.assertTrue(self.fs.geturl('bar') == "ftp://127.0.0.1:{}/bar".format(self.server.port))
-        self.assertTrue(self.fs.geturl('foo/bar') == "ftp://127.0.0.1:{}/foo/bar".format(self.server.port))
+        self.assertTrue(self.fs.geturl('foo') == "ftp://{}:{}/foo".format(self.server.host, self.server.port))
+        self.assertTrue(self.fs.geturl('bar') == "ftp://{}:{}/bar".format(self.server.host, self.server.port))
+        self.assertTrue(self.fs.geturl('foo/bar') == "ftp://{}:{}/foo/bar".format(self.server.host, self.server.port))

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -172,14 +172,14 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
         self.fs.makedir("foo")
         self.fs.create("bar")
         self.fs.create("foo/bar")
-        self.assertTrue(
-            self.fs.geturl('foo') == "ftp://{}:{}@{}:{}/foo".format(self.user, self.pasw, self.server.host, self.server.port)
+        self.assertEqual(
+            self.fs.geturl('foo'), "ftp://{}:{}@{}:{}/foo".format(self.user, self.pasw, self.server.host, self.server.port)
         )
-        self.assertTrue(
-            self.fs.geturl('bar') == "ftp://{}:{}@{}:{}/bar".format(self.user, self.pasw, self.server.host, self.server.port)
+        self.assertEqual(
+            self.fs.geturl('bar'), "ftp://{}:{}@{}:{}/bar".format(self.user, self.pasw, self.server.host, self.server.port)
         )
-        self.assertTrue(
-            self.fs.geturl('foo/bar') == "ftp://{}:{}@{}:{}/foo/bar".format(self.user, self.pasw, self.server.host, self.server.port)
+        self.assertEqual(
+            self.fs.geturl('foo/bar'), "ftp://{}:{}@{}:{}/foo/bar".format(self.user, self.pasw, self.server.host, self.server.port)
         )
 
     def test_host(self):
@@ -306,6 +306,6 @@ class TestAnonFTPFS(FSTestCases, unittest.TestCase):
         self.fs.makedir("foo")
         self.fs.create("bar")
         self.fs.create("foo/bar")
-        self.assertTrue(self.fs.geturl('foo') == "ftp://{}:{}/foo".format(self.server.host, self.server.port))
-        self.assertTrue(self.fs.geturl('bar') == "ftp://{}:{}/bar".format(self.server.host, self.server.port))
-        self.assertTrue(self.fs.geturl('foo/bar') == "ftp://{}:{}/foo/bar".format(self.server.host, self.server.port))
+        self.assertEqual(self.fs.geturl('foo'), "ftp://{}:{}/foo".format(self.server.host, self.server.port))
+        self.assertEqual(self.fs.geturl('bar'), "ftp://{}:{}/bar".format(self.server.host, self.server.port))
+        self.assertEqual(self.fs.geturl('foo/bar'), "ftp://{}:{}/foo/bar".format(self.server.host, self.server.port))


### PR DESCRIPTION
Now they should support user/passwd in URL.

## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Modified tests for ftp_url() and geturl() methods.
