### PR TITLE
Update base.fs.upload docs to reflect exceptions thrown

### DIFF
--- a/fs/base.py
+++ b/fs/base.py
@@ -1308,6 +1308,10 @@ class FS(object):
                 sensible default.
             **options: Implementation specific options required to open
                 the source file.
+                
+        Raises:
+            fs.errors.ResourceNotFound: If a parent directory of
+                ``path`` does not exist.
 
         Note that the file object ``file`` will *not* be closed by this
         method. Take care to close it after this method completes

--- a/fs/base.py
+++ b/fs/base.py
@@ -1308,7 +1308,7 @@ class FS(object):
                 sensible default.
             **options: Implementation specific options required to open
                 the source file.
-                
+
         Raises:
             fs.errors.ResourceNotFound: If a parent directory of
                 ``path`` does not exist.

--- a/fs/test.py
+++ b/fs/test.py
@@ -1494,6 +1494,10 @@ class FSTestCases(object):
         with self.fs.open("foo", "rb") as f:
             data = f.read()
         self.assertEqual(data, b"bar")
+        
+        # upload to non-existing path (/foo/bar)
+        with self.assertRaises(errors.ResourceNotFound):
+            self.fs.upload("/foo/bar/baz", bytes_file)
 
     def test_upload_chunk_size(self):
         test_data = b"bar" * 128

--- a/fs/test.py
+++ b/fs/test.py
@@ -1495,9 +1495,9 @@ class FSTestCases(object):
             data = f.read()
         self.assertEqual(data, b"bar")
         
-        # upload to non-existing path (/foo/bar)
+        # upload to non-existing path (/spam/eggs)
         with self.assertRaises(errors.ResourceNotFound):
-            self.fs.upload("/foo/bar/baz", bytes_file)
+            self.fs.upload("/spam/eggs", bytes_file)
 
     def test_upload_chunk_size(self):
         test_data = b"bar" * 128


### PR DESCRIPTION
## Type of changes

- Documentation / docstrings

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

A small docs improvement I came across while using the `fs.base.upload` method. It reflects the method throwing `ResourceNotFound` if the path you are uploading to does not exist.
