### PR TITLE
Allow custom subfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,6 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
-.venv
-poetry.lock
-pyproject.toml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.venv
+poetry.lock
+pyproject.toml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/fs/base.py
+++ b/fs/base.py
@@ -101,6 +101,9 @@ class FS(object):
     # most FS will use default walking algorithms
     walker_class = Walker
 
+    # default to SubFS
+    subfs_class = None
+
     def __init__(self):
         # type: (...) -> None
         """Create a filesystem. See help(type(self)) for accurate signature.
@@ -1192,7 +1195,7 @@ class FS(object):
         """
         from .subfs import SubFS
 
-        _factory = factory or SubFS
+        _factory = factory or self.subfs_class or SubFS
 
         if not self.getbasic(path).is_dir:
             raise errors.DirectoryExpected(path=path)

--- a/fs/base.py
+++ b/fs/base.py
@@ -1183,7 +1183,7 @@ class FS(object):
             factory (callable, optional): A callable that when invoked
                 with an FS instance and ``path`` will return a new FS object
                 representing the sub-directory contents. If no ``factory``
-                is supplied then `~fs.subfs.SubFS` will be used.
+                is supplied then `~fs.subfs_class` will be used.
 
         Returns:
             ~fs.subfs.SubFS: A filesystem representing a sub-directory.

--- a/fs/base.py
+++ b/fs/base.py
@@ -101,7 +101,7 @@ class FS(object):
     # most FS will use default walking algorithms
     walker_class = Walker
 
-    # default to SubFS
+    # default to SubFS, used by opendir and should be returned by makedir(s)
     subfs_class = None
 
     def __init__(self):

--- a/tests/test_subfs.py
+++ b/tests/test_subfs.py
@@ -30,14 +30,18 @@ class TestSubFS(TestOSFS):
         _path = os.path.join(self.temp_dir, "__subdir__", relpath(path))
         return _path
 
+
 class CustomSubFS(SubFS):
     """Just a custom class to change the type"""
+
     def custom_function(self, custom_path):
         fs, delegate_path = self.delegate_path(custom_path)
         fs.custom_function(delegate_path)
 
+
 class CustomSubFS2(SubFS):
     """Just a custom class to change the type"""
+
 
 class CustomFS(MemoryFS):
     subfs_class = CustomSubFS
@@ -48,6 +52,7 @@ class CustomFS(MemoryFS):
 
     def custom_function(self, custom_path):
         self.custom_path = custom_path
+
 
 class TestCustomSubFS(unittest.TestCase):
     """Test customization of the SubFS returned from opendir etc"""

--- a/tests/test_subfs.py
+++ b/tests/test_subfs.py
@@ -32,12 +32,22 @@ class TestSubFS(TestOSFS):
 
 class CustomSubFS(SubFS):
     """Just a custom class to change the type"""
+    def custom_function(self, custom_path):
+        fs, delegate_path = self.delegate_path(custom_path)
+        fs.custom_function(delegate_path)
 
 class CustomSubFS2(SubFS):
     """Just a custom class to change the type"""
 
 class CustomFS(MemoryFS):
     subfs_class = CustomSubFS
+
+    def __init__(self):
+        super(CustomFS, self).__init__()
+        self.custom_path = None
+
+    def custom_function(self, custom_path):
+        self.custom_path = custom_path
 
 class TestCustomSubFS(unittest.TestCase):
     """Test customization of the SubFS returned from opendir etc"""
@@ -48,6 +58,9 @@ class TestCustomSubFS(unittest.TestCase):
         subfs = fs.opendir("__subdir__")
         # By default, you get the fs's defined custom SubFS
         assert isinstance(subfs, CustomSubFS)
+
+        subfs.custom_function("filename")
+        assert fs.custom_path == "/__subdir__/filename"
 
         # Providing the factory explicitly still works
         subfs = fs.opendir("__subdir__", factory=CustomSubFS2)

--- a/tests/test_subfs.py
+++ b/tests/test_subfs.py
@@ -3,8 +3,11 @@ from __future__ import unicode_literals
 import os
 import shutil
 import tempfile
+import unittest
 
 from fs import osfs
+from fs.subfs import SubFS
+from fs.memoryfs import MemoryFS
 from fs.path import relpath
 from .test_osfs import TestOSFS
 
@@ -26,3 +29,26 @@ class TestSubFS(TestOSFS):
     def _get_real_path(self, path):
         _path = os.path.join(self.temp_dir, "__subdir__", relpath(path))
         return _path
+
+class CustomSubFS(SubFS):
+    """Just a custom class to change the type"""
+
+class CustomSubFS2(SubFS):
+    """Just a custom class to change the type"""
+
+class CustomFS(MemoryFS):
+    subfs_class = CustomSubFS
+
+class TestCustomSubFS(unittest.TestCase):
+    """Test customization of the SubFS returned from opendir etc"""
+
+    def test_opendir(self):
+        fs = CustomFS()
+        fs.makedir("__subdir__")
+        subfs = fs.opendir("__subdir__")
+        # By default, you get the fs's defined custom SubFS
+        assert isinstance(subfs, CustomSubFS)
+
+        # Providing the factory explicitly still works
+        subfs = fs.opendir("__subdir__", factory=CustomSubFS2)
+        assert isinstance(subfs, CustomSubFS2)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [X] New feature
- [X] Documentation / docstrings
- [X] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Fixes #309. Allows filesystems to specify a custom type to replace the default SubFS, which is, by default, returned by opendir. Filesystem implementors should return their custom type from makedir(s), but existing filesystems will work unaltered.
