### PR TITLE
[MemFS] Release memory when close() is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.9] - (Unreleased)
+
+### Changed
+
+- `MemFS` now immediately releases all memory it holds when `close()` is called,
+  rather than when it gets garbage collected. Closes [issue #308](https://github.com/PyFilesystem/pyfilesystem2/issues/).
+
 ## [2.4.8] - 2019-06-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - `MemFS` now immediately releases all memory it holds when `close()` is called,
-  rather than when it gets garbage collected. Closes [issue #308](https://github.com/PyFilesystem/pyfilesystem2/issues/).
+  rather than when it gets garbage collected. Closes [issue #308](https://github.com/PyFilesystem/pyfilesystem2/issues/308).
 
 ## [2.4.8] - 2019-06-12
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,9 +2,9 @@
 
 Many thanks to the following developers for contributing to this project:
 
+- [Diego Argueta](https://github.com/dargueta)
 - [Geoff Jukes](https://github.com/geoffjukes)
 - [Giampaolo](https://github.com/gpcimino)
 - [Martin Larralde](https://github.com/althonos)
 - [Will McGugan](https://github.com/willmcgugan)
 - [Zmej Serow](https://github.com/zmej-serow)
-- [Diego Argueta](https://github.com/dargueta)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@ Many thanks to the following developers for contributing to this project:
 - [Martin Larralde](https://github.com/althonos)
 - [Will McGugan](https://github.com/willmcgugan)
 - [Zmej Serow](https://github.com/zmej-serow)
+- [Diego Argueta](https://github.com/dargueta)

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -207,44 +207,6 @@ class _DirEntry(object):
         if not self.is_dir:
             self._bytes_file = io.BytesIO()
 
-    def clean_up(self, force=False):
-        # type: (bool) -> None
-        """Release resources held by this directory entry.
-
-        Arguments:
-            force (bool):
-                Force remaining open files to close and delete subdirectory entries.
-
-        Raises:
-            fs.errors.ResourceLocked:
-                This directory entry has remaining open files and ``force`` is `False`.
-            fs.errors.DirectoryNotEmpty:
-                This directory has remaining entries and ``force`` is `False`.
-        """
-        with self.lock:
-            if self._open_files and not force:
-                raise errors.ResourceLocked(
-                    path=self.name,
-                    msg="Can't release resources for %r: %d open file(s) remain(s)."
-                    % (self.name, len(self._open_files))
-                )
-            if self._dir and not force:
-                raise errors.DirectoryNotEmpty(
-                    path=self.name,
-                    msg="Can't release resources for %r: directory isn't empty." % self.name
-                )
-
-            if self._bytes_file is not None:
-                self._bytes_file.close()
-
-            if force:
-                for fdesc in self._open_files:
-                    fdesc.close()
-
-                for entry in six.itervalues(self._dir):
-                    entry.clean_up(force=force)
-                self._dir.clear()
-
     @property
     def bytes_file(self):
         # type: () -> Optional[io.BytesIO]
@@ -292,8 +254,7 @@ class _DirEntry(object):
 
     def remove_entry(self, name):
         # type: (Text) -> None
-        dirent = self._dir.pop(name)
-        dirent.clean_up()
+        del self._dir[name]
 
     def __contains__(self, name):
         # type: (object) -> bool
@@ -381,7 +342,7 @@ class MemoryFS(FS):
 
     def close(self):
         # type: () -> None
-        self.root.clean_up(force=True)
+        self.root = None
         return super(MemoryFS, self).close()
 
     def getinfo(self, path, namespaces=None):

--- a/tests/test_memoryfs.py
+++ b/tests/test_memoryfs.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import posixpath
 import unittest
 
-from fs import errors
 from fs import memoryfs
 from fs.test import FSTestCases
 from fs.test import UNICODE_TEXT
@@ -67,27 +66,3 @@ class TestMemoryFS(FSTestCases, unittest.TestCase):
             "Memory usage increased after closing the file system; diff is %0.2f KiB."
             % (diff_close.size_diff / 1024.0),
         )
-
-    def test_dirent_clean_up__open_file_crashes(self):
-        """clean_up() crashes if files are open and force=False"""
-        self._create_many_files()
-
-        for path in {"/one/other-two/three/0", "/one/two/2", "/2"}:
-            fdesc = self.fs.open(path, "r")
-
-            with self.subTest(to_drop=path):
-                dirent = self.fs._get_dir_entry(path)
-                self.assertIsNotNone(dirent, "Couldn't find %s" % path)
-                with self.assertRaises(errors.ResourceLocked):
-                    dirent.clean_up()
-
-    def test_dirent_clean_up__subentries_crashes(self):
-        """clean_up() crashes if the dirent has entries and force=False"""
-        self._create_many_files()
-
-        for path in {"/one/other-two/three", "/one/two"}:
-            with self.subTest(to_drop=path):
-                dirent = self.fs._get_dir_entry(path)
-                self.assertIsNotNone(dirent, "Couldn't find %s" % path)
-                with self.assertRaises(errors.DirectoryNotEmpty):
-                    dirent.clean_up()


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

MemFS now immediately releases the memory used up by its files when `close()` is called, rather than when the file system gets garbage collected. Closes #308 .