### PR TITLE
Implement proper symlink support in `ReadTarFS`

### DIFF
--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -348,6 +348,10 @@ class ReadTarFS(FS):
                 "is_dir": member.isdir(),
             }
 
+            if "link" in namespaces:
+                raw_info["link"] = {
+                    "target": self._decode(member.linkname) if member.issym() else None
+                }
             if "details" in namespaces:
                 raw_info["details"] = {
                     "size": member.size,

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -431,11 +431,13 @@ class ReadTarFS(FS):
         except KeyError:
             six.raise_from(errors.ResourceNotFound(path), None)
 
-        if not member.isfile():
+        # TarFile.extractfile returns None if the entry is
+        # neither a file nor a symlink
+        reader =  self._tar.extractfile(member)
+        if reader is None:
             raise errors.FileExpected(path)
 
-        rw = RawWrapper(cast(IO, self._tar.extractfile(member)))
-
+        rw = RawWrapper(reader)
         if six.PY2:  # Patch nonexistent file.flush in Python2
 
             def _flush():

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -389,6 +389,13 @@ class ReadTarFS(FS):
         except KeyError:
             return False
 
+    def islink(self, path):
+        _path = relpath(self.validatepath(path))
+        try:
+            return self._directory_entries[_path].issym()
+        except KeyError:
+            return False
+
     def setinfo(self, path, info):
         # type: (Text, RawInfo) -> None
         self.check()

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -157,8 +157,7 @@ class TarFS(WrapFS):
 
 @six.python_2_unicode_compatible
 class WriteTarFS(WrapFS):
-    """A writable tar file.
-    """
+    """A writable tar file."""
 
     def __init__(
         self,
@@ -234,8 +233,7 @@ class WriteTarFS(WrapFS):
 
 @six.python_2_unicode_compatible
 class ReadTarFS(FS):
-    """A readable tar file.
-    """
+    """A readable tar file."""
 
     _meta = {
         "case_insensitive": True,
@@ -433,7 +431,7 @@ class ReadTarFS(FS):
 
         # TarFile.extractfile returns None if the entry is
         # neither a file nor a symlink
-        reader =  self._tar.extractfile(member)
+        reader = self._tar.extractfile(member)
         if reader is None:
             raise errors.FileExpected(path)
 


### PR DESCRIPTION
## Type of changes

- [x] Bug fix
- [x] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

The current version of `ReadTarFS` does not support symlinks properly where Tar files do. This PR changes the following:

### `OSFS` like behaviour for `Info`

- [x] `Info.is_dir` is `True` for symlinks that map to existing directories.
- [x] `ReadTarFS.isdir(path)` returns True if `path` is a symlink that maps to an existing directory.
- [x] `ReadTarFS.isfile(path)` returns True if the `path` is a symlink that maps to an existing file.
- [x] `ReadTarFs.islink(path)` return True if the `path` is a symlink (that can also be dangling).

### Transparent handling of symlinks

- [x] `ReadTarFS.openbin(path)` also works if `path` is a symlink that maps to an existing file.
- [x] `ReadTarFS.listdir(path)` also works if `path` is a symlink that maps to an existing file.

##

Closes #409, #425.
