### PR TITLE
Export 'FS' in 'fs.base'

### DIFF
--- a/fs/__init__.py
+++ b/fs/__init__.py
@@ -8,5 +8,6 @@ from .enums import ResourceType, Seek
 from .opener import open_fs
 from ._fscompat import fsencode, fsdecode
 from . import path
+from . import base
 
-__all__ = ["__version__", "ResourceType", "Seek", "open_fs"]
+__all__ = ["__version__", "ResourceType", "Seek", "open_fs", "base"]


### PR DESCRIPTION
## Type of changes

- [X ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.

My project(s) are using static analysis tools such as pytype and mypy. MyPy in particular requires type annotations that I cannot access with the current code. Here is an example:

```python
from fs.base import FS

class Foo:
    def __init__(self, filesystem: FS):
        self._fs = filesystem
```

This commit simply adds `FS` to the exported modules in `fs/__init__.py`.