### PR TITLE
password support to ZipFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.4.12] - (Unreleased)
 
+### Added
+
+- Added `passwd` argument and `setpassword` for ReadZipFS to extract password
+  protected date from zip file. [#360](https://github.com/PyFilesystem/pyfilesystem2/issues/360)
+
 ### Changed
 
 - Start testing on PyPy. Due to [#342](https://github.com/PyFilesystem/pyfilesystem2/issues/342)

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -41,6 +41,7 @@ __all__ = [
     "NoURL",
     "OperationFailed",
     "OperationTimeout",
+    "PasswordUnsupported",
     "PathError",
     "PermissionDenied",
     "RemoteConnectionError",
@@ -253,6 +254,13 @@ class RemoveRootError(OperationFailed):
     """
 
     default_message = "root directory may not be removed"
+
+
+class PasswordUnsupported(Unsupported):
+    """Attempt to create a password protected zip file.
+    """
+
+    default_message = "can not create password protected zip"
 
 
 class ResourceError(FSError):

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -483,6 +483,4 @@ class ReadZipFS(FS):
         # type: (AnyStr) -> None
         """Set *passwd* as default password to extract encrypted files.
         """
-        if passwd is None:
-            raise ValueError('passwd')
         self._zip.setpassword(_bytes(passwd))

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -461,13 +461,13 @@ class ReadZipFS(FS):
         if hasattr(self, "_zip"):
             self._zip.close()
 
-    def readbytes(self, path, pwd=None):
+    def readbytes(self, path, passwd=None):
         # type: (Text, Optional[AnyStr]) -> bytes
         self.check()
         if not self._directory.isfile(path):
             raise errors.ResourceNotFound(path)
         zip_name = self._path_to_zip_name(path)
-        zip_bytes = self._zip.read(zip_name, pwd=_bytes(pwd))
+        zip_bytes = self._zip.read(zip_name, pwd=_bytes(passwd))
         return zip_bytes
 
     def geturl(self, path, purpose="download"):

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -160,6 +160,8 @@ class ZipFS(WrapFS):
             defined in the `zipfile` module in the stdlib).
         temp_fs (str): An FS URL for the temporary filesystem used to
             store data prior to zipping.
+        passwd (str or bytes): Password for extracting file from zip file. Only
+            used for read mode.
 
     """
 
@@ -171,11 +173,14 @@ class ZipFS(WrapFS):
         compression=zipfile.ZIP_DEFLATED,  # type: int
         encoding="utf-8",  # type: Text
         temp_fs="temp://__ziptemp__",  # type: Text
+        passwd=None,  # type: Optional[AnyStr]
     ):
         # type: (...) -> FS
         # This magic returns a different class instance based on the
         # value of the ``write`` parameter.
         if write:
+            if passwd is not None:
+                raise errors.PasswordUnsupported()
             return WriteZipFS(
                 file, compression=compression, encoding=encoding, temp_fs=temp_fs
             )
@@ -191,6 +196,7 @@ class ZipFS(WrapFS):
             compression=zipfile.ZIP_DEFLATED,  # type: int
             encoding="utf-8",  # type: Text
             temp_fs="temp://__ziptemp__",  # type: Text
+            passwd=None,  # type: Optional[AnyStr]
         ):
             # type: (...) -> None
             pass

--- a/tests/test_zipfs.py
+++ b/tests/test_zipfs.py
@@ -1,6 +1,7 @@
 # -*- encoding: UTF-8
 from __future__ import unicode_literals
 
+import codecs
 import os
 import sys
 import tempfile
@@ -13,11 +14,20 @@ from fs import zipfs
 from fs.compress import write_zip
 from fs.opener import open_fs
 from fs.opener.errors import NotWriteable
-from fs.errors import NoURL
+from fs.errors import NoURL, PasswordUnsupported
 from fs.test import FSTestCases
 from fs.enums import Seek
 
 from .test_archives import ArchiveTestCases
+
+
+class TestBytes(unittest.TestCase):
+    def test_conversion(self):
+        self.assertIsNone(zipfs._bytes(None))
+        self.assertEqual(zipfs._bytes("passwd"), b"passwd")
+        self.assertEqual(zipfs._bytes(b"passwd"), b"passwd")
+        with self.assertRaises(TypeError):
+            zipfs._bytes(1234)
 
 
 class TestWriteReadZipFS(unittest.TestCase):
@@ -39,6 +49,10 @@ class TestWriteReadZipFS(unittest.TestCase):
                 self.assertIsInstance(path, six.text_type)
                 with zip_fs.openbin(path) as f:
                     f.read()
+
+    def test_create_password(self):
+        with self.assertRaises(PasswordUnsupported):
+            zipfs.ZipFS(self._temp_path, write=True, passwd="hello")
 
 
 class TestWriteZipFS(FSTestCases, unittest.TestCase):
@@ -218,6 +232,45 @@ class TestDirsZipFS(unittest.TestCase):
                 self.assertTrue(zip_fs.isfile("foo/bar/baz/egg"))
         finally:
             os.remove(path)
+
+
+class TestPasswordReadZipFS(unittest.TestCase):
+
+    ZIP_BIN = (
+        b"UEsDBAoACQAAAH2whk8tOwivGAAAAAwAAAADABwAZm9vVVQJAAPNX+pdzl/qXXV4CwABBPUBAAAE"
+        b"FAAAAJ6pj1kohibjIq4YqnEKUZ8SCJMeUkl9oVBLBwgtOwivGAAAAAwAAABQSwECHgMKAAkAAAB9"
+        b"sIZPLTsIrxgAAAAMAAAAAwAYAAAAAAABAAAApIEAAAAAZm9vVVQFAAPNX+pddXgLAAEE9QEAAAQU"
+        b"AAAAUEsFBgAAAAABAAEASQAAAGUAAAAAAA=="
+    )
+
+    PASSWD = "P@ssw0rd"
+
+    def setUp(self):
+        fh, path = tempfile.mkstemp("testzip.zip")
+        os.write(fh, codecs.decode(self.ZIP_BIN, "base64"))
+        os.close(fh)
+        self.path = path
+
+    def tearDown(self):
+        os.remove(self.path)
+
+    def test_openbin(self):
+        with zipfs.ReadZipFS(self.path, passwd=self.PASSWD) as zip_fs:
+            with zip_fs.openbin("foo") as fp:
+                self.assertEqual(fp.read(), b"hello world\n")
+
+        with zipfs.ReadZipFS(self.path) as zip_fs:
+            with zip_fs.openbin("foo", passwd=self.PASSWD) as fp:
+                self.assertEqual(fp.read(), b"hello world\n")
+
+    def test_readbytes(self):
+        with zipfs.ReadZipFS(self.path, passwd=self.PASSWD) as zip_fs:
+            self.assertEqual(zip_fs.readbytes("foo"), b"hello world\n")
+
+        with zipfs.ReadZipFS(self.path) as zip_fs:
+            self.assertEqual(
+                zip_fs.readbytes("foo", passwd=self.PASSWD), b"hello world\n"
+            )
 
 
 class TestOpener(unittest.TestCase):

--- a/tests/test_zipfs.py
+++ b/tests/test_zipfs.py
@@ -272,6 +272,14 @@ class TestPasswordReadZipFS(unittest.TestCase):
                 zip_fs.readbytes("foo", passwd=self.PASSWD), b"hello world\n"
             )
 
+    def test_setpassword(self):
+        with zipfs.ReadZipFS(self.path) as zip_fs:
+            with self.assertRaises(RuntimeError):
+                zip_fs._zip.read("foo")
+
+            zip_fs.setpassword(self.PASSWD)
+            self.assertEqual(zip_fs._zip.read("foo"), b"hello world\n")
+
 
 class TestOpener(unittest.TestCase):
     def test_not_writeable(self):


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [v] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [v] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [v] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [v] I've added tests for new code.
- [v] I accept that @willmcgugan may be pedantic in the code review.

## Description

Related issue: #360 

This PR add `passwd` argument for `ZipFS` and `ReadZipFS` constructor to set the default password for extracting the file. And for per-file password, there is also `passwd` arg on `openbin` and `readbytes` to override the default settings. 

Extra, I added `setpassword` on `ReadZipFS` since users could get the fs from `open_fs` and there would be no place the set password.

One thing to be mention, it changes `readbytes`'s signature: 
```diff
-    def readbytes(self, path):
-        # type: (Text) -> bytes
+    def readbytes(self, path, passwd=None):
+        # type: (Text, Optional[AnyStr]) -> bytes
```
and thus it does not follow the form on the base class. 
Please let me know if you have any concern.