### PR TITLE
Include additional files in source distributions, fixes #364

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Start testing on PyPy. Due to [#342](https://github.com/PyFilesystem/pyfilesystem2/issues/342)
   we have to treat PyPy builds specially and allow them to fail, but at least we'll
   be able to see if we break something aside from known issues with FTP tests.
+- Include docs in source distributions as well the whole tests folder,
+  ensuring `conftest.py` is present, fixes [#364](https://github.com/PyFilesystem/pyfilesystem2/issues/364).
 
 ## [2.4.11] - 2019-09-07
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ Many thanks to the following developers for contributing to this project:
 - [Diego Argueta](https://github.com/dargueta)
 - [Geoff Jukes](https://github.com/geoffjukes)
 - [Giampaolo](https://github.com/gpcimino)
+- [Louis Sautier](https://github.com/sbraz)
 - [Martin Larralde](https://github.com/althonos)
 - [Will McGugan](https://github.com/willmcgugan)
 - [Zmej Serow](https://github.com/zmej-serow)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,5 @@
 include LICENSE
+graft tests
+graft docs
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION


## Type of changes

- [X] Bug fix


## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description
Hi,
This will ensure the missing `conftest.py` file is included in source distributions (fixes #364), as well as the docs folder (useful for distros that build doc from the PyPI tarballs).

