### PR TITLE
Prepare for release `v2.4.12`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,19 @@
 ## Type of changes
 
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Documentation / docstrings
-- [ ] Tests
-- [ ] Other
+<!-- Remove unrelated categories -->
+
+- Bug fix
+- New feature
+- Documentation / docstrings
+- Tests
+- Other
 
 ## Checklist
 
 - [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
 - [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
 - [ ] I've added tests for new code.
-- [ ] I accept that @willmcgugan may be pedantic in the code review.
+- [ ] I accept that @PyFilesystem/maintainers may be pedantic in the code review.
 
 ## Description
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
   - "pypy"
   - "pypy3.5-7.0" # Need 7.0+ due to a bug in earlier versions that broke our tests.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
   - "pypy"
   - "pypy3.5-7.0" # Need 7.0+ due to a bug in earlier versions that broke our tests.
 
@@ -36,8 +36,22 @@ before_install:
 install:
   - pip install -e .
 
+# command to run tests
+script: tox
+
 after_success:
   - coveralls
 
-# command to run tests
-script: tox
+before_deploy:
+  - pip install -U twine wheel
+  - python setup.py sdist bdist_wheel
+
+deploy:
+  provider: script
+  script: twine upload dist/*
+  skip_cleanup: true
+  on:
+    python: 3.9
+    tags: true
+    repo: PyFilesystem/pyfilesystem2
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.4.12] - (Unreleased)
+## [2.4.12] - 2020-10-18
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.4.12] - 2020-10-18
+## [2.4.12] - 2021-01-13
 
 ### Added
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,7 @@ Many thanks to the following developers for contributing to this project:
 - [C. W.](https://github.com/chfw)
 - [Diego Argueta](https://github.com/dargueta)
 - [Geoff Jukes](https://github.com/geoffjukes)
-- [Giampaolo](https://github.com/gpcimino)
+- [Giampaolo Cimino](https://github.com/gpcimino)
 - [Justin Charlong](https://github.com/jcharlong)
 - [Louis Sautier](https://github.com/sbraz)
 - [Martin Larralde](https://github.com/althonos)

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2017-2020 The PyFilesystem2 contributors
 Copyright (c) 2016-2019 Will McGugan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2020 The PyFilesystem2 contributors
+Copyright (c) 2017-2021 The PyFilesystem2 contributors
 Copyright (c) 2016-2019 Will McGugan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ The following developers have contributed code and their time to this projects:
 
 - [Will McGugan](https://github.com/willmcgugan)
 - [Martin Larralde](https://github.com/althonos)
-- [Giampaolo](https://github.com/gpcimino)
+- [Giampaolo Cimino](https://github.com/gpcimino)
 - [Geoff Jukes](https://github.com/geoffjukes)
 
-See CONTRIBUTORS.md for a full list of contributors.
+See [CONTRIBUTORS.md](https://github.com/PyFilesystem/pyfilesystem2/blob/master/CONTRIBUTORS.md)
+for a full list of contributors.
 
 PyFilesystem2 owes a massive debt of gratitude to the following
 developers who contributed code and ideas to the original version.

--- a/fs/_version.py
+++ b/fs/_version.py
@@ -1,3 +1,3 @@
 """Version, used in module and setup.py.
 """
-__version__ = "2.4.11"
+__version__ = "2.4.12"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,13 +2,62 @@
 universal = 1
 
 [metadata]
+version = attr: fs._version.__version__
+name = fs
+author = Will McGugan
+author_email = will@willmcgugan.com
+maintainer = Martin Larralde
+maintainer_email = martin.larralde@embl.de
+url = https://github.com/PyFilesystem/pyfilesystem2
+license = MIT
 license_file = LICENSE
+description = Python's filesystem abstraction layer
 long_description = file: README.md
 long_description_content_type = text/markdown
+platform = any
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: System :: Filesystems
 project_urls =
     Bug Reports = https://github.com/PyFilesystem/pyfilesystem2/issues
     Documentation = https://pyfilesystem2.readthedocs.io/en/latest/
     Wiki = https://www.pyfilesystem.org/
+
+[options]
+zip_safe = false
+packages = find:
+setup_requires =
+    setuptools >=38.3.0
+install_requires =
+    appdirs~=1.4.3
+    pytz
+    setuptools
+    six ~=1.10
+    enum34 ~=1.1.6      ;  python_version < '3.4'
+    typing ~=3.6        ;  python_version < '3.6'
+    backports.os ~=0.1  ;  python_version < '3.0'
+
+[options.extras_require]
+scandir =
+    scandir~=1.5        ;  python_version < '3.5'
+
+[options.packages.find]
+exclude = tests
+
+[options.package_data]
+fs = py.typed
 
 [pydocstyle]
 inherit = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: System :: Filesystems

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
 
+import os
+
+with open(os.path.join("fs", "_version.py")) as f:
+    exec(f.read())
+
 from setuptools import setup
-setup()
+setup(version=__version__)

--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,4 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
-
-with open("fs/_version.py") as f:
-    exec(f.read())
-
-CLASSIFIERS = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.4",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
-    "Topic :: System :: Filesystems",
-]
-
-REQUIREMENTS = ["appdirs~=1.4.3", "pytz", "setuptools", "six~=1.10"]
-
-setup(
-    author="Will McGugan",
-    author_email="will@willmcgugan.com",
-    classifiers=CLASSIFIERS,
-    description="Python's filesystem abstraction layer",
-    install_requires=REQUIREMENTS,
-    extras_require={
-        "scandir :python_version < '3.5'": ["scandir~=1.5"],
-        ":python_version < '3.4'": ["enum34~=1.1.6"],
-        ":python_version < '3.6'": ["typing~=3.6"],
-        ":python_version < '3.0'": ["backports.os~=0.1"],
-    },
-    license="MIT",
-    name="fs",
-    packages=find_packages(exclude=("tests",)),
-    package_data={"fs": ["py.typed"]},
-    zip_safe=False,
-    platforms=["any"],
-    url="https://github.com/PyFilesystem/pyfilesystem2",
-    version=__version__,
-)
+from setuptools import setup
+setup()


### PR DESCRIPTION
## Type of changes

- Other

## Description

Here it is, release `v2.4.12`, a little more than one year after the previous one! The goal was to get some bug fixes before Python 2.7 reaches EOL.

About the project organisation:
- I moved `PULL_REQUEST_TEMPLATE.md` to `.github` and removed the check boxes from the categories, since GitHub would mistake them for a checklist.
- I added a copyright line about contributors in `LICENSE`.
- I replaced the `@willmcgugan` mention by `@Pyfilesystem/maintainers` in the pull request template.
- I added myself as a maintainer to the PyPI metadata 
- I moved all project metadata to `setup.cfg` instead of previously having half in `setup.py` and half in `setup.cfg`

Then we probably need to setup Travis-CI to deploy to PyPI, and we should be in the clear.

ping @PyFilesystem/maintainers  
