### PR TITLE
#345: Fix imports breaking setuptools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed tests leaving tmp files
 - Fixed typing issues
 - Fixed link namespace returning bytes
+- Fixed imports and improper namespacing that broke packages using `fs` as a namespace,
+  such as `fs.dropboxfs`. Closes [#345](https://github.com/PyFilesystem/pyfilesystem2/issues/345).
 
 ## [2.4.10] - 2019-07-29
 

--- a/fs/__init__.py
+++ b/fs/__init__.py
@@ -1,8 +1,6 @@
 """Python filesystem abstraction layer.
 """
 
-__import__("pkg_resources").declare_namespace(__name__)
-
 from ._version import __version__
 from .enums import ResourceType, Seek
 from .opener import open_fs

--- a/fs/base.py
+++ b/fs/base.py
@@ -21,7 +21,8 @@ import warnings
 
 import six
 
-from . import copy, errors, fsencode, iotools, move, tools, walk, wildcard
+from . import copy, errors, iotools, move, tools, walk, wildcard
+from ._fscompat import fsencode
 from .glob import BoundGlobber
 from .mode import validate_open_mode
 from .path import abspath, join, normpath

--- a/fs/opener/__init__.py
+++ b/fs/opener/__init__.py
@@ -2,9 +2,6 @@
 """Open filesystems from a URL.
 """
 
-# Declare fs.opener as a namespace package
-__import__("pkg_resources").declare_namespace(__name__)
-
 # Import objects into fs.opener namespace
 from .base import Opener
 from .parse import parse_fs_url as parse

--- a/fs/test.py
+++ b/fs/test.py
@@ -19,10 +19,10 @@ import time
 
 import fs.copy
 import fs.move
-from fs import ResourceType, Seek
 from fs import errors
 from fs import walk
 from fs import glob
+from fs.enums import ResourceType, Seek
 from fs.opener import open_fs
 from fs.subfs import ClosingSubFS, SubFS
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

See detailed description in #345; this PR fixes it. I've tested this manually using fs.dropboxfs and it seems to work, but I don't know how to write unit tests for it.
