### PR TITLE
Add readinto method for MemoryFS and FTPFS file objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Missing `mode` attribute to `_MemoryFile` objects returned by `MemoryFS.openbin`.
+- Missing `readinto` method for `MemoryFS` and `FTPFS` file objects. Closes
+  [#380](https://github.com/PyFilesystem/pyfilesystem2/issues/380).
 
 ### Changed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ Many thanks to the following developers for contributing to this project:
 - [Justin Charlong](https://github.com/jcharlong)
 - [Louis Sautier](https://github.com/sbraz)
 - [Martin Larralde](https://github.com/althonos)
+- [Nick Henderson](https://github.com/nwh)
 - [Will McGugan](https://github.com/willmcgugan)
 - [Zmej Serow](https://github.com/zmej-serow)
 - [Morten Engelhardt Olsen](https://github.com/xoriath)

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -239,7 +239,7 @@ class FTPFile(io.RawIOBase):
         # type: (bytearray) -> int
         data = self.read(len(buffer))
         bytes_read = len(data)
-        buffer[: len(data)] = data
+        buffer[:bytes_read] = data
         return bytes_read
 
     def readline(self, size=-1):

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -235,6 +235,13 @@ class FTPFile(io.RawIOBase):
                 remaining -= len(chunk)
         return b"".join(chunks)
 
+    def readinto(self, buffer):
+        # type: (bytearray) -> int
+        data = self.read(len(buffer))
+        bytes_read = len(data)
+        buffer[: len(data)] = data
+        return bytes_read
+
     def readline(self, size=-1):
         # type: (int) -> bytes
         return next(line_iterator(self, size))  # type: ignore

--- a/fs/iotools.py
+++ b/fs/iotools.py
@@ -117,7 +117,7 @@ class RawWrapper(io.RawIOBase):
         except AttributeError:
             data = self._f.read(len(b))
             bytes_read = len(data)
-            b[: len(data)] = data
+            b[:bytes_read] = data
             return bytes_read
 
     @typing.no_type_check
@@ -128,7 +128,7 @@ class RawWrapper(io.RawIOBase):
         except AttributeError:
             data = self._f.read1(len(b))
             bytes_read = len(data)
-            b[: len(data)] = data
+            b[:bytes_read] = data
             return bytes_read
 
     def readline(self, limit=-1):

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -120,6 +120,8 @@ class _MemoryFile(io.RawIOBase):
 
     def readline(self, size=-1):
         # type: (int) -> bytes
+        if not self._mode.reading:
+            raise IOError("File not open for reading")
         with self._seek_lock():
             self.on_access()
             return self._bytes_io.readline(size)
@@ -153,6 +155,8 @@ class _MemoryFile(io.RawIOBase):
 
     def readlines(self, hint=-1):
         # type: (int) -> List[bytes]
+        if not self._mode.reading:
+            raise IOError("File not open for reading")
         with self._seek_lock():
             self.on_access()
             return self._bytes_io.readlines(hint)

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -142,6 +142,14 @@ class _MemoryFile(io.RawIOBase):
         # type: () -> bool
         return self._mode.reading
 
+    def readinto(self, b):
+        # type (bytes) -> Optional[int]
+        if not self._mode.reading:
+            raise IOError("File not open for reading")
+        with self._seek_lock():
+            self.on_access()
+            return self._bytes_io.readinto(b)
+
     def readlines(self, hint=-1):
         # type: (int) -> List[bytes]
         with self._seek_lock():

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -146,7 +146,7 @@ class _MemoryFile(io.RawIOBase):
         return self._mode.reading
 
     def readinto(self, b):
-        # type (bytes) -> Optional[int]
+        # type (bytearray) -> Optional[int]
         if not self._mode.reading:
             raise IOError("File not open for reading")
         with self._seek_lock():

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -113,6 +113,7 @@ class _MemoryFile(io.RawIOBase):
     def next(self):
         # type: () -> bytes
         with self._seek_lock():
+            self.on_access()
             return next(self._bytes_io)
 
     __next__ = next
@@ -153,6 +154,7 @@ class _MemoryFile(io.RawIOBase):
     def readlines(self, hint=-1):
         # type: (int) -> List[bytes]
         with self._seek_lock():
+            self.on_access()
             return self._bytes_io.readlines(hint)
 
     def seekable(self):

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -145,13 +145,13 @@ class _MemoryFile(io.RawIOBase):
         # type: () -> bool
         return self._mode.reading
 
-    def readinto(self, b):
+    def readinto(self, buffer):
         # type (bytearray) -> Optional[int]
         if not self._mode.reading:
             raise IOError("File not open for reading")
         with self._seek_lock():
             self.on_access()
-            return self._bytes_io.readinto(b)
+            return self._bytes_io.readinto(buffer)
 
     def readlines(self, hint=-1):
         # type: (int) -> List[bytes]

--- a/fs/test.py
+++ b/fs/test.py
@@ -870,6 +870,11 @@ class FSTestCases(object):
             self.assertTrue(f.readable())
             self.assertFalse(f.closed)
             self.assertEqual(f.readlines(8), [b"Hello\n", b"World\n"])
+            self.assertEqual(f.tell(), 12)
+            b = bytearray(4)
+            self.assertEqual(f.readinto(b), 4)
+            self.assertEqual(f.tell(), 16)
+            self.assertEqual(b, b"foo\n")
             with self.assertRaises(IOError):
                 f.write(b"no")
         self.assertTrue(f.closed)

--- a/fs/test.py
+++ b/fs/test.py
@@ -871,10 +871,10 @@ class FSTestCases(object):
             self.assertFalse(f.closed)
             self.assertEqual(f.readlines(8), [b"Hello\n", b"World\n"])
             self.assertEqual(f.tell(), 12)
-            b = bytearray(4)
-            self.assertEqual(f.readinto(b), 4)
+            buffer = bytearray(4)
+            self.assertEqual(f.readinto(buffer), 4)
             self.assertEqual(f.tell(), 16)
-            self.assertEqual(b, b"foo\n")
+            self.assertEqual(buffer, b"foo\n")
             with self.assertRaises(IOError):
                 f.write(b"no")
         self.assertTrue(f.closed)


### PR DESCRIPTION
## Type of changes

- [X] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [x] Tests
- [ ] Other

## Checklist

- [X] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

Added `readinto` method for `MemoryFS` file objects.  See #380 .