### PR TITLE
Add extra 'clean' rules to Makefile, and get 'make docs' working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
 
 .PHONY: release
-release:
-	rm dist/*.whl dist/*.tar.gz
+release: cleandist
 	python3 setup.py sdist bdist_wheel
 	twine upload dist/*.whl dist/*.tar.gz
+
+.PHONY: cleandist
+cleandist:
+	rm -f dist/*.whl dist/*.tar.gz
+
+.PHONY: cleandocs
+cleandocs:
+	$(MAKE) -C docs clean
+
+.PHONY: clean
+clean: cleandist cleandocs
 
 .PHONY: test
 test:
@@ -19,7 +29,7 @@ testall:
 
 .PHONY: docs
 docs:
-	cd docs && make html
+	$(MAKE) -C docs html
 	python -c "import os, webbrowser; webbrowser.open('file://' + os.path.abspath('./docs/build/html/index.html'))"
 
 .PHONY: typecheck

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@
 
 import sys
 import os
-from fs import __version__
 
 
 import sphinx_rtd_theme
@@ -26,7 +25,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../..'))
 
 # -- General configuration ------------------------------------------------
 
@@ -71,6 +70,7 @@ author = u'Will McGugan'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
+from fs import __version__
 # The short X.Y version.
 version = '.'.join(__version__.split('.')[:2])
 # The full version, including alpha/beta/rc tags.


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Small Makefile tweaks, and fix the `ImportError: No module named 'fs'` error that `make docs` was giving me.