### PR TITLE
Fixing issue on py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,6 @@ python:
   - "pypy"
   - "pypy3.5-7.0" # Need 7.0+ due to a bug in earlier versions that broke our tests.
 
-matrix:
-  include:
-    - name: "Type checking"
-      python: "3.7"
-      env: TOXENV=typecheck
-    - name: "Lint"
-      python: "3.7"
-      env: TOXENV=lint
-    - python: "3.8"
-
-  # Temporary bandaid for https://github.com/PyFilesystem/pyfilesystem2/issues/342
-  allow_failures:
-    - python: pypy
-    - python: pypy3.5-7.0
 
 before_install:
   - pip install -U tox tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,12 @@ matrix:
     - name: "Lint"
       python: "3.7"
       env: TOXENV=lint
+    - python: "3.8"
 
   # Temporary bandaid for https://github.com/PyFilesystem/pyfilesystem2/issues/342
   allow_failures:
     - python: pypy
-    - python: pypy3.5-8.0
+    - python: pypy3.5-7.0
 
 before_install:
   - pip install -U tox tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
   # Temporary bandaid for https://github.com/PyFilesystem/pyfilesystem2/issues/342
   allow_failures:
     - python: pypy
-    - python: pypy3.5-7.0
+    - python: pypy3.5-8.0
 
 before_install:
   - pip install -U tox tox-travis

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ CLASSIFIERS = [
     "Topic :: System :: Filesystems",
 ]
 
-REQUIREMENTS = ["appdirs~=1.4.3", "pytz", "setuptools", "six~=1.10"]
+REQUIREMENTS = ["appdirs~=1.4.3", "pytz", "setuptools", "six~=1.10", "typing; python_version < '3.5'"]
 
 setup(
     author="Will McGugan",
@@ -33,7 +33,6 @@ setup(
     extras_require={
         "scandir :python_version < '3.5'": ["scandir~=1.5"],
         ":python_version < '3.4'": ["enum34~=1.1.6"],
-        ":python_version < '3.6'": ["typing~=3.6"],
         ":python_version < '3.0'": ["backports.os~=0.1"],
     },
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ CLASSIFIERS = [
     "Topic :: System :: Filesystems",
 ]
 
-REQUIREMENTS = ["appdirs~=1.4.3", "pytz", "setuptools", "six~=1.10", "typing; python_version < '3.5'"]
+REQUIREMENTS = ["appdirs~=1.4.3", "pytz", "setuptools", "six~=1.10"]
 
 setup(
     author="Will McGugan",
@@ -33,6 +33,7 @@ setup(
     extras_require={
         "scandir :python_version < '3.5'": ["scandir~=1.5"],
         ":python_version < '3.4'": ["enum34~=1.1.6"],
+        ":python_version < '3.7'": ["typing>=3.5.3"],
         ":python_version < '3.0'": ["backports.os~=0.1"],
     },
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37}{,-scandir},pypy,typecheck,lint
+envlist = {py27,py34,py35,py36,py37,py38}{,-scandir},pypy,typecheck,lint
 sitepackages = False
 skip_missing_interpreters=True
 


### PR DESCRIPTION
Py3.8
AttributeError: type object 'Callable' has no attribute '_abc_registry'

`typing` package is a built-in for all currently supported Python versions until python3.8.

```
from typing import Any
  File "/.tox/django22/lib/python3.8/site-packages/typing.py", line 1357, in <module>
    class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
  File "/.tox/django22/lib/python3.8/site-packages/typing.py", line 1005, in __new__
    self._abc_registry = extra._abc_registry
AttributeError: type object 'Callable' has no attribute '_abc_registry'
```

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
