### PR TITLE
Documentation fixes for release v2.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Start testing on PyPy. Due to [#342](https://github.com/PyFilesystem/pyfilesystem2/issues/342)
   we have to treat PyPy builds specially and allow them to fail, but at least we'll
   be able to see if we break something aside from known issues with FTP tests.
-- Include docs in source distributions as well the whole tests folder,
+- Include docs in source distributions as well as the whole tests folder,
   ensuring `conftest.py` is present, fixes [#364](https://github.com/PyFilesystem/pyfilesystem2/issues/364).
-- Stop patching copy with Python 3.8+ because it already uses sendfile.
+- Stop patching copy with Python 3.8+ because it already uses `sendfile`.
+
+### Fixed
+
 - Fixed crash when CPython's -OO flag is used
 - Fixed error when parsing timestamps from a FTP directory served from a WindowsNT FTP Server, fixes [#395](https://github.com/PyFilesystem/pyfilesystem2/issues/395).
+- Fixed documentation of `Mode.to_platform_bin`. Closes [#382](https://github.com/PyFilesystem/pyfilesystem2/issues/382).
+- Fixed the code example in the "Testing Filesystems" section of the
+  "Implementing Filesystems" guide. Closes [#407](https://github.com/PyFilesystem/pyfilesystem2/issues/407).
 
 ## [2.4.11] - 2019-09-07
 

--- a/docs/source/implementers.rst
+++ b/docs/source/implementers.rst
@@ -40,9 +40,10 @@ To test your implementation, you can borrow the test suite used to test the buil
 
 Here's the simplest possible example to test a filesystem class called ``MyFS``::
 
+    import unittest
     from fs.test import FSTestCases
 
-    class TestMyFS(FSTestCases):
+    class TestMyFS(FSTestCases, unittest.TestCase):
 
         def make_fs(self):
             # Return an instance of your FS object here

--- a/fs/mode.py
+++ b/fs/mode.py
@@ -84,8 +84,7 @@ class Mode(typing.Container[Text]):
         # type: () -> Text
         """Get a *binary* mode string for the current platform.
 
-        Currently, this just removes the 'x' on PY2 because PY2 doesn't
-        support exclusive mode.
+        This removes the 't' and adds a 'b' if needed.
 
         """
         _mode = self.to_platform().replace("t", "")


### PR DESCRIPTION
## Type of changes

- Documentation / docstrings

## Checklist

- [x] ~~I've run the latest [black](https://github.com/ambv/black) with default args on new code.~~
- [x] ~~I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.~~
- [x] ~~I've added tests for new code.~~
- [x] ~~I accept that @willmcgugan may be pedantic in the code review.~~

## Description

- fixes #382 (Incorrect docstring of `Mode.to_platform_bin`)
- fixes #407 (Missing import in the testing example of the "Implementing Filesystems" section of the guide)
