### PR TITLE
add options for readbytes and readtext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.4.12] - (Unreleased)
 
+### Added
+
+- Added options for readbytes and readtext
+
 ### Changed
 
 - Start testing on PyPy. Due to [#342](https://github.com/PyFilesystem/pyfilesystem2/issues/342)

--- a/fs/base.py
+++ b/fs/base.py
@@ -221,7 +221,7 @@ class FS(object):
         path,  # type: Text
         mode="r",  # type: Text
         buffering=-1,  # type: int
-        **options  # type: Any
+        **options,  # type: Any
     ):
         # type: (...) -> BinaryIO
         """Open a binary file-like object.
@@ -644,6 +644,7 @@ class FS(object):
         encoding=None,  # type: Optional[Text]
         errors=None,  # type: Optional[Text]
         newline="",  # type: Text
+        **options,  # type: Any
     ):
         # type: (...) -> Text
         """Get the contents of a file as a string.
@@ -664,7 +665,12 @@ class FS(object):
         """
         with closing(
             self.open(
-                path, mode="rt", encoding=encoding, errors=errors, newline=newline
+                path,
+                mode="rt",
+                encoding=encoding,
+                errors=errors,
+                newline=newline,
+                **options,
             )
         ) as read_file:
             contents = read_file.read()
@@ -1130,7 +1136,7 @@ class FS(object):
         encoding=None,  # type: Optional[Text]
         errors=None,  # type: Optional[Text]
         newline="",  # type: Text
-        **options  # type: Any
+        **options,  # type: Any
     ):
         # type: (...) -> IO
         """Open a file.

--- a/fs/base.py
+++ b/fs/base.py
@@ -1169,7 +1169,7 @@ class FS(object):
         """
         validate_open_mode(mode)
         bin_mode = mode.replace("t", "")
-        bin_file = self.openbin(path, mode=bin_mode, buffering=buffering)
+        bin_file = self.openbin(path, mode=bin_mode, buffering=buffering, **options)
         io_stream = iotools.make_stream(
             path,
             bin_file,
@@ -1178,7 +1178,6 @@ class FS(object):
             encoding=encoding or "utf-8",
             errors=errors,
             newline=newline,
-            **options
         )
         return io_stream
 

--- a/fs/base.py
+++ b/fs/base.py
@@ -1178,6 +1178,7 @@ class FS(object):
             encoding=encoding or "utf-8",
             errors=errors,
             newline=newline,
+            line_buffering=options.get("line_buffering", False),
         )
         return io_stream
 

--- a/fs/base.py
+++ b/fs/base.py
@@ -586,8 +586,8 @@ class FS(object):
             iter_info = itertools.islice(iter_info, start, end)
         return iter_info
 
-    def readbytes(self, path):
-        # type: (Text) -> bytes
+    def readbytes(self, path, **options):
+        # type: (Text, Any) -> bytes
         """Get the contents of a file as bytes.
 
         Arguments:

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -772,8 +772,8 @@ class FTPFS(FS):
         if not self.exists(path):
             raise errors.ResourceNotFound(path)
 
-    def readbytes(self, path):
-        # type: (Text) -> bytes
+    def readbytes(self, path, **options):
+        # type: (Text, Any) -> bytes
         _path = self.validatepath(path)
         data = io.BytesIO()
         with ftp_errors(self, path):

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -186,8 +186,8 @@ class MountFS(FS):
         fs, _path = self._delegate(path)
         return fs.removedir(_path)
 
-    def readbytes(self, path):
-        # type: (Text) -> bytes
+    def readbytes(self, path, **options):
+        # type: (Text, Any) -> bytes
         self.check()
         fs, _path = self._delegate(path)
         return fs.readbytes(_path)

--- a/fs/mountfs.py
+++ b/fs/mountfs.py
@@ -203,6 +203,7 @@ class MountFS(FS):
         encoding=None,  # type: Optional[Text]
         errors=None,  # type: Optional[Text]
         newline="",  # type: Text
+        **options,  # type: Any
     ):
         # type: (...) -> Text
         self.check()
@@ -284,7 +285,7 @@ class MountFS(FS):
         encoding=None,  # type: Optional[Text]
         errors=None,  # type: Optional[Text]
         newline="",  # type: Text
-        **options  # type: Any
+        **options,  # type: Any
     ):
         # type: (...) -> IO
         validate_open_mode(mode)
@@ -297,7 +298,7 @@ class MountFS(FS):
             encoding=encoding,
             errors=errors,
             newline=newline,
-            **options
+            **options,
         )
 
     def upload(self, path, file, chunk_size=None, **options):

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -293,8 +293,8 @@ class MultiFS(FS):
         fs = self._delegate_required(path)
         return fs.download(path, file, chunk_size=chunk_size, **options)
 
-    def readtext(self, path, encoding=None, errors=None, newline=""):
-        # type: (Text, Optional[Text], Optional[Text], Text) -> Text
+    def readtext(self, path, encoding=None, errors=None, newline="", **options):
+        # type: (Text, Optional[Text], Optional[Text], Text, Any) -> Text
         self.check()
         fs = self._delegate_required(path)
         return fs.readtext(path, encoding=encoding, errors=errors, newline=newline)

--- a/fs/multifs.py
+++ b/fs/multifs.py
@@ -280,8 +280,8 @@ class MultiFS(FS):
         if not exists:
             raise errors.ResourceNotFound(path)
 
-    def readbytes(self, path):
-        # type: (Text) -> bytes
+    def readbytes(self, path, **options):
+        # type: (Text, Any) -> bytes
         self.check()
         fs = self._delegate(path)
         if fs is None:

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -334,8 +334,8 @@ class WrapFS(FS, typing.Generic[_F]):
             for info in iter_files:
                 yield info
 
-    def readbytes(self, path):
-        # type: (Text) -> bytes
+    def readbytes(self, path, **options):
+        # type: (Text, Any) -> bytes
         self.check()
         _fs, _path = self.delegate_path(path)
         with unwrap_errors(path):

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -348,6 +348,7 @@ class WrapFS(FS, typing.Generic[_F]):
         encoding=None,  # type: Optional[Text]
         errors=None,  # type: Optional[Text]
         newline="",  # type: Text
+        **options,  # type: Any
     ):
         # type: (...) -> Text
         self.check()
@@ -456,7 +457,7 @@ class WrapFS(FS, typing.Generic[_F]):
         errors=None,  # type: Optional[Text]
         newline="",  # type: Text
         line_buffering=False,  # type: bool
-        **options  # type: Any
+        **options,  # type: Any
     ):
         # type: (...) -> IO[AnyStr]
         self.check()
@@ -470,7 +471,7 @@ class WrapFS(FS, typing.Generic[_F]):
                 errors=errors,
                 newline=newline,
                 line_buffering=line_buffering,
-                **options
+                **options,
             )
         return open_file
 

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -439,8 +439,8 @@ class ReadZipFS(FS):
         if hasattr(self, "_zip"):
             self._zip.close()
 
-    def readbytes(self, path):
-        # type: (Text) -> bytes
+    def readbytes(self, path, **options):
+        # type: (Text, Any) -> bytes
         self.check()
         if not self._directory.isfile(path):
             raise errors.ResourceNotFound(path)


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [x] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Pre discuss in #361, this PR add options for `readbytes` and `readtext` in each class.

Also it changes a behavior in `FS.open`, I found this when I was investigate if there's any other thing to be changed.
It seems no extra parameters are required for `iotools.make_stream`, and the description for `options` is *arguments for the filesystem*. So I guess it was misplaced and move options for `openbin` inside the function.



