### PR TITLE
Start testing PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ python:
   - "3.6"
   - "3.7"
   - "3.8-dev"
-# TODO (dargueta): Enable these once we figure out FTP timing issues in PyPy tests
-#  - 'pypy'
-#  - 'pypy3.5-7.0'
+  - 'pypy'
+  - 'pypy3.5-7.0'  # Need 7.0+ due to a bug in earlier versions that broke our tests.
 
 matrix:
   include:
@@ -21,6 +20,11 @@ matrix:
     - name: 'Lint'
       python: '3.7'
       env: TOXENV=lint
+
+  # Temporary bandaid for https://github.com/PyFilesystem/pyfilesystem2/issues/342
+  allow_failures:
+    - python: pypy
+    - python: pypy3.5-7.0
 
 before_install:
   - pip install -U tox tox-travis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.4.12] - (Unreleased)
+
+### Changed
+
+- Start testing on PyPy. Due to [#342](https://github.com/PyFilesystem/pyfilesystem2/issues/342)
+  we have to treat PyPy builds specially and allow them to fail, but at least we'll
+  be able to see if we break something aside from known issues with FTP tests.
+
 ## [2.4.11] - 2019-09-07
 
 ### Added


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

There's a problem with the SFTP server daemon in our tests that causes PyPy to fail on them (see #342). We can still test PyPy compatibility with other parts of the codebase without failing the build by using Travis' [`allow_failures`](https://docs.travis-ci.com/user/customizing-the-build/#rows-that-are-allowed-to-fail) directive. This will still run tests on PyPy, but won't fail the build if the PyPy builds don't pass. We can remove the `allow_failures` part once #342 is fixed.
