### PR TITLE
Fix missing ENOTSUP on PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       sudo: true
       env:
         - SETUPTOOLS=setuptools PIP=pip
-    - python: "pypy3.5"
+    - python: "pypy3.5-7.0"
       sudo: true
       env:
         - SETUPTOOLS=setuptools PIP=pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ matrix:
     - python: "3.4"
       env:
         - SETUPTOOLS=setuptools PIP=pip
+    - python: "pypy"
+      env:
+        - SETUPTOOLS=setuptools PIP=pip
+    - python: "pypy3.5"
+      env:
+        - SETUPTOOLS=setuptools PIP=pip
 
 before_install:
   - pip install $SETUPTOOLS $PIP -U

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,11 @@ matrix:
       env:
         - SETUPTOOLS=setuptools PIP=pip
     - python: "pypy"
+      sudo: true
       env:
         - SETUPTOOLS=setuptools PIP=pip
     - python: "pypy3.5"
+      sudo: true
       env:
         - SETUPTOOLS=setuptools PIP=pip
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed tests leaving tmp files
 - Fixed typing issues
 - Fixed link namespace returning bytes
+- Fixed missing `errno.ENOTSUP` on PyPy. Closes [#338](https://github.com/PyFilesystem/pyfilesystem2/issues/338).
 
 ## [2.4.10] - 2019-07-29
 

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -728,9 +728,8 @@ class FTPFS(FS):
                     for raw_info in self._parse_mlsx(lines):
                         yield Info(raw_info)
                     return
-            with self._lock:
-                for info in self._read_dir(_path).values():
-                    yield info
+            for info in self._read_dir(_path).values():
+                yield info
 
     def scandir(
         self,

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -60,7 +60,6 @@ if False:  # typing.TYPE_CHECKING
         IO,
         List,
         Optional,
-        MutableSet,
         SupportsInt,
         Text,
         Tuple,
@@ -427,7 +426,7 @@ class OSFS(FS):
             errno.EBADF,
             errno.ENOTSOCK,
             errno.EOPNOTSUPP,
-        }  # type: MutableSet[int]
+        }
 
         # PyPy doesn't define ENOTSUP so we have to add it conditionally.
         if hasattr(errno, "ENOTSUP"):

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: System :: Filesystems",
 ]
 

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -10,7 +10,6 @@ import tempfile
 import unittest
 
 from fs import osfs
-from fs import fsencode, fsdecode
 from fs.path import relpath
 from fs import errors
 
@@ -88,7 +87,7 @@ class TestOSFS(FSTestCases, unittest.TestCase):
     def test_copy_sendfile(self):
         # try copying using sendfile
         with mock.patch.object(osfs, "sendfile") as sendfile:
-            sendfile.side_effect = OSError(errno.ENOTSUP, "sendfile not supported")
+            sendfile.side_effect = OSError(errno.ENOSYS, "sendfile not supported")
             self.test_copy()
         # check other errors are transmitted
         self.fs.touch("foo")


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

1. Only add `errno.ENOTSUP` to FTP failure codes if that's present.
2. Removed a few unused imports.

Closes #338