### PR TITLE
Do not test the patched copy implementation with Python 3.8+, fixes #421

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Start testing on PyPy. Due to [#342](https://github.com/PyFilesystem/pyfilesystem2/issues/342)
   we have to treat PyPy builds specially and allow them to fail, but at least we'll
   be able to see if we break something aside from known issues with FTP tests.
+- Stop patching copy with Python 3.8+ because it already uses sendfile.
 
 ## [2.4.11] - 2019-09-07
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ Many thanks to the following developers for contributing to this project:
 - [Diego Argueta](https://github.com/dargueta)
 - [Geoff Jukes](https://github.com/geoffjukes)
 - [Giampaolo](https://github.com/gpcimino)
+- [Louis Sautier](https://github.com/sbraz)
 - [Martin Larralde](https://github.com/althonos)
 - [Will McGugan](https://github.com/willmcgugan)
 - [Zmej Serow](https://github.com/zmej-serow)

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -419,7 +419,7 @@ class OSFS(FS):
             raise errors.DirectoryExpected(dirname(dst_path))
         return _src_path, _dst_path
 
-    if sys.version_info[:2] <= (3, 8) and sendfile is not None:
+    if sys.version_info[:2] < (3, 8) and sendfile is not None:
 
         _sendfile_error_codes = {
             errno.EIO,

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -6,6 +6,7 @@ import io
 import os
 import shutil
 import tempfile
+import sys
 import unittest
 import pytest
 
@@ -88,6 +89,11 @@ class TestOSFS(FSTestCases, unittest.TestCase):
         self.assertNotIn("TYRIONLANISTER", fs2.getsyspath("/"))
 
     @pytest.mark.skipif(osfs.sendfile is None, reason="sendfile not supported")
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 8),
+        reason="the copy function uses sendfile in Python 3.8+, "
+        "making the patched implementation irrelevant",
+    )
     def test_copy_sendfile(self):
         # try copying using sendfile
         with mock.patch.object(osfs, "sendfile") as sendfile:


### PR DESCRIPTION
## Type of changes

- [X] Bug fix


## Checklist

- [X] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [X] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [X] I've added tests for new code.
- [X] I accept that @willmcgugan may be pedantic in the code review.

## Description

This skips the copy tests when it hasn't been patched (i.e. Python 3.8+) while also reverting part of
6f89b81daab7b604a77eff232639b03b6fc55ab2 (do not patch copy for Python 3.8 whose `shutil.copy` implementation uses sendfile).
