### PR TITLE
Fix symlink handling in OSFS

### DIFF
--- a/fs/base.py
+++ b/fs/base.py
@@ -981,8 +981,12 @@ class FS(object):
             bool: `True` if ``path`` maps to a symlink.
 
         """
-        self.getinfo(path)
-        return False
+        try:
+            self.getinfo(path, namespaces=["link"]).target is not None
+        except errors.MissingInfoNamespace:
+            return False  # filesystem does not support symlinks
+        except errors.ResourceNotFound:
+            return False  # path does not exist, so it can't be a link
 
     def lock(self):
         # type: () -> RLock

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -599,7 +599,7 @@ class OSFS(FS):
         self.check()
         sys_path = self._to_sys_path(path)
         with convert_os_errors("gettype", path):
-            stat = os.stat(sys_path)
+            stat = os.lstat(sys_path)
         resource_type = self._get_type_from_stat(stat)
         return resource_type
 

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -608,8 +608,6 @@ class OSFS(FS):
         self.check()
         _path = self.validatepath(path)
         sys_path = self._to_sys_path(_path)
-        if not self.exists(path):
-            raise errors.ResourceNotFound(path)
         with convert_os_errors("islink", path):
             return os.path.islink(sys_path)
 

--- a/fs/test.py
+++ b/fs/test.py
@@ -392,8 +392,7 @@ class FSTestCases(object):
     def test_islink(self):
         self.fs.touch("foo")
         self.assertFalse(self.fs.islink("foo"))
-        with self.assertRaises(errors.ResourceNotFound):
-            self.fs.islink("bar")
+        self.assertFalse(self.fs.islink("bar"))
 
     def test_getsize(self):
         self.fs.writebytes("empty", b"")

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -203,3 +203,17 @@ class TestOSFS(FSTestCases, unittest.TestCase):
 
     def test_geturl_return_no_url(self):
         self.assertRaises(errors.NoURL, self.fs.geturl, "test/path", "upload")
+
+    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="No symlink support")
+    def test_symlinks_dangling(self):
+        self.fs.create("a")
+        os.symlink(self.fs.getsyspath("a"), self.fs.getsyspath("b"))
+
+        self.assertTrue(self.fs.exists("a"))
+        self.assertFalse(self.fs.islink("a"))
+        self.assertTrue(self.fs.exists("b"))
+        self.assertTrue(self.fs.islink("b"))
+
+        self.fs.remove("a")
+        self.assertTrue(self.fs.islink("b"))
+        self.assertIs(self.fs.getinfo("b", namespaces=["link"]).target, None)

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -11,6 +11,7 @@ import unittest
 import pytest
 
 from fs import osfs, open_fs
+from fs.enums import ResourceType
 from fs.path import relpath, dirname
 from fs import errors
 from fs.test import FSTestCases
@@ -211,9 +212,11 @@ class TestOSFS(FSTestCases, unittest.TestCase):
 
         self.assertTrue(self.fs.exists("a"))
         self.assertFalse(self.fs.islink("a"))
+        self.assertEqual(self.fs.gettype("a"), ResourceType.file)
         self.assertTrue(self.fs.exists("b"))
         self.assertTrue(self.fs.islink("b"))
+        self.assertEqual(self.fs.gettype("b"), ResourceType.symlink)
 
         self.fs.remove("a")
         self.assertTrue(self.fs.islink("b"))
-        self.assertIs(self.fs.getinfo("b", namespaces=["link"]).target, None)
+        self.assertEqual(self.fs.gettype("b"), ResourceType.symlink)


### PR DESCRIPTION
## Type of changes

- Bug fix

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description


### Closes #425

Changes the behaviour of `FS.islink` so that is never raises `ResourceNotFound`, to be consistent with `FS.isfile` and `FS.isdir`, and instead uses `FS.gettype` to check if the resource type is `symlink`.


### Closes #411

Fixes the behaviour of the following `OSFS` methods so that they work as expected:

- [x] `OSFS.islink(path)`: returns `True` on existing path to a symlink, `False` otherwise`
- [x] `OSFS.gettype(path)`: returns `ResourceType.symlink` is the path maps to a symlink (not the case before)
- [ ] `OSFS.getinfo(path)`: works even if `path` is a dangling symlink (**TODO**)
- [ ] `OSFS.scandir(dir)`: works even if `dir` contains a dangling symlink


