### PR TITLE
Require `FS.openbin` to return a file-handle with in binary mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.4.12] - (Unreleased)
 
+### Added
+
+- Missing `mode` attribute to `_MemoryFile` objects returned by `MemoryFS.openbin`.
+
 ### Changed
 
 - Start testing on PyPy. Due to [#342](https://github.com/PyFilesystem/pyfilesystem2/issues/342)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed documentation of `Mode.to_platform_bin`. Closes [#382](https://github.com/PyFilesystem/pyfilesystem2/issues/382).
 - Fixed the code example in the "Testing Filesystems" section of the
   "Implementing Filesystems" guide. Closes [#407](https://github.com/PyFilesystem/pyfilesystem2/issues/407).
+- Fixed `FTPFS.openbin` not implicitly opening files in binary mode like expected
+  from `openbin`. Closes [#406](https://github.com/PyFilesystem/pyfilesystem2/issues/406).
 
 ## [2.4.11] - 2019-09-07
 

--- a/fs/ftpfs.py
+++ b/fs/ftpfs.py
@@ -682,7 +682,7 @@ class FTPFS(FS):
                     raise errors.FileExpected(path)
                 if _mode.exclusive:
                     raise errors.FileExists(path)
-            ftp_file = FTPFile(self, _path, mode)
+            ftp_file = FTPFile(self, _path, _mode.to_platform_bin())
         return ftp_file  # type: ignore
 
     def remove(self, path):

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -77,6 +77,7 @@ class _MemoryFile(io.RawIOBase):
 
     @property
     def mode(self):
+        # type: () -> Text
         return self._mode.to_platform_bin()
 
     @contextlib.contextmanager

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -75,6 +75,10 @@ class _MemoryFile(io.RawIOBase):
         _template = "<memoryfile '{path}' '{mode}'>"
         return _template.format(path=self._path, mode=self._mode)
 
+    @property
+    def mode(self):
+        return self._mode.to_platform_bin()
+
     @contextlib.contextmanager
     def _seek_lock(self):
         # type: () -> Iterator[None]

--- a/fs/test.py
+++ b/fs/test.py
@@ -774,6 +774,7 @@ class FSTestCases(object):
 
         with self.fs.openbin("foo/hello", "w") as f:
             repr(f)
+            self.assertIn("b", f.mode)
             self.assertIsInstance(f, io.IOBase)
             self.assertTrue(f.writable())
             self.assertFalse(f.readable())
@@ -787,6 +788,7 @@ class FSTestCases(object):
 
         # Read it back
         with self.fs.openbin("foo/hello", "r") as f:
+            self.assertIn("b", f.mode)
             self.assertIsInstance(f, io.IOBase)
             self.assertTrue(f.readable())
             self.assertFalse(f.writable())
@@ -927,6 +929,7 @@ class FSTestCases(object):
         with self.fs.openbin("file.bin", "wb") as write_file:
             repr(write_file)
             text_type(write_file)
+            self.assertIn("b", write_file.mode)
             self.assertIsInstance(write_file, io.IOBase)
             self.assertTrue(write_file.writable())
             self.assertFalse(write_file.readable())
@@ -938,6 +941,7 @@ class FSTestCases(object):
         with self.fs.openbin("file.bin", "rb") as read_file:
             repr(write_file)
             text_type(write_file)
+            self.assertIn("b", read_file.mode)
             self.assertIsInstance(read_file, io.IOBase)
             self.assertTrue(read_file.readable())
             self.assertFalse(read_file.writable())


### PR DESCRIPTION
## Type of changes

- Bug fix
- Tests

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

- Add a test for `openbin` method in `FSTestCases` ensuring the returned object has a `mode` attribute containing the "b" flag.
- Fix `FTPFS.openbin` not implicitly converting mode to binary mode. Closes #406 .
- Add missing `mode` attribute to `_MemoryFile` objects created by `MemoryFS.openbin`.

