### PR TITLE
Migrate tests to Pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,4 @@ after_success:
   - coveralls
 
 # command to run tests
-script:
-  - tox
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,25 @@
+dist: xenial
 sudo: false
 language: python
 
+python:
+  - '2.7'
+  - '3.4'
+  - '3.5'
+  - '3.6'
+  - '3.7'
+# TODO (dargueta): Enable these once we figure out SFTP timing issues in PyPy tests
+#  - 'pypy'
+#  - 'pypy3.5'
+
 matrix:
   include:
-    - python: "2.7"
-      env:
-        - SETUPTOOLS=setuptools PIP=pip
-    - python: "3.7"
-      env:
-        - SETUPTOOLS=setuptools PIP=pip
-      dist: xenial
-      sudo: true
-      install:
-        - pip install mypy
-        - make typecheck
-    - python: "3.6"
-      install:
-        - pip install mypy
-        - make typecheck
-      env:
-        - SETUPTOOLS=setuptools PIP=pip
-    - python: "3.5"
-      env:
-        - SETUPTOOLS=setuptools PIP=pip
-    - python: "3.4"
-      env:
-        - SETUPTOOLS=setuptools PIP=pip
+    - name: "Type checking"
+      python: '3.7'
+      env: TOXENV=typecheck
 
 before_install:
-  - pip install $SETUPTOOLS $PIP -U
+  - pip install -U tox tox-travis
   - pip --version
   - pip install -r testrequirements.txt
   - pip freeze
@@ -41,4 +32,4 @@ after_success:
 
 # command to run tests
 script:
-  - nosetests -v --with-coverage --cover-package=fs tests
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ python:
   - '3.5'
   - '3.6'
   - '3.7'
-# TODO (dargueta): Enable these once we figure out SFTP timing issues in PyPy tests
+# TODO (dargueta): Enable these once we figure out FTP timing issues in PyPy tests
 #  - 'pypy'
-#  - 'pypy3.5'
+#  - 'pypy3.5-7.0'
 
 matrix:
   include:
-    - name: "Type checking"
+    - name: 'Type checking'
       python: '3.7'
       env: TOXENV=typecheck
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed tests leaving tmp files
 - Fixed typing issues
 - Fixed link namespace returning bytes
+- Fixed abstract class import from `collections` which would break on Python 3.8
+- Fixed incorrect imports of `mock` on Python 3
+- Removed some unused imports and unused `requirements.txt` file
+- Added mypy checks to Travis
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed typing issues
 - Fixed link namespace returning bytes
 
+### Changed
+
+Entire test suite has been migrated to [pytest](https://docs.pytest.org/en/latest/).
+Closes [#327](https://github.com/PyFilesystem/pyfilesystem2/issues/327).
+
 ## [2.4.10] - 2019-07-29
 
 ### Fixed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,10 +20,10 @@ environment:
 
 install:
   # We need wheel installed to build wheels
-  - "%PYTHON%\\python.exe -m pip install nose psutil pyftpdlib mock"
+  - "%PYTHON%\\python.exe -m pip install pytest pytest-randomly pytest-cov psutil pyftpdlib mock"
   - "%PYTHON%\\python.exe setup.py install"
 
 build: off
 
 test_script:
-  - "%PYTHON%\\python.exe -m nose tests -v"
+  - "%PYTHON%\\python.exe -m pytest -v tests"

--- a/docs/source/implementers.rst
+++ b/docs/source/implementers.rst
@@ -54,6 +54,13 @@ You may also want to override some of the methods in the test suite for more tar
 .. autoclass:: fs.test.FSTestCases
     :members:
 
+.. note::
+
+    As of version 2.4.11 this project uses `pytest <https://pytest.org/en/latest/>`_ to run its tests.
+    While it's completely compatible with ``unittest``-style tests, it's much more powerful and
+    feature-rich. We suggest you take advantage of it and its plugins in new tests you write, rather
+    than sticking to strict ``unittest`` features. For benefits and limitations, see `here <https://pytest.org/en/latest/unittest.html>`_.
+
 
 .. _essential-methods:
 

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -8,7 +8,6 @@ import collections
 import errno
 import platform
 import sys
-import typing
 from contextlib import contextmanager
 
 from six import reraise, PY3
@@ -116,4 +115,4 @@ def unwrap_errors(path_replace):
                 e.path = path_replace.get(e.path, e.path)
             else:
                 e.path = path_replace
-        reraise(type(e), e)
+        raise

--- a/fs/test.py
+++ b/fs/test.py
@@ -17,6 +17,8 @@ import math
 import os
 import time
 
+import pytest
+
 import fs.copy
 import fs.move
 from fs import ResourceType, Seek
@@ -1790,7 +1792,7 @@ class FSTestCases(object):
 
     def test_unicode_path(self):
         if not self.fs.getmeta().get("unicode_paths", False):
-            self.skipTest("the filesystem does not support unicode paths.")
+            return pytest.skip("the filesystem does not support unicode paths.")
 
         self.fs.makedir("földér")
         self.fs.writetext("☭.txt", "Smells like communism.")
@@ -1813,10 +1815,10 @@ class FSTestCases(object):
     def test_case_sensitive(self):
         meta = self.fs.getmeta()
         if "case_insensitive" not in meta:
-            self.skipTest("case sensitivity not known")
+            return pytest.skip("case sensitivity not known")
 
         if meta.get("case_insensitive", False):
-            self.skipTest("the filesystem is not case sensitive.")
+            return pytest.skip("the filesystem is not case sensitive.")
 
         self.fs.makedir("foo")
         self.fs.makedir("Foo")

--- a/fs/test.py
+++ b/fs/test.py
@@ -8,7 +8,6 @@ All Filesystems should be able to pass these.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import collections
 from datetime import datetime
 import io
 import itertools
@@ -31,6 +30,11 @@ from fs.subfs import ClosingSubFS, SubFS
 import pytz
 import six
 from six import text_type
+
+if six.PY2:
+    import collections as collections_abc
+else:
+    import collections.abc as collections_abc
 
 
 UNICODE_TEXT = """
@@ -1287,7 +1291,7 @@ class FSTestCases(object):
 
         # Check scandir returns an iterable
         iter_scandir = self.fs.scandir("/")
-        self.assertTrue(isinstance(iter_scandir, collections.Iterable))
+        self.assertTrue(isinstance(iter_scandir, collections_abc.Iterable))
         self.assertEqual(list(iter_scandir), [])
 
         # Check scanning
@@ -1300,7 +1304,7 @@ class FSTestCases(object):
         self.fs.create("bar")
         self.fs.makedir("dir")
         iter_scandir = self.fs.scandir("/")
-        self.assertTrue(isinstance(iter_scandir, collections.Iterable))
+        self.assertTrue(isinstance(iter_scandir, collections_abc.Iterable))
 
         scandir = sorted(
             [r.raw for r in iter_scandir], key=lambda info: info["basic"]["name"]
@@ -1848,4 +1852,3 @@ class FSTestCases(object):
             self.assertEqual(
                 foo_fs.hash("hashme.txt", "md5"), "9fff4bb103ab8ce4619064109c54cb9c"
             )
-

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -12,8 +12,6 @@ from collections import defaultdict
 from collections import deque
 from collections import namedtuple
 
-import six
-
 from ._repr import make_repr
 from .errors import FSError
 from .path import abspath
@@ -295,7 +293,7 @@ class Walker(object):
                 yield info
         except FSError as error:
             if not self.on_error(dir_path, error):
-                six.reraise(type(error), error)
+                raise
 
     def walk(
         self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-appdirs~=1.4.3
-backports.os==0.1.1;  python_version == '2.7'
-enum34==1.1.6 ; python_version < '3.4'
-pytz
-setuptools
-six==1.10.0
-typing==3.6.4 ; python_version < '3.5'

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,3 +43,6 @@ exclude_lines =
     if False:
     @typing.overload
 
+[tool:pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ omit = fs/test.py
 
 [coverage:report]
 show_missing = true
+skip_covered = true
 exclude_lines =
     pragma: no cover
     if False:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,9 @@ warn_return_any = false
 disallow_untyped_defs = false
 
 [coverage:run]
+branch = true
 omit = fs/test.py
+source = fs
 
 [coverage:report]
 show_missing = true

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,6 @@ setup(
     package_data={"fs": ["py.typed"]},
     zip_safe=False,
     platforms=["any"],
-    test_suite="nose.collector",
-    tests_require=["appdirs", "mock", "pytz", "pyftpdlib"],
     url="https://github.com/PyFilesystem/pyfilesystem2",
     version=__version__,
 )

--- a/testrequirements.txt
+++ b/testrequirements.txt
@@ -1,7 +1,6 @@
-appdirs~=1.4.0
-coverage
-mock
-pyftpdlib==1.5.2
-python-coveralls
-pytz==2016.7
-nose
+pytest==4.6.5
+pytest-cov==2.7.1
+pytest-randomly==1.2.3  ; python_version<"3.5"
+pytest-randomly==3.0.0  ; python_version>="3.5"
+mock==3.0.5  ; python_version<"3.3"
+pyftpdlib==1.5.5

--- a/testrequirements.txt
+++ b/testrequirements.txt
@@ -4,3 +4,8 @@ pytest-randomly==1.2.3  ; python_version<"3.5"
 pytest-randomly==3.0.0  ; python_version>="3.5"
 mock==3.0.5  ; python_version<"3.3"
 pyftpdlib==1.5.5
+
+# Not directly required. `pyftpdlib` appears to need these but doesn't list them
+# as requirements.
+psutil
+pysendfile

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+import pytest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+@pytest.fixture
+@mock.patch("appdirs.user_data_dir", autospec=True, spec_set=True)
+@mock.patch("appdirs.site_data_dir", autospec=True, spec_set=True)
+@mock.patch("appdirs.user_config_dir", autospec=True, spec_set=True)
+@mock.patch("appdirs.site_config_dir", autospec=True, spec_set=True)
+@mock.patch("appdirs.user_cache_dir", autospec=True, spec_set=True)
+@mock.patch("appdirs.user_state_dir", autospec=True, spec_set=True)
+@mock.patch("appdirs.user_log_dir", autospec=True, spec_set=True)
+def mock_appdir_directories(
+    user_log_dir_mock,
+    user_state_dir_mock,
+    user_cache_dir_mock,
+    site_config_dir_mock,
+    user_config_dir_mock,
+    site_data_dir_mock,
+    user_data_dir_mock,
+    tmpdir
+):
+    """Mock out every single AppDir directory so tests can't access real ones."""
+    user_log_dir_mock.return_value = str(tmpdir.join("user_log").mkdir())
+    user_state_dir_mock.return_value = str(tmpdir.join("user_state").mkdir())
+    user_cache_dir_mock.return_value = str(tmpdir.join("user_cache").mkdir())
+    site_config_dir_mock.return_value = str(tmpdir.join("site_config").mkdir())
+    user_config_dir_mock.return_value = str(tmpdir.join("user_config").mkdir())
+    site_data_dir_mock.return_value = str(tmpdir.join("site_data").mkdir())
+    user_data_dir_mock.return_value = str(tmpdir.join("user_data").mkdir())

--- a/tests/test_appfs.py
+++ b/tests/test_appfs.py
@@ -1,26 +1,29 @@
 from __future__ import unicode_literals
 
-import unittest
-
+import pytest
 import six
 
-from fs.appfs import UserDataFS
+from fs import appfs
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
-class TestAppFS(unittest.TestCase):
-    """Test Application FS."""
+@pytest.fixture
+def fs(mock_appdir_directories):
+    """Create a UserDataFS but strictly using a temporary directory."""
+    return appfs.UserDataFS("fstest", "willmcgugan", "1.0")
 
-    def test_user_data(self):
-        """Test UserDataFS."""
-        user_data_fs = UserDataFS("fstest", "willmcgugan", "1.0")
-        if six.PY2:
-            self.assertEqual(
-                repr(user_data_fs),
-                "UserDataFS(u'fstest', author=u'willmcgugan', version=u'1.0')",
-            )
-        else:
-            self.assertEqual(
-                repr(user_data_fs),
-                "UserDataFS('fstest', author='willmcgugan', version='1.0')",
-            )
-        self.assertEqual(str(user_data_fs), "<userdatafs 'fstest'>")
+
+@pytest.mark.skipif(six.PY2, reason="Test requires Python 3 repr")
+def test_user_data_repr_py3(fs):
+    assert repr(fs) == "UserDataFS('fstest', author='willmcgugan', version='1.0')"
+    assert str(fs) == "<userdatafs 'fstest'>"
+
+
+@pytest.mark.skipif(not six.PY2, reason="Test requires Python 2 repr")
+def test_user_data_repr_py2(fs):
+    assert repr(fs) == "UserDataFS(u'fstest', author=u'willmcgugan', version=u'1.0')"
+    assert str(fs) == "<userdatafs 'fstest'>"

--- a/tests/test_appfs.py
+++ b/tests/test_appfs.py
@@ -5,11 +5,6 @@ import six
 
 from fs import appfs
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
 
 @pytest.fixture
 def fs(mock_appdir_directories):

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,9 +5,9 @@ from __future__ import unicode_literals
 import unittest
 
 try:
-    import mock
-except ImportError:
     from unittest import mock
+except ImportError:
+    import mock
 
 
 from fs.base import FS

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,12 +4,6 @@ from __future__ import unicode_literals
 
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-
 from fs.base import FS
 from fs import errors
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -6,6 +6,8 @@ import shutil
 import tempfile
 import unittest
 
+import pytest
+
 import six
 
 import fs
@@ -14,7 +16,9 @@ from fs.osfs import OSFS
 
 if platform.system() != "Windows":
 
-    @unittest.skipIf(platform.system() == "Darwin", "Bad unicode not possible on OSX")
+    @pytest.mark.skipif(
+        platform.system() == "Darwin", reason="Bad unicode not possible on OSX"
+    )
     class TestEncoding(unittest.TestCase):
 
         TEST_FILENAME = b"foo\xb1bar"

--- a/tests/test_ftp_parse.py
+++ b/tests/test_ftp_parse.py
@@ -1,10 +1,14 @@
 from __future__ import unicode_literals
 
-import mock
 import time
 import unittest
 
 from fs import _ftp_parse as ftp_parse
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 time2017 = time.struct_time([2017, 11, 28, 1, 1, 1, 1, 332, 0])
 

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -12,8 +12,6 @@ import time
 import unittest
 import uuid
 
-from nose.plugins.attrib import attr
-
 from six import text_type
 
 from ftplib import error_perm
@@ -128,7 +126,6 @@ class TestFTPErrors(unittest.TestCase):
         self.assertEqual(str(err_info.exception), "unable to connect to ftp.example.com")
 
 
-@attr("slow")
 class TestFTPFS(FSTestCases, unittest.TestCase):
 
     user = "user"
@@ -198,7 +195,6 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
     def test_host(self):
         self.assertEqual(self.fs.host, self.server.host)
 
-    # @attr('slow')
     def test_connection_error(self):
         fs = FTPFS("ftp.not.a.chance", timeout=1)
         with self.assertRaises(errors.RemoteConnectionError):
@@ -265,7 +261,6 @@ class TestFTPFSNoMLSD(TestFTPFS):
         pass
 
 
-@attr("slow")
 class TestAnonFTPFS(FSTestCases, unittest.TestCase):
 
     user = "anonymous"

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -12,6 +12,7 @@ import time
 import unittest
 import uuid
 
+import pytest
 from six import text_type
 
 from ftplib import error_perm
@@ -126,6 +127,7 @@ class TestFTPErrors(unittest.TestCase):
         self.assertEqual(str(err_info.exception), "unable to connect to ftp.example.com")
 
 
+@pytest.mark.slow
 class TestFTPFS(FSTestCases, unittest.TestCase):
 
     user = "user"
@@ -261,6 +263,7 @@ class TestFTPFSNoMLSD(TestFTPFS):
         pass
 
 
+@pytest.mark.slow
 class TestAnonFTPFS(FSTestCases, unittest.TestCase):
 
     user = "anonymous"

--- a/tests/test_memoryfs.py
+++ b/tests/test_memoryfs.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 import posixpath
 import unittest
 
+import pytest
+
 from fs import memoryfs
 from fs.test import FSTestCases
 from fs.test import UNICODE_TEXT
@@ -14,6 +16,9 @@ except ImportError:
     tracemalloc = None
 
 
+@pytest.mark.skipif(
+    not tracemalloc, reason="`tracemalloc` isn't supported on this Python version."
+)
 class TestMemoryFS(FSTestCases, unittest.TestCase):
     """Test OSFS implementation."""
 
@@ -28,9 +33,6 @@ class TestMemoryFS(FSTestCases, unittest.TestCase):
                     posixpath.join(parent_dir, str(file_id)), UNICODE_TEXT
                 )
 
-    @unittest.skipIf(
-        not tracemalloc, "`tracemalloc` isn't supported on this Python version."
-    )
     def test_close_mem_free(self):
         """Ensure all file memory is freed when calling close().
 

--- a/tests/test_memoryfs.py
+++ b/tests/test_memoryfs.py
@@ -16,9 +16,6 @@ except ImportError:
     tracemalloc = None
 
 
-@pytest.mark.skipif(
-    not tracemalloc, reason="`tracemalloc` isn't supported on this Python version."
-)
 class TestMemoryFS(FSTestCases, unittest.TestCase):
     """Test OSFS implementation."""
 
@@ -33,6 +30,9 @@ class TestMemoryFS(FSTestCases, unittest.TestCase):
                     posixpath.join(parent_dir, str(file_id)), UNICODE_TEXT
                 )
 
+    @pytest.mark.skipif(
+        not tracemalloc, reason="`tracemalloc` isn't supported on this Python version."
+    )
     def test_close_mem_free(self):
         """Ensure all file memory is freed when calling close().
 

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -276,7 +276,7 @@ class TestOpeners(unittest.TestCase):
         self.assertEqual(app_fs.app_dirs.version, None)
 
     def test_user_data_opener(self):
-        user_data_fs = open_fs("userdata://fstest:willmcgugan:1.0")
+        user_data_fs = open_fs("userdata://fstest:willmcgugan:1.0", create=True)
         self.assertIsInstance(user_data_fs, UserDataFS)
         user_data_fs.makedir("foo", recreate=True)
         user_data_fs.writetext("foo/bar.txt", "baz")

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -1,13 +1,10 @@
 from __future__ import unicode_literals
 
 import os
-import mock
 import sys
 import tempfile
 import unittest
 import pkg_resources
-
-import six
 
 from fs import open_fs, opener
 from fs.osfs import OSFS
@@ -16,6 +13,11 @@ from fs.memoryfs import MemoryFS
 from fs.appfs import UserDataFS
 from fs.opener.parse import ParseResult
 from fs.opener.registry import Registry
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestParse(unittest.TestCase):

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -6,6 +6,8 @@ import tempfile
 import unittest
 import pkg_resources
 
+import pytest
+
 from fs import open_fs, opener
 from fs.osfs import OSFS
 from fs.opener import registry, errors
@@ -206,6 +208,7 @@ class TestManageFS(unittest.TestCase):
         self.assertTrue(mem_fs.isclosed())
 
 
+@pytest.mark.usefixtures("mock_appdir_directories")
 class TestOpeners(unittest.TestCase):
     def test_repr(self):
         # Check __repr__ works

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -8,6 +8,8 @@ import shutil
 import tempfile
 import unittest
 
+import pytest
+
 from fs import osfs
 from fs.path import relpath
 from fs import errors
@@ -87,7 +89,7 @@ class TestOSFS(FSTestCases, unittest.TestCase):
         self.assertIn("TYRIONLANISTER", fs1.getsyspath("/"))
         self.assertNotIn("TYRIONLANISTER", fs2.getsyspath("/"))
 
-    @unittest.skipIf(osfs.sendfile is None, "sendfile not supported")
+    @pytest.mark.skipif(osfs.sendfile is None, reason="sendfile not supported")
     def test_copy_sendfile(self):
         # try copying using sendfile
         with mock.patch.object(osfs, "sendfile") as sendfile:
@@ -133,7 +135,7 @@ class TestOSFS(FSTestCases, unittest.TestCase):
         finally:
             shutil.rmtree(dir_path)
 
-    @unittest.skipIf(not hasattr(os, "symlink"), "No symlink support")
+    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="No symlink support")
     def test_symlinks(self):
         with open(self._get_real_path("foo"), "wb") as f:
             f.write(b"foobar")

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -4,19 +4,22 @@ from __future__ import unicode_literals
 import errno
 import io
 import os
-import mock
 import shutil
 import tempfile
 import unittest
 
 from fs import osfs
-from fs import fsencode, fsdecode
 from fs.path import relpath
 from fs import errors
 
 from fs.test import FSTestCases
 
 from six import text_type
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestOSFS(FSTestCases, unittest.TestCase):

--- a/tests/test_tarfs.py
+++ b/tests/test_tarfs.py
@@ -4,16 +4,13 @@ from __future__ import unicode_literals
 import io
 import os
 import six
-import gzip
-import tarfile
-import getpass
 import tarfile
 import tempfile
 import unittest
-import uuid
+
+import pytest
 
 from fs import tarfs
-from fs import errors
 from fs.enums import ResourceType
 from fs.compress import write_tar
 from fs.opener import open_fs
@@ -106,7 +103,7 @@ class TestWriteGZippedTarFS(FSTestCases, unittest.TestCase):
                 tarfile.open(fs._tar_file, "r:{}".format(other_comps))
 
 
-@unittest.skipIf(six.PY2, "Python2 does not support LZMA")
+@pytest.mark.skipif(six.PY2, reason="Python2 does not support LZMA")
 class TestWriteXZippedTarFS(FSTestCases, unittest.TestCase):
     def make_fs(self):
         fh, _tar_file = tempfile.mkstemp()

--- a/tests/test_tempfs.py
+++ b/tests/test_tempfs.py
@@ -4,9 +4,13 @@ import os
 
 from fs.tempfs import TempFS
 from fs import errors
-import mock
 
 from .test_osfs import TestOSFS
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestTempFS(TestOSFS):

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,16 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37}{,-scandir},pypy
+envlist = {py27,py34,py35,py36,py37}{,-scandir},pypy,typecheck
 sitepackages = False
 skip_missing_interpreters=True
 
 [testenv]
 deps = -r {toxinidir}/testrequirements.txt
 commands = coverage run -m pytest --cov=fs {posargs} {toxinidir}/tests
+
+[testenv:typecheck]
+python=python37
+deps =
+  mypy
+  -r {toxinidir}/testrequirements.txt
+commands = make typecheck
+whitelist_externals = make

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps = -r {toxinidir}/testrequirements.txt
 commands = coverage run -m pytest --cov=fs {posargs} {toxinidir}/tests
 
 [testenv:typecheck]
-python=python37
+python = python37
 deps =
   mypy
   -r {toxinidir}/testrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,5 @@ sitepackages = False
 skip_missing_interpreters=True
 
 [testenv]
-deps = appdirs
-    backports.os
-    coverage
-    enum34
-    nose
-    mock
-    pyftpdlib
-    pytz
-    psutil
-    scandir: scandir
-    pysendfile
-commands = nosetests --with-coverage --cover-package=fs --cover-package=fs.opener tests \
-	[]
+deps = -r {toxinidir}/testrequirements.txt
+commands = coverage run -m pytest --cov=fs {posargs} {toxinidir}/tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters=True
 
 [testenv]
 deps = -r {toxinidir}/testrequirements.txt
-commands = coverage run -m pytest --cov=fs --cov-append {posargs} {toxinidir}/tests
+commands = coverage run -m pytest --cov-append {posargs} {toxinidir}/tests
 
 [testenv:typecheck]
 python = python37

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters=True
 
 [testenv]
 deps = -r {toxinidir}/testrequirements.txt
-commands = coverage run -m pytest --cov=fs {posargs} {toxinidir}/tests
+commands = coverage run -m pytest --cov=fs --cov-append {posargs} {toxinidir}/tests
 
 [testenv:typecheck]
 python = python37


### PR DESCRIPTION
Closes #327

## Type of changes

- [x] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

* Migrate test suite from `nose` to `pytest`
* Randomized execution order of tests to expose interdependencies
* Overhauled Travis config to use tox environments instead of passing them in multiple places

### Bugs / Cleanup

* Fix a few `import mock` bugs that imported `mock` on Python 3 instead of the native module
* Remove unused imports in a few test files
* Remove `requirements.txt`, as it's out of date and no longer needed.
* Fixed abstract class imports from `collections` which will break on Python 3.8