### PR TITLE
Add flake8 linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
     - name: 'Type checking'
       python: '3.7'
       env: TOXENV=typecheck
+    - name: 'Lint'
+      python: '3.7'
+      env: TOXENV=lint
 
 before_install:
   - pip install -U tox tox-travis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed abstract class import from `collections` which would break on Python 3.8
 - Fixed incorrect imports of `mock` on Python 3
 - Removed some unused imports and unused `requirements.txt` file
-- Added mypy checks to Travis
+- Added mypy checks to Travis. Closes [#332](https://github.com/PyFilesystem/pyfilesystem2/issues/332).
+- Fixed bug in a decorator that would trigger an `AttributeError` when a class
+  was created that implemented a deprecated method and had no docstring of its
+  own.
 
 ### Changed
 
 - Entire test suite has been migrated to [pytest](https://docs.pytest.org/en/latest/). Closes [#327](https://github.com/PyFilesystem/pyfilesystem2/issues/327).
+- Style checking is now enforced using `flake8`; this involved some code cleanup
+  such as removing unused imports.
 
 ## [2.4.10] - 2019-07-29
 

--- a/fs/_bulk.py
+++ b/fs/_bulk.py
@@ -7,6 +7,7 @@ Implements a thread pool for parallel copying of files.
 from __future__ import unicode_literals
 
 import threading
+import typing
 
 from six.moves.queue import Queue
 
@@ -14,10 +15,10 @@ from .copy import copy_file_internal
 from .errors import BulkCopyFailed
 from .tools import copy_file_data
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from .base import FS
     from types import TracebackType
-    from typing import IO, Iterator, List, Optional, Mapping, Text, Type, Union
+    from typing import IO, List, Optional, Text, Type
 
 
 class _Worker(threading.Thread):

--- a/fs/_bulk.py
+++ b/fs/_bulk.py
@@ -97,7 +97,7 @@ class Copier(object):
     def stop(self):
         """Stop the workers (will block until they are finished)."""
         if self.running and self.num_workers:
-            for worker in self.workers:
+            for _worker in self.workers:
                 self.queue.put(None)
             for worker in self.workers:
                 worker.join()

--- a/fs/_fscompat.py
+++ b/fs/_fscompat.py
@@ -1,5 +1,3 @@
-import sys
-
 import six
 
 try:

--- a/fs/_repr.py
+++ b/fs/_repr.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import typing
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Text, Tuple
 
 

--- a/fs/_typing.py
+++ b/fs/_typing.py
@@ -12,7 +12,7 @@ from typing import overload  # type: ignore
 
 if _PY.major == 3 and _PY.minor == 5 and _PY.micro in (0, 1):
 
-    def overload(func):  # pragma: no cover
+    def overload(func):  # pragma: no cover  # noqa: F811
         return func
 
 

--- a/fs/_url_tools.py
+++ b/fs/_url_tools.py
@@ -1,9 +1,10 @@
 import re
 import six
 import platform
+import typing
 
-if False:  # typing.TYPE_CHECKING
-    from typing import Text, Union, BinaryIO
+if typing.TYPE_CHECKING:
+    from typing import Text
 
 _WINDOWS_PLATFORM = platform.system() == "Windows"
 

--- a/fs/appfs.py
+++ b/fs/appfs.py
@@ -15,7 +15,7 @@ from .osfs import OSFS
 from ._repr import make_repr
 from appdirs import AppDirs
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Optional, Text
 
 

--- a/fs/base.py
+++ b/fs/base.py
@@ -1624,7 +1624,8 @@ class FS(object):
 
         Arguments:
             path(str): A path on the filesystem.
-            name(str): One of the algorithms supported by the hashlib module, e.g. `"md5"`
+            name(str):
+                One of the algorithms supported by the hashlib module, e.g. `"md5"`
 
         Returns:
             str: The hex digest of the hash.

--- a/fs/base.py
+++ b/fs/base.py
@@ -84,7 +84,7 @@ def _new_name(method, old_name):
 """.format(
         method.__name__
     )
-    if getattr(_method, "__doc__"):
+    if hasattr(_method, "__doc__"):
         _method.__doc__ += deprecated_msg
 
     return _method

--- a/fs/base.py
+++ b/fs/base.py
@@ -28,7 +28,7 @@ from .path import abspath, join, normpath
 from .time import datetime_to_epoch
 from .walk import Walker
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from datetime import datetime
     from threading import RLock
     from typing import (

--- a/fs/compress.py
+++ b/fs/compress.py
@@ -22,7 +22,7 @@ from .time import datetime_to_epoch
 from .errors import NoSysPath, MissingInfoNamespace
 from .walk import Walker
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import BinaryIO, Optional, Text, Tuple, Type, Union
     from .base import FS
 

--- a/fs/compress.py
+++ b/fs/compress.py
@@ -23,7 +23,7 @@ from .errors import NoSysPath, MissingInfoNamespace
 from .walk import Walker
 
 if typing.TYPE_CHECKING:
-    from typing import BinaryIO, Optional, Text, Tuple, Type, Union
+    from typing import BinaryIO, Optional, Text, Tuple, Union
     from .base import FS
 
     ZipTime = Tuple[int, int, int, int, int, int]

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -11,10 +11,9 @@ from .path import abspath, combine, frombase, normpath
 from .tools import is_thread_safe
 from .walk import Walker
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Callable, Optional, Text, Union
     from .base import FS
-    from .walk import Walker
 
     _OnCopy = Callable[[FS, Text, FS, Text], object]
 

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -16,12 +16,12 @@ from . import errors
 
 if typing.TYPE_CHECKING:
     from types import TracebackType
-    from typing import Iterator, Optional, Mapping, Text, Type, Union
+    from typing import Iterator, Optional, Text, Type, Union
 
 try:
     from collections.abc import Mapping
 except ImportError:
-    from collections import Mapping
+    from collections import Mapping  # noqa: E811
 
 
 _WINDOWS_PLATFORM = platform.system() == "Windows"

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 import errno
 import platform
 import sys
+import typing
 from contextlib import contextmanager
 
 from six import reraise

--- a/fs/error_tools.py
+++ b/fs/error_tools.py
@@ -4,23 +4,22 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import collections
 import errno
 import platform
 import sys
 from contextlib import contextmanager
 
-from six import reraise, PY3
+from six import reraise
 
 from . import errors
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from types import TracebackType
     from typing import Iterator, Optional, Mapping, Text, Type, Union
 
-if PY3:
+try:
     from collections.abc import Mapping
-else:
+except ImportError:
     from collections import Mapping
 
 

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -17,7 +17,7 @@ import typing
 import six
 from six import text_type
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Optional, Text
 
 

--- a/fs/filesize.py
+++ b/fs/filesize.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 
 import typing
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Iterable, SupportsInt, Text
 
 

--- a/fs/filesize.py
+++ b/fs/filesize.py
@@ -34,7 +34,8 @@ def _to_str(size, suffixes, base):
     elif size < base:
         return "{:,} bytes".format(size)
 
-    for i, suffix in enumerate(suffixes, 2):
+    # TODO (dargueta): Don't rely on unit or suffix being defined in the loop.
+    for i, suffix in enumerate(suffixes, 2):  # noqa: B007
         unit = base ** i
         if size < unit:
             break

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import calendar
-import ftplib
 import io
 import itertools
 import socket
@@ -36,7 +35,7 @@ from .path import normpath
 from .path import split
 from . import _ftp_parse as ftp_parse
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     import ftplib
     from typing import (
         Any,
@@ -45,7 +44,6 @@ if False:  # typing.TYPE_CHECKING
         ContextManager,
         Iterable,
         Iterator,
-        Collection,
         Container,
         Dict,
         List,
@@ -103,7 +101,7 @@ def manage_ftp(ftp):
     finally:
         try:
             ftp.quit()
-        except:  # pragma: no cover
+        except Exception:  # pragma: no cover
             pass
 
 
@@ -442,8 +440,15 @@ class FTPFS(FS):
     def ftp_url(self):
         # type: () -> Text
         """Get the FTP url this filesystem will open."""
-        _host_part = self.host if self.port == 21 else "{}:{}".format(self.host, self.port)
-        _user_part = "" if self.user == "anonymous" or self.user is None else "{}:{}@".format(self.user, self.passwd)
+        if self.port == 21:
+            _host_part = self.host
+        else:
+            _host_part = "{}:{}".format(self.host, self.port)
+
+        if self.user == "anonymous" or self.user is None:
+            _user_part = ""
+        else:
+            _user_part = "{}:{}@".format(self.user, self.passwd)
         url = "ftp://{}{}".format(_user_part, _host_part)
         return url
 
@@ -575,7 +580,7 @@ class FTPFS(FS):
                 details["created"] = cls._parse_ftp_time(facts["create"])
             yield raw_info
 
-    if False:  # typing.TYPE_CHECKING
+    if typing.TYPE_CHECKING:
 
         def opendir(self, path, factory=None):
             # type: (_F, Text, Optional[_OpendirFactory]) -> SubFS[_F]

--- a/fs/glob.py
+++ b/fs/glob.py
@@ -179,7 +179,7 @@ class Globber(object):
         directories = 0
         files = 0
         data = 0
-        for path, info in self._make_iter(namespaces=["details"]):
+        for _path, info in self._make_iter(namespaces=["details"]):
             if info.is_dir:
                 directories += 1
             else:

--- a/fs/glob.py
+++ b/fs/glob.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 from collections import namedtuple
-from typing import Iterator, List
 import re
+import typing
 
 from .lrucache import LRUCache
 from ._repr import make_repr
@@ -14,10 +14,9 @@ GlobMatch = namedtuple("GlobMatch", ["path", "info"])
 Counts = namedtuple("Counts", ["files", "directories", "data"])
 LineCounts = namedtuple("LineCounts", ["lines", "non_blank"])
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Iterator, List, Optional, Pattern, Text, Tuple
     from .base import FS
-    from .info import Info
 
 
 _PATTERN_CACHE = LRUCache(

--- a/fs/info.py
+++ b/fs/info.py
@@ -69,16 +69,16 @@ class Info(object):
         return self.raw == getattr(other, "raw", None)
 
     @overload
-    def _make_datetime(self, t):  # pragma: no cover
+    def _make_datetime(self, t):
         # type: (None) -> None
         pass
 
-    @overload
-    def _make_datetime(self, t):  # pragma: no cover
+    @overload  # noqa: F811
+    def _make_datetime(self, t):
         # type: (int) -> datetime
         pass
 
-    def _make_datetime(self, t):
+    def _make_datetime(self, t):  # noqa: F811
         # type: (Optional[int]) -> Optional[datetime]
         if t is not None:
             return self._to_datetime(t)
@@ -86,16 +86,16 @@ class Info(object):
             return None
 
     @overload
-    def get(self, namespace, key):  # pragma: no cover
+    def get(self, namespace, key):
         # type: (Text, Text) -> Any
         pass
 
-    @overload
-    def get(self, namespace, key, default):  # pragma: no cover
+    @overload  # noqa: F811
+    def get(self, namespace, key, default):
         # type: (Text, Text, T) -> Union[Any, T]
         pass
 
-    def get(self, namespace, key, default=None):
+    def get(self, namespace, key, default=None):  # noqa: F811
         # type: (Text, Text, Optional[Any]) -> Optional[Any]
         """Get a raw info value.
 

--- a/fs/info.py
+++ b/fs/info.py
@@ -18,7 +18,7 @@ from .permissions import Permissions
 from .time import epoch_to_datetime
 from ._typing import overload, Text
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from datetime import datetime
     from typing import Any, Callable, List, Mapping, Optional, Union
 

--- a/fs/iotools.py
+++ b/fs/iotools.py
@@ -10,11 +10,10 @@ from io import SEEK_SET, SEEK_CUR
 
 from .mode import Mode
 
-if False:  # typing.TYPE_CHECKING
-    from io import RawIOBase, IOBase
+if typing.TYPE_CHECKING:
+    from io import RawIOBase
     from typing import (
         Any,
-        BinaryIO,
         Iterable,
         Iterator,
         IO,

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -228,22 +228,22 @@ class _DirEntry(object):
                 _bytes_file.seek(0, os.SEEK_END)
                 return _bytes_file.tell()
 
-    @overload
-    def get_entry(self, name, default):  # pragma: no cover
+    @overload  # noqa: F811
+    def get_entry(self, name, default):
         # type: (Text, _DirEntry) -> _DirEntry
         pass
 
-    @overload
-    def get_entry(self, name):  # pragma: no cover
+    @overload  # noqa: F811
+    def get_entry(self, name):
         # type: (Text) -> Optional[_DirEntry]
         pass
 
-    @overload
-    def get_entry(self, name, default):  # pragma: no cover
+    @overload  # noqa: F811
+    def get_entry(self, name, default):
         # type: (Text, None) -> Optional[_DirEntry]
         pass
 
-    def get_entry(self, name, default=None):
+    def get_entry(self, name, default=None):  # noqa: F811
         # type: (Text, Optional[_DirEntry]) -> Optional[_DirEntry]
         assert self.is_dir, "must be a directory"
         return self._dir.get(name, default)

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -23,7 +23,7 @@ from .path import normpath
 from .path import split
 from ._typing import overload
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import (
         Any,
         BinaryIO,
@@ -377,7 +377,7 @@ class MemoryFS(FS):
                 raise errors.DirectoryExpected(path)
             return dir_entry.list()
 
-    if False:  # typing.TYPE_CHECKING
+    if typing.TYPE_CHECKING:
 
         def opendir(self, path, factory=None):
             # type: (_M, Text, Optional[_OpendirFactory]) -> SubFS[_M]

--- a/fs/mirror.py
+++ b/fs/mirror.py
@@ -19,7 +19,6 @@ the expense of potentially copying extra files.
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from contextlib import contextmanager
 import typing
 
 from ._bulk import Copier
@@ -29,7 +28,7 @@ from .opener import manage_fs
 from .tools import is_thread_safe
 from .walk import Walker
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Callable, Optional, Text, Union
     from .base import FS
     from .info import Info

--- a/fs/mode.py
+++ b/fs/mode.py
@@ -15,8 +15,8 @@ import six
 from ._typing import Text
 
 
-if False:  # typing.TYPE_CHECKING
-    from typing import Container, FrozenSet, Set, Union
+if typing.TYPE_CHECKING:
+    from typing import FrozenSet, Set, Union
 
 
 __all__ = ["Mode", "check_readable", "check_writable", "validate_openbin_mode"]

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -18,7 +18,7 @@ from .path import normpath
 from .mode import validate_open_mode
 from .mode import validate_openbin_mode
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import (
         Any,
         BinaryIO,

--- a/fs/move.py
+++ b/fs/move.py
@@ -10,7 +10,7 @@ from .copy import copy_dir
 from .copy import copy_file
 from .opener import manage_fs
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from .base import FS
     from typing import Text, Union
 

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -17,7 +17,7 @@ from .mode import check_writable
 from .opener import open_fs
 from .path import abspath, normpath
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import (
         Any,
         BinaryIO,

--- a/fs/opener/appfs.py
+++ b/fs/opener/appfs.py
@@ -12,7 +12,7 @@ from .base import Opener
 from .registry import registry
 from .errors import OpenerError
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Text, Union
     from .parse import ParseResult
     from ..appfs import _AppFS

--- a/fs/opener/base.py
+++ b/fs/opener/base.py
@@ -7,8 +7,8 @@ import typing
 
 import six
 
-if False:  # typing.TYPE_CHECKING
-    from typing import List, Text, Union
+if typing.TYPE_CHECKING:
+    from typing import List, Text
     from ..base import FS
     from .parse import ParseResult
 

--- a/fs/opener/ftpfs.py
+++ b/fs/opener/ftpfs.py
@@ -6,16 +6,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import six
-
 import typing
 
 from .base import Opener
 from .registry import registry
-from ..errors import FSError, CreateFailed
+from ..errors import CreateFailed
 
-if False:  # typing.TYPE_CHECKING
-    from typing import List, Text, Union
+if typing.TYPE_CHECKING:
+    from typing import Text, Union
     from ..ftpfs import FTPFS
     from ..subfs import SubFS
     from .parse import ParseResult

--- a/fs/opener/ftpfs.py
+++ b/fs/opener/ftpfs.py
@@ -14,7 +14,7 @@ from ..errors import CreateFailed
 
 if typing.TYPE_CHECKING:
     from typing import Text, Union
-    from ..ftpfs import FTPFS
+    from ..ftpfs import FTPFS  # noqa: F401
     from ..subfs import SubFS
     from .parse import ParseResult
 

--- a/fs/opener/memoryfs.py
+++ b/fs/opener/memoryfs.py
@@ -14,7 +14,7 @@ from .registry import registry
 if typing.TYPE_CHECKING:
     from typing import Text
     from .parse import ParseResult
-    from ..memoryfs import MemoryFS
+    from ..memoryfs import MemoryFS  # noqa: F401
 
 
 @registry.install

--- a/fs/opener/memoryfs.py
+++ b/fs/opener/memoryfs.py
@@ -11,7 +11,7 @@ import typing
 from .base import Opener
 from .registry import registry
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Text
     from .parse import ParseResult
     from ..memoryfs import MemoryFS

--- a/fs/opener/osfs.py
+++ b/fs/opener/osfs.py
@@ -14,7 +14,7 @@ from .registry import registry
 if typing.TYPE_CHECKING:
     from typing import Text
     from .parse import ParseResult
-    from ..osfs import OSFS
+    from ..osfs import OSFS  # noqa: F401
 
 
 @registry.install

--- a/fs/opener/osfs.py
+++ b/fs/opener/osfs.py
@@ -11,7 +11,7 @@ import typing
 from .base import Opener
 from .registry import registry
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Text
     from .parse import ParseResult
     from ..osfs import OSFS

--- a/fs/opener/parse.py
+++ b/fs/opener/parse.py
@@ -14,7 +14,7 @@ from six.moves.urllib.parse import parse_qs, unquote
 
 from .errors import ParseError
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Optional, Text
 
 

--- a/fs/opener/registry.py
+++ b/fs/opener/registry.py
@@ -10,20 +10,18 @@ import collections
 import contextlib
 import typing
 
-import six
 import pkg_resources
 
 from .base import Opener
 from .errors import UnsupportedProtocol, EntryPointError
 from .parse import parse_fs_url
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import (
         Callable,
         Dict,
         Iterator,
         List,
-        Optional,
         Text,
         Type,
         Tuple,
@@ -279,8 +277,6 @@ class Registry(object):
             _fs = self.open_fs(fs_url, create=create, writeable=writeable, cwd=cwd)
             try:
                 yield _fs
-            except:
-                raise
             finally:
                 _fs.close()
 

--- a/fs/opener/tarfs.py
+++ b/fs/opener/tarfs.py
@@ -15,7 +15,7 @@ from .errors import NotWriteable
 if typing.TYPE_CHECKING:
     from typing import Text
     from .parse import ParseResult
-    from ..tarfs import TarFS
+    from ..tarfs import TarFS  # noqa: F401
 
 
 @registry.install

--- a/fs/opener/tarfs.py
+++ b/fs/opener/tarfs.py
@@ -12,7 +12,7 @@ from .base import Opener
 from .registry import registry
 from .errors import NotWriteable
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Text
     from .parse import ParseResult
     from ..tarfs import TarFS

--- a/fs/opener/tempfs.py
+++ b/fs/opener/tempfs.py
@@ -11,7 +11,7 @@ import typing
 from .base import Opener
 from .registry import registry
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Text
     from .parse import ParseResult
     from ..tempfs import TempFS

--- a/fs/opener/tempfs.py
+++ b/fs/opener/tempfs.py
@@ -14,7 +14,7 @@ from .registry import registry
 if typing.TYPE_CHECKING:
     from typing import Text
     from .parse import ParseResult
-    from ..tempfs import TempFS
+    from ..tempfs import TempFS  # noqa: F401
 
 
 @registry.install

--- a/fs/opener/zipfs.py
+++ b/fs/opener/zipfs.py
@@ -15,7 +15,7 @@ from .errors import NotWriteable
 if typing.TYPE_CHECKING:
     from typing import Text
     from .parse import ParseResult
-    from ..zipfs import ZipFS
+    from ..zipfs import ZipFS  # noqa: F401
 
 
 @registry.install

--- a/fs/opener/zipfs.py
+++ b/fs/opener/zipfs.py
@@ -12,7 +12,7 @@ from .base import Opener
 from .registry import registry
 from .errors import NotWriteable
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Text
     from .parse import ParseResult
     from ..zipfs import ZipFS

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -50,11 +50,10 @@ from .mode import Mode, validate_open_mode
 from .errors import FileExpected, NoURL
 from ._url_tools import url_quote
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import (
         Any,
         BinaryIO,
-        Callable,
         Collection,
         Dict,
         Iterator,
@@ -151,7 +150,8 @@ class OSFS(FS):
 
         try:
             # https://stackoverflow.com/questions/7870041/check-if-file-system-is-case-insensitive-in-python
-            # I don't know of a better way of detecting case insensitivity of a filesystem
+            # I don't know of a better way of detecting case insensitivity of a
+            # filesystem
             with tempfile.NamedTemporaryFile(prefix="TmP") as _tmp_file:
                 _meta["case_insensitive"] = os.path.exists(_tmp_file.name.lower())
         except Exception:
@@ -396,7 +396,7 @@ class OSFS(FS):
 
     # --- Type hint for opendir ------------------------------
 
-    if False:  # typing.TYPE_CHECKING
+    if typing.TYPE_CHECKING:
 
         def opendir(self, path, factory=None):
             # type: (_O, Text, Optional[_OpendirFactory]) -> SubFS[_O]
@@ -671,8 +671,7 @@ class OSFS(FS):
         except UnicodeEncodeError as error:
             raise errors.InvalidCharsInPath(
                 path,
-                msg="path '{path}' could not be encoded for the filesystem (check LANG env var); {error}".format(
-                    path=path, error=error
-                ),
+                msg="path '{path}' could not be encoded for the filesystem (check LANG"
+                    " env var); {error}".format(path=path, error=error),
             )
         return super(OSFS, self).validatepath(path)

--- a/fs/path.py
+++ b/fs/path.py
@@ -68,7 +68,7 @@ def normpath(path):
             ...
         IllegalBackReference: path 'foo/../../bar' contains back-references outside of filesystem"
 
-    """
+    """  # noqa: E501
     if path in "/":
         return path
 

--- a/fs/path.py
+++ b/fs/path.py
@@ -16,7 +16,7 @@ import typing
 
 from .errors import IllegalBackReference
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import List, Text, Tuple
 
 

--- a/fs/permissions.py
+++ b/fs/permissions.py
@@ -5,14 +5,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import typing
-from typing import Container, Iterable
+from typing import Iterable
 
 import six
 
 from ._typing import Text
 
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Iterator, List, Optional, Tuple, Type, Union
 
 

--- a/fs/subfs.py
+++ b/fs/subfs.py
@@ -12,6 +12,7 @@ from .wrapfs import WrapFS
 from .path import abspath, join, normpath, relpath
 
 if typing.TYPE_CHECKING:
+    from .base import FS  # noqa: E401
     from typing import Text, Tuple
 
 

--- a/fs/subfs.py
+++ b/fs/subfs.py
@@ -11,9 +11,8 @@ import six
 from .wrapfs import WrapFS
 from .path import abspath, join, normpath, relpath
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Text, Tuple
-    from .base import FS
 
 
 _F = typing.TypeVar("_F", bound="FS", covariant=True)

--- a/fs/subfs.py
+++ b/fs/subfs.py
@@ -12,7 +12,7 @@ from .wrapfs import WrapFS
 from .path import abspath, join, normpath, relpath
 
 if typing.TYPE_CHECKING:
-    from .base import FS  # noqa: E401
+    from .base import FS  # noqa: F401
     from typing import Text, Tuple
 
 

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -20,16 +20,14 @@ from .errors import IllegalBackReference, NoURL
 from .info import Info
 from .iotools import RawWrapper
 from .opener import open_fs
+from ._url_tools import url_quote
 from .path import relpath, basename, isbase, normpath, parts, frombase
 from .wrapfs import WrapFS
-from .permissions import Permissions
-from ._url_tools import url_quote
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from tarfile import TarInfo
     from typing import (
         Any,
-        AnyStr,
         BinaryIO,
         Collection,
         Dict,
@@ -39,7 +37,7 @@ if False:  # typing.TYPE_CHECKING
         Tuple,
         Union,
     )
-    from .info import Info, RawInfo
+    from .info import RawInfo
     from .permissions import Permissions
     from .subfs import SubFS
 
@@ -143,7 +141,7 @@ class TarFS(WrapFS):
         else:
             return ReadTarFS(file, encoding=encoding)
 
-    if False:  # typing.TYPE_CHECKING
+    if typing.TYPE_CHECKING:
 
         def __init__(
             self,

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -20,6 +20,7 @@ from .errors import IllegalBackReference, NoURL
 from .info import Info
 from .iotools import RawWrapper
 from .opener import open_fs
+from .permissions import Permissions
 from ._url_tools import url_quote
 from .path import relpath, basename, isbase, normpath, parts, frombase
 from .wrapfs import WrapFS
@@ -38,7 +39,6 @@ if typing.TYPE_CHECKING:
         Union,
     )
     from .info import RawInfo
-    from .permissions import Permissions
     from .subfs import SubFS
 
     T = typing.TypeVar("T", bound="ReadTarFS")

--- a/fs/tempfs.py
+++ b/fs/tempfs.py
@@ -21,7 +21,7 @@ import six
 from . import errors
 from .osfs import OSFS
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import Optional, Text
 
 

--- a/fs/test.py
+++ b/fs/test.py
@@ -485,7 +485,7 @@ class FSTestCases(object):
         # Raw info should be serializable
         try:
             json.dumps(info)
-        except:
+        except ValueError:
             assert False, "info should be JSON serializable"
 
         # Non existant namespace is not an error

--- a/fs/test.py
+++ b/fs/test.py
@@ -1286,7 +1286,7 @@ class FSTestCases(object):
     def test_scandir(self):
         # Check exception for scanning dir that doesn't exist
         with self.assertRaises(errors.ResourceNotFound):
-            for info in self.fs.scandir("/foobar"):
+            for _info in self.fs.scandir("/foobar"):
                 pass
 
         # Check scandir returns an iterable
@@ -1307,7 +1307,7 @@ class FSTestCases(object):
         self.assertTrue(isinstance(iter_scandir, collections_abc.Iterable))
 
         scandir = sorted(
-            [r.raw for r in iter_scandir], key=lambda info: info["basic"]["name"]
+            (r.raw for r in iter_scandir), key=lambda info: info["basic"]["name"]
         )
 
         # Filesystems may send us more than we ask for
@@ -1337,7 +1337,7 @@ class FSTestCases(object):
         self.assertEqual(len(page2), 1)
         page3 = list(self.fs.scandir("/", page=(4, 6)))
         self.assertEqual(len(page3), 0)
-        paged = set(r.name for r in itertools.chain(page1, page2))
+        paged = {r.name for r in itertools.chain(page1, page2)}
         self.assertEqual(paged, {"foo", "bar", "dir"})
 
     def test_filterdir(self):

--- a/fs/test.py
+++ b/fs/test.py
@@ -485,8 +485,8 @@ class FSTestCases(object):
         # Raw info should be serializable
         try:
             json.dumps(info)
-        except ValueError:
-            assert False, "info should be JSON serializable"
+        except (TypeError, ValueError):
+            raise AssertionError("info should be JSON serializable")
 
         # Non existant namespace is not an error
         no_info = self.fs.getinfo("foo", "__nosuchnamespace__").raw

--- a/fs/tools.py
+++ b/fs/tools.py
@@ -4,7 +4,6 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import io
 import typing
 
 from . import errors
@@ -15,7 +14,8 @@ from .path import dirname
 from .path import normpath
 from .path import recursepath
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
+    import io
     from typing import IO, List, Optional, Text
     from .base import FS
 

--- a/fs/tools.py
+++ b/fs/tools.py
@@ -15,7 +15,6 @@ from .path import normpath
 from .path import recursepath
 
 if typing.TYPE_CHECKING:
-    import io
     from typing import IO, List, Optional, Text
     from .base import FS
 

--- a/fs/tree.py
+++ b/fs/tree.py
@@ -12,7 +12,7 @@ import typing
 
 from fs.path import abspath, join, normpath
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import List, Optional, Text, TextIO, Tuple
     from .base import FS
     from .info import Info

--- a/fs/walk.py
+++ b/fs/walk.py
@@ -18,7 +18,7 @@ from .path import abspath
 from .path import combine
 from .path import normpath
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import (
         Any,
         Callable,

--- a/fs/wildcard.py
+++ b/fs/wildcard.py
@@ -9,10 +9,9 @@ import typing
 from functools import partial
 
 from .lrucache import LRUCache
-from . import path
 
-if False:  # typing.TYPE_CHECKING
-    from typing import Callable, Iterable, MutableMapping, Text, Tuple, Pattern
+if typing.TYPE_CHECKING:
+    from typing import Callable, Iterable, Text, Tuple, Pattern
 
 
 _PATTERN_CACHE = LRUCache(1000)  # type: LRUCache[Tuple[Text, bool], Pattern]

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -37,8 +37,8 @@ if typing.TYPE_CHECKING:
         Text,
         Tuple,
     )
-    from .base import FS
-    from .info import Info, RawInfo
+    from .base import FS  # noqa: F401
+    from .info import RawInfo
     from .subfs import SubFS
     from .permissions import Permissions
 

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -24,7 +24,7 @@ from .errors import ResourceReadOnly, ResourceNotFound
 from .info import Info
 from .mode import check_writable
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from datetime import datetime
     from typing import (
         Any,

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -3,7 +3,6 @@
 
 from __future__ import unicode_literals
 
-import copy
 import typing
 
 import six
@@ -16,7 +15,7 @@ from .move import move_file, move_dir
 from .path import abspath, normpath
 from .error_tools import unwrap_errors
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from datetime import datetime
     from threading import RLock
     from typing import (
@@ -25,7 +24,6 @@ if False:  # typing.TYPE_CHECKING
         BinaryIO,
         Callable,
         Collection,
-        Dict,
         Iterator,
         Iterable,
         IO,
@@ -33,7 +31,6 @@ if False:  # typing.TYPE_CHECKING
         Mapping,
         Optional,
         Text,
-        TextIO,
         Tuple,
         Union,
     )

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -24,7 +24,7 @@ from .time import datetime_to_epoch
 from .wrapfs import WrapFS
 from ._url_tools import url_quote
 
-if False:  # typing.TYPE_CHECKING
+if typing.TYPE_CHECKING:
     from typing import (
         Any,
         BinaryIO,
@@ -181,7 +181,7 @@ class ZipFS(WrapFS):
         else:
             return ReadZipFS(file, encoding=encoding)
 
-    if False:  # typing.TYPE_CHECKING
+    if typing.TYPE_CHECKING:
 
         def __init__(
             self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ exclude_lines =
     pragma: no cover
     if False:
     @typing.overload
+    @overload
 
 [tool:pytest]
 markers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,3 +50,19 @@ exclude_lines =
 [tool:pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+
+[flake8]
+extend-ignore = E203,E402,W503
+max-line-length = 88
+per-file-ignores =
+    fs/__init__.py:F401
+    fs/*/__init__.py:F401
+    tests/*:E501
+    fs/opener/*:F811
+    fs/_fscompat.py:F401
+
+[isort]
+default_section = THIRD_PARTY
+known_first_party = fs
+known_standard_library = typing
+line_length = 88

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -10,7 +10,6 @@ from fs.opener import open_fs
 from fs.enums import ResourceType
 from fs import walk
 from fs import errors
-from fs.memoryfs import MemoryFS
 from fs.test import UNICODE_TEXT
 
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -8,8 +8,6 @@ import tempfile
 import shutil
 import calendar
 
-from six import PY2
-
 import fs.copy
 from fs import open_fs
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -354,7 +354,7 @@ class TestCopy(unittest.TestCase):
             src_file1 = self._touch(src_dir, "src" + os.sep + "file1.txt")
             self._write_file(src_file1)
 
-            dst_dir = self._create_sandbox_dir(home=src_dir)
+            self._create_sandbox_dir(home=src_dir)
 
             src_fs = open_fs("osfs://" + src_dir)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -56,7 +56,7 @@ class TestCreateFailed(unittest.TestCase):
         def test(x):
             raise errors[x]
 
-        for index, exc in enumerate(errors):
+        for index, _exc in enumerate(errors):
             try:
                 test(index)
             except Exception as e:

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -124,7 +124,9 @@ class TestFTPErrors(unittest.TestCase):
         with self.assertRaises(errors.RemoteConnectionError) as err_info:
             with ftp_errors(mem_fs):
                 raise socket.error
-        self.assertEqual(str(err_info.exception), "unable to connect to ftp.example.com")
+        self.assertEqual(
+            str(err_info.exception), "unable to connect to ftp.example.com"
+        )
 
 
 @pytest.mark.slow
@@ -178,20 +180,34 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
         super(TestFTPFS, self).tearDown()
 
     def test_ftp_url(self):
-        self.assertEqual(self.fs.ftp_url, "ftp://{}:{}@{}:{}".format(self.user, self.pasw, self.server.host, self.server.port))
+        self.assertEqual(
+            self.fs.ftp_url,
+            "ftp://{}:{}@{}:{}".format(
+                self.user, self.pasw, self.server.host, self.server.port
+            ),
+        )
 
     def test_geturl(self):
         self.fs.makedir("foo")
         self.fs.create("bar")
         self.fs.create("foo/bar")
         self.assertEqual(
-            self.fs.geturl('foo'), "ftp://{}:{}@{}:{}/foo".format(self.user, self.pasw, self.server.host, self.server.port)
+            self.fs.geturl("foo"),
+            "ftp://{}:{}@{}:{}/foo".format(
+                self.user, self.pasw, self.server.host, self.server.port
+            ),
         )
         self.assertEqual(
-            self.fs.geturl('bar'), "ftp://{}:{}@{}:{}/bar".format(self.user, self.pasw, self.server.host, self.server.port)
+            self.fs.geturl("bar"),
+            "ftp://{}:{}@{}:{}/bar".format(
+                self.user, self.pasw, self.server.host, self.server.port
+            ),
         )
         self.assertEqual(
-            self.fs.geturl('foo/bar'), "ftp://{}:{}@{}:{}/foo/bar".format(self.user, self.pasw, self.server.host, self.server.port)
+            self.fs.geturl("foo/bar"),
+            "ftp://{}:{}@{}:{}/foo/bar".format(
+                self.user, self.pasw, self.server.host, self.server.port
+            ),
         )
 
     def test_host(self):
@@ -299,11 +315,7 @@ class TestAnonFTPFS(FSTestCases, unittest.TestCase):
         super(TestAnonFTPFS, cls).tearDownClass()
 
     def make_fs(self):
-        return open_fs(
-            "ftp://{}:{}".format(
-                self.server.host, self.server.port
-            )
-        )
+        return open_fs("ftp://{}:{}".format(self.server.host, self.server.port))
 
     def tearDown(self):
         shutil.rmtree(self._temp_path)
@@ -311,12 +323,23 @@ class TestAnonFTPFS(FSTestCases, unittest.TestCase):
         super(TestAnonFTPFS, self).tearDown()
 
     def test_ftp_url(self):
-        self.assertEqual(self.fs.ftp_url, "ftp://{}:{}".format(self.server.host, self.server.port))
+        self.assertEqual(
+            self.fs.ftp_url, "ftp://{}:{}".format(self.server.host, self.server.port)
+        )
 
     def test_geturl(self):
         self.fs.makedir("foo")
         self.fs.create("bar")
         self.fs.create("foo/bar")
-        self.assertEqual(self.fs.geturl('foo'), "ftp://{}:{}/foo".format(self.server.host, self.server.port))
-        self.assertEqual(self.fs.geturl('bar'), "ftp://{}:{}/bar".format(self.server.host, self.server.port))
-        self.assertEqual(self.fs.geturl('foo/bar'), "ftp://{}:{}/foo/bar".format(self.server.host, self.server.port))
+        self.assertEqual(
+            self.fs.geturl("foo"),
+            "ftp://{}:{}/foo".format(self.server.host, self.server.port),
+        )
+        self.assertEqual(
+            self.fs.geturl("bar"),
+            "ftp://{}:{}/bar".format(self.server.host, self.server.port),
+        )
+        self.assertEqual(
+            self.fs.geturl("foo/bar"),
+            "ftp://{}:{}/foo/bar".format(self.server.host, self.server.port),
+        )

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -29,7 +29,7 @@ class TestParse(unittest.TestCase):
 
     def test_parse_not_url(self):
         with self.assertRaises(errors.ParseError):
-            parsed = opener.parse("foo/bar")
+            opener.parse("foo/bar")
 
     def test_parse_simple(self):
         parsed = opener.parse("osfs://foo/bar")

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals, print_function
+from __future__ import absolute_import, unicode_literals, print_function
 
 """
   fstests.test_path:  testcases for the fs path functions
@@ -8,7 +8,29 @@ from __future__ import unicode_literals, print_function
 
 import unittest
 
-from fs.path import *
+from fs.path import (
+    abspath,
+    basename,
+    combine,
+    dirname,
+    forcedir,
+    frombase,
+    isabs,
+    isbase,
+    isdotfile,
+    isparent,
+    issamedir,
+    iswildcard,
+    iteratepath,
+    join,
+    normpath,
+    parts,
+    recursepath,
+    relativefrom,
+    relpath,
+    split,
+    splitext,
+)
 
 
 class TestPathFunctions(unittest.TestCase):

--- a/tests/test_tarfs.py
+++ b/tests/test_tarfs.py
@@ -163,13 +163,13 @@ class TestReadTarFS(ArchiveTestCases, unittest.TestCase):
     def test_read_from_fileobject(self):
         try:
             tarfs.TarFS(open(self._temp_path, "rb"))
-        except:
+        except Exception:
             self.fail("Couldn't open tarfs from fileobject")
 
     def test_read_from_filename(self):
         try:
             tarfs.TarFS(self._temp_path)
-        except:
+        except Exception:
             self.fail("Couldn't open tarfs from filename")
 
     def test_read_non_existent_file(self):

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from __future__ import unicode_literals
 
 import io

--- a/tox.ini
+++ b/tox.ini
@@ -25,19 +25,3 @@ deps =
   # flake8-isort
   flake8-mutable
 commands = flake8 fs tests
-
-[flake8]
-extend-ignore = E203,E402,W503
-max-line-length = 88
-per-file-ignores =
-    fs/__init__.py:F401
-    fs/*/__init__.py:F401
-    tests/*:E501
-    fs/opener/*:F811
-    fs/_fscompat.py:F401
-
-[isort]
-default_section = THIRD_PARTY
-known_first_party = fs
-known_standard_library = typing
-line_length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -14,3 +14,6 @@ deps =
   -r {toxinidir}/testrequirements.txt
 commands = make typecheck
 whitelist_externals = make
+
+[flake8]
+max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37}{,-scandir},pypy,typecheck
+envlist = {py27,py34,py35,py36,py37}{,-scandir},pypy,typecheck,lint
 sitepackages = False
 skip_missing_interpreters=True
 
@@ -15,5 +15,29 @@ deps =
 commands = make typecheck
 whitelist_externals = make
 
+[testenv:lint]
+python = python37
+deps =
+  flake8
+  # flake8-builtins
+  flake8-bugbear
+  flake8-comprehensions
+  # flake8-isort
+  flake8-mutable
+commands = flake8 fs tests
+
 [flake8]
+extend-ignore = E203,E402,W503
 max-line-length = 88
+per-file-ignores =
+    fs/__init__.py:F401
+    fs/*/__init__.py:F401
+    tests/*:E501
+    fs/opener/*:F811
+    fs/_fscompat.py:F401
+
+[isort]
+default_section = THIRD_PARTY
+known_first_party = fs
+known_standard_library = typing
+line_length = 88


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

### Bugs (or potential ones)

* Fixed `getattr` call that would cause an AttributeError where it was supposed to prevent it.
* Replaced overbroad except when serializing JSON with its documented exceptions. This would otherwise have hidden problems we weren't expecting.
* Replaced bare `except:` with `except Exception:`, see [here](https://docs.python.org/2/howto/doanddont.html#except) for why.

## Cleanup

* Removed unused imports
* Fixed some long lines
* Explicitly marked unused variables with leading underscore
* Removed unused variables
* Replaced `if False` with `if typing.TYPE_CHECKING`
* Replaced `from *` with explicit imports in some tests

## Other

* Added flake8 for linting
* Minor tweak to coverage so `@overload` is also ignored, not just `@typing.overload`

Expansion on discussion in #332.