### PR TITLE
Check path for `hassyspath` and use `shutil.rmdir` if True

### DIFF
--- a/fs/base.py
+++ b/fs/base.py
@@ -12,6 +12,7 @@ import abc
 import hashlib
 import itertools
 import os
+import shutil
 import threading
 import time
 import typing
@@ -1219,17 +1220,20 @@ class FS(object):
             dir_path (str): Path to a directory on the filesystem.
 
         """
-        _dir_path = abspath(normpath(dir_path))
         with self._lock:
-            walker = walk.Walker(search="depth")
-            gen_info = walker.info(self, _dir_path)
-            for _path, info in gen_info:
-                if info.is_dir:
-                    self.removedir(_path)
-                else:
-                    self.remove(_path)
-            if _dir_path != "/":
-                self.removedir(dir_path)
+            if self.hassyspath(path):
+                shutil.rmtree(self.getsyspath(path))
+            else:
+                _dir_path = abspath(normpath(dir_path))
+                walker = walk.Walker(search="depth")
+                gen_info = walker.info(self, _dir_path)
+                for _path, info in gen_info:
+                    if info.is_dir:
+                        self.removedir(_path)
+                    else:
+                        self.remove(_path)
+                if _dir_path != "/":
+                    self.removedir(dir_path)
 
     def scandir(
         self,


### PR DESCRIPTION
## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ x] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review :)

## Description

Minor enhancement to `removetree` when the path has a syspath and so can be removed via `shutil.rmtree`
