### PR TITLE
[FTPFS] Handle EOFError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.9] - (Unreleased)
+
+- `FTPFS` now translates `EOFError` into `RemoteConnectionError`. Closes [#292](https://github.com/PyFilesystem/pyfilesystem2/issues/292)
+
 ## [2.4.8] - 2019-06-12
 
 ### Changed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
 Many thanks to the following developers for contributing to this project:
 
+- [Diego Argueta](https://github.com/dargueta)
 - [Geoff Jukes](https://github.com/geoffjukes)
 - [Giampaolo](https://github.com/gpcimino)
 - [Martin Larralde](https://github.com/althonos)

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -77,6 +77,8 @@ def ftp_errors(fs, path=None):
         raise errors.RemoteConnectionError(
             msg="unable to connect to {}".format(fs.host)
         )
+    except EOFError:
+        raise errors.RemoteConnectionError(msg="lost connection to {}".format(fs.host))
     except error_temp as error:
         if path is not None:
             raise errors.ResourceError(

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import socket
-import ftplib
 import os
 import platform
 import shutil
@@ -114,6 +113,20 @@ class TestFTPErrors(unittest.TestCase):
             with ftp_errors(mem_fs):
                 raise error_perm("999 foo")
 
+    def test_manager_with_host(self):
+        mem_fs = open_fs("mem://")
+        mem_fs.host = "ftp.example.com"
+
+        with self.assertRaises(errors.RemoteConnectionError) as err_info:
+            with ftp_errors(mem_fs):
+                raise EOFError
+        self.assertEqual(str(err_info.exception), "lost connection to ftp.example.com")
+
+        with self.assertRaises(errors.RemoteConnectionError) as err_info:
+            with ftp_errors(mem_fs):
+                raise socket.error
+        self.assertEqual(str(err_info.exception), "unable to connect to ftp.example.com")
+
 
 @attr("slow")
 class TestFTPFS(FSTestCases, unittest.TestCase):
@@ -167,7 +180,7 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
 
     def test_ftp_url(self):
         self.assertEqual(self.fs.ftp_url, "ftp://{}:{}@{}:{}".format(self.user, self.pasw, self.server.host, self.server.port))
-        
+
     def test_geturl(self):
         self.fs.makedir("foo")
         self.fs.create("bar")
@@ -251,7 +264,7 @@ class TestFTPFSNoMLSD(TestFTPFS):
     def test_features(self):
         pass
 
-    
+
 @attr("slow")
 class TestAnonFTPFS(FSTestCases, unittest.TestCase):
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Catch `EOFError` if thrown by an FTP operation and re-raise it as a `RemoteConnectionError`.
Closes #292.