### PR TITLE
Added preserve_time parameter to move, copy, and mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Better documentation of the `writable` parameter of `fs.open_fs`, and
   hint about using `fs.wrap.read_only` when a read-only filesystem is
   required. Closes [#441](https://github.com/PyFilesystem/pyfilesystem2/issues/441).
+- Copy and move operations now provide a parameter `preserve_time` that, when
+  passed as `True`, makes sure the "mtime" of the destination file will be
+  the same as that of the source file.
 
 ### Changed
 

--- a/fs/_bulk.py
+++ b/fs/_bulk.py
@@ -13,12 +13,11 @@ from six.moves.queue import Queue
 
 from .copy import copy_file_internal
 from .errors import BulkCopyFailed
-from .tools import copy_file_data
 
 if typing.TYPE_CHECKING:
     from .base import FS
     from types import TracebackType
-    from typing import IO, List, Optional, Text, Type
+    from typing import List, Optional, Text, Type
 
 
 class _Worker(threading.Thread):

--- a/fs/_bulk.py
+++ b/fs/_bulk.py
@@ -11,13 +11,14 @@ import typing
 
 from six.moves.queue import Queue
 
-from .copy import copy_file_internal
+from .copy import copy_file_internal, copy_modified_time
 from .errors import BulkCopyFailed
+from .tools import copy_file_data
 
 if typing.TYPE_CHECKING:
     from .base import FS
     from types import TracebackType
-    from typing import List, Optional, Text, Type
+    from typing import List, Optional, Text, Type, IO, Tuple
 
 
 class _Worker(threading.Thread):
@@ -55,40 +56,32 @@ class _Task(object):
 class _CopyTask(_Task):
     """A callable that copies from one file another."""
 
-    def __init__(
-        self,
-        src_fs,  # type: FS
-        src_path,  # type: Text
-        dst_fs,  # type: FS
-        dst_path,  # type: Text
-        preserve_time,  # type: bool
-    ):
-        # type: (...) -> None
-        self.src_fs = src_fs
-        self.src_path = src_path
-        self.dst_fs = dst_fs
-        self.dst_path = dst_path
-        self.preserve_time = preserve_time
+    def __init__(self, src_file, dst_file):
+        # type: (IO, IO) -> None
+        self.src_file = src_file
+        self.dst_file = dst_file
 
     def __call__(self):
         # type: () -> None
-        copy_file_internal(
-            self.src_fs,
-            self.src_path,
-            self.dst_fs,
-            self.dst_path,
-            preserve_time=self.preserve_time,
-        )
+        try:
+            copy_file_data(self.src_file, self.dst_file, chunk_size=1024 * 1024)
+        finally:
+            try:
+                self.src_file.close()
+            finally:
+                self.dst_file.close()
 
 
 class Copier(object):
     """Copy files in worker threads."""
 
-    def __init__(self, num_workers=4):
-        # type: (int) -> None
+    def __init__(self, num_workers=4, preserve_time=False):
+        # type: (int, bool) -> None
         if num_workers < 0:
             raise ValueError("num_workers must be >= 0")
         self.num_workers = num_workers
+        self.preserve_time = preserve_time
+        self.all_tasks = []  # type: List[Tuple[FS, Text, FS, Text]]
         self.queue = None  # type: Optional[Queue[_Task]]
         self.workers = []  # type: List[_Worker]
         self.errors = []  # type: List[Exception]
@@ -97,7 +90,7 @@ class Copier(object):
     def start(self):
         """Start the workers."""
         if self.num_workers:
-            self.queue = Queue()
+            self.queue = Queue(maxsize=self.num_workers)
             self.workers = [_Worker(self) for _ in range(self.num_workers)]
             for worker in self.workers:
                 worker.start()
@@ -106,10 +99,18 @@ class Copier(object):
     def stop(self):
         """Stop the workers (will block until they are finished)."""
         if self.running and self.num_workers:
+            # Notify the workers that all tasks have arrived
+            # and wait for them to finish.
             for _worker in self.workers:
                 self.queue.put(None)
             for worker in self.workers:
                 worker.join()
+
+            # If the "last modified" time is to be preserved, do it now.
+            if self.preserve_time:
+                for args in self.all_tasks:
+                    copy_modified_time(*args)
+
             # Free up references held by workers
             del self.workers[:]
             self.queue.join()
@@ -139,8 +140,15 @@ class Copier(object):
         if self.queue is None:
             # This should be the most performant for a single-thread
             copy_file_internal(
-                src_fs, src_path, dst_fs, dst_path, preserve_time=preserve_time
+                src_fs, src_path, dst_fs, dst_path, preserve_time=self.preserve_time
             )
         else:
-            task = _CopyTask(src_fs, src_path, dst_fs, dst_path, preserve_time)
+            self.all_tasks.append((src_fs, src_path, dst_fs, dst_path))
+            src_file = src_fs.openbin(src_path, "r")
+            try:
+                dst_file = dst_fs.openbin(dst_path, "w")
+            except Exception:
+                src_file.close()
+                raise
+            task = _CopyTask(src_file, dst_file)
             self.queue.put(task)

--- a/fs/_bulk.py
+++ b/fs/_bulk.py
@@ -124,13 +124,16 @@ class Copier(object):
         if traceback is None and self.errors:
             raise BulkCopyFailed(self.errors)
 
-    def copy(self, src_fs, src_path, dst_fs, dst_path):
-        # type: (FS, Text, FS, Text) -> None
+    def copy(self, src_fs, src_path, dst_fs, dst_path, preserve_time=False):
+        # type: (FS, Text, FS, Text, bool) -> None
         """Copy a file from one fs to another."""
         if self.queue is None:
             # This should be the most performant for a single-thread
-            copy_file_internal(src_fs, src_path, dst_fs, dst_path)
+            copy_file_internal(
+                src_fs, src_path, dst_fs, dst_path, preserve_time=preserve_time
+            )
         else:
+            # TODO(preserve_time)
             src_file = src_fs.openbin(src_path, "r")
             try:
                 dst_file = dst_fs.openbin(dst_path, "w")

--- a/fs/base.py
+++ b/fs/base.py
@@ -387,8 +387,14 @@ class FS(object):
         """
         self._closed = True
 
-    def copy(self, src_path, dst_path, overwrite=False):
-        # type: (Text, Text, bool) -> None
+    def copy(
+        self,
+        src_path,  # type: Text
+        dst_path,  # type: Text
+        overwrite=False,  # type: bool
+        preserve_time=False,  # type: bool
+    ):
+        # type: (...) -> None
         """Copy file contents from ``src_path`` to ``dst_path``.
 
         Arguments:
@@ -396,6 +402,8 @@ class FS(object):
             dst_path (str): Path to destination file.
             overwrite (bool): If `True`, overwrite the destination file
                 if it exists (defaults to `False`).
+            preserve_time (bool): If `True`, try to preserve atime, ctime,
+                and mtime of the resource (defaults to `False`).
 
         Raises:
             fs.errors.DestinationExists: If ``dst_path`` exists,
@@ -404,6 +412,7 @@ class FS(object):
                 ``dst_path`` does not exist.
 
         """
+        # TODO(preserve_time)
         with self._lock:
             if not overwrite and self.exists(dst_path):
                 raise errors.DestinationExists(dst_path)
@@ -411,8 +420,14 @@ class FS(object):
                 # FIXME(@althonos): typing complains because open return IO
                 self.upload(dst_path, read_file)  # type: ignore
 
-    def copydir(self, src_path, dst_path, create=False):
-        # type: (Text, Text, bool) -> None
+    def copydir(
+        self,
+        src_path,  # type: Text
+        dst_path,  # type: Text
+        create=False,  # type: bool
+        preserve_time=False,  # type: bool
+    ):
+        # type: (...) -> None
         """Copy the contents of ``src_path`` to ``dst_path``.
 
         Arguments:
@@ -420,6 +435,8 @@ class FS(object):
             dst_path (str): Path to destination directory.
             create (bool): If `True`, then ``dst_path`` will be created
                 if it doesn't exist already (defaults to `False`).
+            preserve_time (bool): If `True`, try to preserve atime, ctime,
+                and mtime of the resource (defaults to `False`).
 
         Raises:
             fs.errors.ResourceNotFound: If the ``dst_path``
@@ -431,7 +448,7 @@ class FS(object):
                 raise errors.ResourceNotFound(dst_path)
             if not self.getinfo(src_path).is_dir:
                 raise errors.DirectoryExpected(src_path)
-            copy.copy_dir(self, src_path, self, dst_path)
+            copy.copy_dir(self, src_path, self, dst_path, preserve_time=preserve_time)
 
     def create(self, path, wipe=False):
         # type: (Text, bool) -> bool
@@ -1004,8 +1021,8 @@ class FS(object):
         """
         return self._lock
 
-    def movedir(self, src_path, dst_path, create=False):
-        # type: (Text, Text, bool) -> None
+    def movedir(self, src_path, dst_path, create=False, preserve_time=False):
+        # type: (Text, Text, bool, bool) -> None
         """Move directory ``src_path`` to ``dst_path``.
 
         Arguments:
@@ -1013,6 +1030,8 @@ class FS(object):
             dst_path (str): Path to destination directory.
             create (bool): If `True`, then ``dst_path`` will be created
                 if it doesn't exist already (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve atime, ctime,
+            and mtime of the resources (defaults to `False`).
 
         Raises:
             fs.errors.ResourceNotFound: if ``dst_path`` does not exist,
@@ -1022,7 +1041,7 @@ class FS(object):
         with self._lock:
             if not create and not self.exists(dst_path):
                 raise errors.ResourceNotFound(dst_path)
-            move.move_dir(self, src_path, self, dst_path)
+            move.move_dir(self, src_path, self, dst_path, preserve_time=preserve_time)
 
     def makedirs(
         self,

--- a/fs/base.py
+++ b/fs/base.py
@@ -22,7 +22,7 @@ import warnings
 import six
 
 from . import copy, errors, fsencode, iotools, move, tools, walk, wildcard
-from .copy import copy_mtime
+from .copy import copy_modified_time
 from .glob import BoundGlobber
 from .mode import validate_open_mode
 from .path import abspath, join, normpath
@@ -426,7 +426,8 @@ class FS(object):
             with closing(self.open(src_path, "rb")) as read_file:
                 # FIXME(@althonos): typing complains because open return IO
                 self.upload(dst_path, read_file)  # type: ignore
-            copy_mtime(self, src_path, self, dst_path)
+            if preserve_time:
+                copy_modified_time(self, src_path, self, dst_path)
 
     def copydir(
         self,
@@ -1150,12 +1151,15 @@ class FS(object):
                 except OSError:
                     pass
                 else:
+                    if preserve_time:
+                        copy_modified_time(self, src_path, self, dst_path)
                     return
         with self._lock:
             with self.open(src_path, "rb") as read_file:
                 # FIXME(@althonos): typing complains because open return IO
                 self.upload(dst_path, read_file)  # type: ignore
-            copy_mtime(self, src_path, self, dst_path)
+            if preserve_time:
+                copy_modified_time(self, src_path, self, dst_path)
             self.remove(src_path)
 
     def open(

--- a/fs/base.py
+++ b/fs/base.py
@@ -22,7 +22,7 @@ import warnings
 import six
 
 from . import copy, errors, fsencode, iotools, move, tools, walk, wildcard
-from .copy import copy_cmtime
+from .copy import copy_mtime
 from .glob import BoundGlobber
 from .mode import validate_open_mode
 from .path import abspath, join, normpath
@@ -426,7 +426,7 @@ class FS(object):
             with closing(self.open(src_path, "rb")) as read_file:
                 # FIXME(@althonos): typing complains because open return IO
                 self.upload(dst_path, read_file)  # type: ignore
-            copy_cmtime(self, src_path, self, dst_path)
+            copy_mtime(self, src_path, self, dst_path)
 
     def copydir(
         self,
@@ -1155,7 +1155,7 @@ class FS(object):
             with self.open(src_path, "rb") as read_file:
                 # FIXME(@althonos): typing complains because open return IO
                 self.upload(dst_path, read_file)  # type: ignore
-            copy_cmtime(self, src_path, self, dst_path)
+            copy_mtime(self, src_path, self, dst_path)
             self.remove(src_path)
 
     def open(

--- a/fs/base.py
+++ b/fs/base.py
@@ -409,8 +409,8 @@ class FS(object):
             dst_path (str): Path to destination file.
             overwrite (bool): If `True`, overwrite the destination file
                 if it exists (defaults to `False`).
-            preserve_time (bool): If `True`, try to preserve atime, ctime,
-                and mtime of the resource (defaults to `False`).
+            preserve_time (bool): If `True`, try to preserve mtime of the
+                resource (defaults to `False`).
 
         Raises:
             fs.errors.DestinationExists: If ``dst_path`` exists,
@@ -443,8 +443,8 @@ class FS(object):
             dst_path (str): Path to destination directory.
             create (bool): If `True`, then ``dst_path`` will be created
                 if it doesn't exist already (defaults to `False`).
-            preserve_time (bool): If `True`, try to preserve atime, ctime,
-                and mtime of the resource (defaults to `False`).
+            preserve_time (bool): If `True`, try to preserve mtime of the
+                resource (defaults to `False`).
 
         Raises:
             fs.errors.ResourceNotFound: If the ``dst_path``
@@ -1054,8 +1054,8 @@ class FS(object):
             dst_path (str): Path to destination directory.
             create (bool): If `True`, then ``dst_path`` will be created
                 if it doesn't exist already (defaults to `False`).
-            preserve_time (bool): If `True`, try to preserve atime, ctime,
-                and mtime of the resources (defaults to `False`).
+            preserve_time (bool): If `True`, try to preserve mtime of the
+                resources (defaults to `False`).
 
         Raises:
             fs.errors.ResourceNotFound: if ``dst_path`` does not exist,
@@ -1122,8 +1122,8 @@ class FS(object):
                 file will be written to.
             overwrite (bool): If `True`, destination path will be
                 overwritten if it exists.
-            preserve_time (bool): If `True`, try to preserve atime, ctime,
-                and mtime of the resources (defaults to `False`).
+            preserve_time (bool): If `True`, try to preserve mtime of the
+                resources (defaults to `False`).
 
         Raises:
             fs.errors.FileExpected: If ``src_path`` maps to a

--- a/fs/base.py
+++ b/fs/base.py
@@ -22,7 +22,7 @@ import warnings
 import six
 
 from . import copy, errors, fsencode, iotools, move, tools, walk, wildcard
-from .copy import copy_metadata
+from .copy import copy_cmtime
 from .glob import BoundGlobber
 from .mode import validate_open_mode
 from .path import abspath, join, normpath
@@ -419,7 +419,7 @@ class FS(object):
             with closing(self.open(src_path, "rb")) as read_file:
                 # FIXME(@althonos): typing complains because open return IO
                 self.upload(dst_path, read_file)  # type: ignore
-            copy_metadata(self, src_path, self, dst_path)
+            copy_cmtime(self, src_path, self, dst_path)
 
     def copydir(
         self,
@@ -1130,8 +1130,8 @@ class FS(object):
             with self.open(src_path, "rb") as read_file:
                 # FIXME(@althonos): typing complains because open return IO
                 self.upload(dst_path, read_file)  # type: ignore
+            copy_cmtime(self, src_path, self, dst_path)
             self.remove(src_path)
-            copy_metadata(self, src_path, self, dst_path)
 
     def open(
         self,

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -45,7 +45,9 @@ def copy_fs(
             resources (defaults to `False`).
 
     """
-    return copy_fs_if(src_fs, dst_fs, "always", walker, on_copy, workers, preserve_time=preserve_time)
+    return copy_fs_if(
+        src_fs, dst_fs, "always", walker, on_copy, workers, preserve_time=preserve_time
+    )
 
 
 def copy_fs_if_newer(
@@ -66,7 +68,9 @@ def copy_fs_if_newer(
     warnings.warn(
         "copy_fs_if_newer is deprecated. Use copy_fs_if instead.", DeprecationWarning
     )
-    return copy_fs_if(src_fs, dst_fs, "newer", walker, on_copy, workers, preserve_time=preserve_time)
+    return copy_fs_if(
+        src_fs, dst_fs, "newer", walker, on_copy, workers, preserve_time=preserve_time
+    )
 
 
 def copy_fs_if(
@@ -135,7 +139,9 @@ def copy_file(
             resource (defaults to `False`).
 
     """
-    copy_file_if(src_fs, src_path, dst_fs, dst_path, "always", preserve_time=preserve_time)
+    copy_file_if(
+        src_fs, src_path, dst_fs, dst_path, "always", preserve_time=preserve_time
+    )
 
 
 def copy_file_if_newer(
@@ -156,7 +162,9 @@ def copy_file_if_newer(
         "copy_file_if_newer is deprecated. Use copy_file_if instead.",
         DeprecationWarning,
     )
-    return copy_file_if(src_fs, src_path, dst_fs, dst_path, "newer", preserve_time=preserve_time)
+    return copy_file_if(
+        src_fs, src_path, dst_fs, dst_path, "newer", preserve_time=preserve_time
+    )
 
 
 def copy_file_if(
@@ -210,7 +218,14 @@ def copy_file_if(
                 _src_fs, src_path, _dst_fs, dst_path, condition
             )
             if do_copy:
-                copy_file_internal(_src_fs, src_path, _dst_fs, dst_path, preserve_time=preserve_time, lock=True,)
+                copy_file_internal(
+                    _src_fs,
+                    src_path,
+                    _dst_fs,
+                    dst_path,
+                    preserve_time=preserve_time,
+                    lock=True,
+                )
             return do_copy
 
 
@@ -262,7 +277,6 @@ def copy_file_internal(
             _copy_locked()
     else:
         _copy_locked()
-
 
 
 def copy_structure(
@@ -327,7 +341,17 @@ def copy_dir(
             resources (defaults to `False`).
 
     """
-    copy_dir_if(src_fs, src_path, dst_fs, dst_path, "always", walker, on_copy, workers, preserve_time=preserve_time)
+    copy_dir_if(
+        src_fs,
+        src_path,
+        dst_fs,
+        dst_path,
+        "always",
+        walker,
+        on_copy,
+        workers,
+        preserve_time=preserve_time,
+    )
 
 
 def copy_dir_if_newer(
@@ -350,7 +374,17 @@ def copy_dir_if_newer(
     warnings.warn(
         "copy_dir_if_newer is deprecated. Use copy_dir_if instead.", DeprecationWarning
     )
-    copy_dir_if(src_fs, src_path, dst_fs, dst_path, "newer", walker, on_copy, workers, preserve_time=preserve_time)
+    copy_dir_if(
+        src_fs,
+        src_path,
+        dst_fs,
+        dst_path,
+        "newer",
+        walker,
+        on_copy,
+        workers,
+        preserve_time=preserve_time,
+    )
 
 
 def copy_dir_if(

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -40,8 +40,8 @@ def copy_fs(
             dst_path)``.
         workers (int): Use `worker` threads to copy data, or ``0`` (default) for
             a single-threaded copy.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resources (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resources (defaults to `False`).
 
     """
     return copy_dir(
@@ -76,8 +76,8 @@ def copy_fs_if_newer(
             dst_path)``.
         workers (int): Use ``worker`` threads to copy data, or ``0`` (default) for
             a single-threaded copy.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resources (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resources (defaults to `False`).
 
     """
     return copy_dir_if_newer(
@@ -138,8 +138,8 @@ def copy_file(
         src_path (str): Path to a file on the source filesystem.
         dst_fs (FS or str): Destination filesystem (instance or URL).
         dst_path (str): Path to a file on the destination filesystem.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resource (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resource (defaults to `False`).
 
     """
     with manage_fs(src_fs, writeable=False) as _src_fs:
@@ -182,8 +182,8 @@ def copy_file_internal(
         src_path (str): Path to a file on the source filesystem.
         dst_fs (FS): Destination filesystem.
         dst_path (str): Path to a file on the destination filesystem.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resource (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resource (defaults to `False`).
 
     """
     if src_fs is dst_fs:
@@ -223,8 +223,8 @@ def copy_file_if_newer(
         src_path (str): Path to a file on the source filesystem.
         dst_fs (FS or str): Destination filesystem (instance or URL).
         dst_path (str): Path to a file on the destination filesystem.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resource (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resource (defaults to `False`).
 
     Returns:
         bool: `True` if the file copy was executed, `False` otherwise.
@@ -273,8 +273,8 @@ def copy_structure(
         walker (~fs.walk.Walker, optional): A walker object that will be
             used to scan for files in ``src_fs``. Set this if you only
             want to consider a sub-set of the resources in ``src_fs``.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resource (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resource (defaults to `False`).
 
     """
     walker = walker or Walker()
@@ -311,8 +311,8 @@ def copy_dir(
             ``(src_fs, src_path, dst_fs, dst_path)``.
         workers (int): Use ``worker`` threads to copy data, or ``0`` (default) for
             a single-threaded copy.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resources (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resources (defaults to `False`).
 
     """
     on_copy = on_copy or (lambda *args: None)
@@ -383,8 +383,8 @@ def copy_dir_if_newer(
             ``(src_fs, src_path, dst_fs, dst_path)``.
         workers (int): Use ``worker`` threads to copy data, or ``0`` (default) for
             a single-threaded copy.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resources (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resources (defaults to `False`).
 
     """
     on_copy = on_copy or (lambda *args: None)

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -258,7 +258,7 @@ def copy_file_internal(
     if src_fs is dst_fs:
         # Same filesystem, so we can do a potentially optimized
         # copy
-        src_fs.copy(src_path, dst_path, overwrite=True)
+        src_fs.copy(src_path, dst_path, overwrite=True, preserve_time=preserve_time)
         return
 
     def _copy_locked():

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -159,7 +159,7 @@ def copy_file(
                     else:
                         with _src_fs.openbin(src_path) as read_file:
                             _dst_fs.upload(dst_path, read_file)
-                    copy_cmtime(_src_fs, src_path, _dst_fs, dst_path)
+                    copy_mtime(_src_fs, src_path, _dst_fs, dst_path)
 
 
 def copy_file_internal(
@@ -199,7 +199,7 @@ def copy_file_internal(
         with src_fs.openbin(src_path) as read_file:
             dst_fs.upload(dst_path, read_file)
 
-    copy_cmtime(src_fs, src_path, dst_fs, dst_path)
+    copy_mtime(src_fs, src_path, dst_fs, dst_path)
 
 
 def copy_file_if_newer(
@@ -445,7 +445,7 @@ def copy_dir_if_newer(
                             on_copy(_src_fs, dir_path, _dst_fs, copy_path)
 
 
-def copy_cmtime(
+def copy_mtime(
     src_fs,  # type: Union[FS, Text]
     src_path,  # type: Text
     dst_fs,  # type: Union[FS, Text]

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -461,7 +461,7 @@ def copy_mtime(
         dst_path (str): Path to a directory on the destination filesystem.
 
     """
-    namespaces = ("details", "metadata_changed", "modified")
+    namespaces = ("details",)
     with manage_fs(src_fs, writeable=False) as _src_fs:
         with manage_fs(dst_fs, create=True) as _dst_fs:
             src_meta = _src_fs.getinfo(src_path, namespaces)

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -45,7 +45,14 @@ def copy_fs(
 
     """
     return copy_dir(
-        src_fs, "/", dst_fs, "/", walker=walker, on_copy=on_copy, workers=workers
+        src_fs,
+        "/",
+        dst_fs,
+        "/",
+        walker=walker,
+        on_copy=on_copy,
+        workers=workers,
+        preserve_time=preserve_time,
     )
 
 
@@ -199,7 +206,8 @@ def copy_file_internal(
         with src_fs.openbin(src_path) as read_file:
             dst_fs.upload(dst_path, read_file)
 
-    copy_mtime(src_fs, src_path, dst_fs, dst_path)
+    if preserve_time:
+        copy_mtime(src_fs, src_path, dst_fs, dst_path)
 
 
 def copy_file_if_newer(
@@ -262,7 +270,6 @@ def copy_structure(
     src_fs,  # type: Union[FS, Text]
     dst_fs,  # type: Union[FS, Text]
     walker=None,  # type: Optional[Walker]
-    preserve_time=False,  # type: bool
 ):
     # type: (...) -> None
     """Copy directories (but not files) from ``src_fs`` to ``dst_fs``.
@@ -273,8 +280,6 @@ def copy_structure(
         walker (~fs.walk.Walker, optional): A walker object that will be
             used to scan for files in ``src_fs``. Set this if you only
             want to consider a sub-set of the resources in ``src_fs``.
-        preserve_time (bool): If `True`, try to preserve mtime of the
-            resource (defaults to `False`).
 
     """
     walker = walker or Walker()

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -444,7 +444,7 @@ class MemoryFS(FS):
                 parent_dir.set_entry(dir_name, new_dir)
             return self.opendir(path)
 
-    def move(self, src_path, dst_path, overwrite=False):
+    def move(self, src_path, dst_path, overwrite=False, preserve_time=False):
         src_dir, src_name = split(self.validatepath(src_path))
         dst_dir, dst_name = split(self.validatepath(dst_path))
 
@@ -465,7 +465,7 @@ class MemoryFS(FS):
             dst_dir_entry.set_entry(dst_name, src_entry)
             src_dir_entry.remove_entry(src_name)
 
-    def movedir(self, src_path, dst_path, create=False):
+    def movedir(self, src_path, dst_path, create=False, preserve_time=False):
         src_dir, src_name = split(self.validatepath(src_path))
         dst_dir, dst_name = split(self.validatepath(dst_path))
 

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -15,6 +15,7 @@ import six
 
 from . import errors
 from .base import FS
+from .copy import copy_modified_time
 from .enums import ResourceType, Seek
 from .info import Info
 from .mode import Mode
@@ -465,6 +466,9 @@ class MemoryFS(FS):
             dst_dir_entry.set_entry(dst_name, src_entry)
             src_dir_entry.remove_entry(src_name)
 
+            if preserve_time:
+                copy_modified_time(self, src_path, self, dst_path)
+
     def movedir(self, src_path, dst_path, create=False, preserve_time=False):
         src_dir, src_name = split(self.validatepath(src_path))
         dst_dir, dst_name = split(self.validatepath(dst_path))
@@ -483,6 +487,9 @@ class MemoryFS(FS):
 
             dst_dir_entry.set_entry(dst_name, src_entry)
             src_dir_entry.remove_entry(src_name)
+
+            if preserve_time:
+                copy_modified_time(self, src_path, self, dst_path)
 
     def openbin(self, path, mode="r", buffering=-1, **options):
         # type: (Text, Text, int, **Any) -> BinaryIO

--- a/fs/mirror.py
+++ b/fs/mirror.py
@@ -86,9 +86,9 @@ def mirror(
         return manage_fs(dst_fs, create=True)
 
     with src() as _src_fs, dst() as _dst_fs:
-        with _src_fs.lock(), _dst_fs.lock():
-            _thread_safe = is_thread_safe(_src_fs, _dst_fs)
-            with Copier(num_workers=workers if _thread_safe else 0) as copier:
+        _thread_safe = is_thread_safe(_src_fs, _dst_fs)
+        with Copier(num_workers=workers if _thread_safe else 0) as copier:
+            with _src_fs.lock(), _dst_fs.lock():
                 _mirror(
                     _src_fs,
                     _dst_fs,

--- a/fs/mirror.py
+++ b/fs/mirror.py
@@ -57,6 +57,7 @@ def mirror(
     walker=None,  # type: Optional[Walker]
     copy_if_newer=True,  # type: bool
     workers=0,  # type: int
+    preserve_time=False,  # type: bool
 ):
     # type: (...) -> None
     """Mirror files / directories from one filesystem to another.
@@ -73,6 +74,8 @@ def mirror(
         workers (int): Number of worker threads used
             (0 for single threaded). Set to a relatively low number
             for network filesystems, 4 would be a good start.
+        preserve_time (bool): If `True`, try to preserve atime, ctime,
+            and mtime of the resources (defaults to `False`).
 
     """
 
@@ -92,13 +95,19 @@ def mirror(
                     walker=walker,
                     copy_if_newer=copy_if_newer,
                     copy_file=copier.copy,
+                    preserve_time=preserve_time,
                 )
 
 
 def _mirror(
-    src_fs, dst_fs, walker=None, copy_if_newer=True, copy_file=copy_file_internal
+    src_fs,  # type: FS
+    dst_fs,  # type: FS
+    walker=None,  # type: Optional[Walker]
+    copy_if_newer=True,  # type: bool
+    copy_file=copy_file_internal,  # type: Callable[[FS, str, FS, str, bool], None]
+    preserve_time=False,  # type: bool
 ):
-    # type: (FS, FS, Optional[Walker], bool, Callable[[FS, str, FS, str], None]) -> None
+    # type: (...) -> None
     walker = walker or Walker()
     walk = walker.walk(src_fs, namespaces=["details"])
     for path, dirs, files in walk:
@@ -122,7 +131,7 @@ def _mirror(
                     # Compare file info
                     if copy_if_newer and not _compare(_file, dst_file):
                         continue
-            copy_file(src_fs, _path, dst_fs, _path)
+            copy_file(src_fs, _path, dst_fs, _path, preserve_time)
 
         # Make directories
         for _dir in dirs:

--- a/fs/mirror.py
+++ b/fs/mirror.py
@@ -87,7 +87,9 @@ def mirror(
 
     with src() as _src_fs, dst() as _dst_fs:
         _thread_safe = is_thread_safe(_src_fs, _dst_fs)
-        with Copier(num_workers=workers if _thread_safe else 0) as copier:
+        with Copier(
+            num_workers=workers if _thread_safe else 0, preserve_time=preserve_time
+        ) as copier:
             with _src_fs.lock(), _dst_fs.lock():
                 _mirror(
                     _src_fs,

--- a/fs/mirror.py
+++ b/fs/mirror.py
@@ -74,8 +74,8 @@ def mirror(
         workers (int): Number of worker threads used
             (0 for single threaded). Set to a relatively low number
             for network filesystems, 4 would be a good start.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resources (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resources (defaults to `False`).
 
     """
 

--- a/fs/move.py
+++ b/fs/move.py
@@ -29,8 +29,8 @@ def move_fs(
         dst_fs (FS or str): Destination filesystem (instance or URL).
         workers (int): Use `worker` threads to copy data, or ``0`` (default) for
             a single-threaded copy.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resources (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resources (defaults to `False`).
 
     """
     move_dir(src_fs, "/", dst_fs, "/", workers=workers, preserve_time=preserve_time)
@@ -51,8 +51,8 @@ def move_file(
         src_path (str): Path to a file on ``src_fs``.
         dst_fs (FS or str): Destination filesystem (instance or URL).
         dst_path (str): Path to a file on ``dst_fs``.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resources (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resources (defaults to `False`).
 
     """
     with manage_fs(src_fs) as _src_fs:
@@ -93,8 +93,8 @@ def move_dir(
         dst_path (str): Path to a directory on ``dst_fs``.
         workers (int): Use ``worker`` threads to copy data, or ``0``
             (default) for a single-threaded copy.
-        preserve_time (bool): If `True`, try to preserve atime, ctime,
-            and mtime of the resources (defaults to `False`).
+        preserve_time (bool): If `True`, try to preserve mtime of the
+            resources (defaults to `False`).
 
     """
 

--- a/fs/move.py
+++ b/fs/move.py
@@ -55,12 +55,13 @@ def move_file(
             and mtime of the resources (defaults to `False`).
 
     """
-    # TODO(preserve_time)
     with manage_fs(src_fs) as _src_fs:
         with manage_fs(dst_fs, create=True) as _dst_fs:
             if _src_fs is _dst_fs:
                 # Same filesystem, may be optimized
-                _src_fs.move(src_path, dst_path, overwrite=True)
+                _src_fs.move(
+                    src_path, dst_path, overwrite=True, preserve_time=preserve_time
+                )
             else:
                 # Standard copy and delete
                 with _src_fs.lock(), _dst_fs.lock():

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -431,8 +431,9 @@ class OSFS(FS):
         if hasattr(errno, "ENOTSUP"):
             _sendfile_error_codes.add(errno.ENOTSUP)
 
-        def copy(self, src_path, dst_path, overwrite=False):
-            # type: (Text, Text, bool) -> None
+        def copy(self, src_path, dst_path, overwrite=False, preserve_time=False):
+            # type: (Text, Text, bool, bool) -> None
+            # TODO(preserve_time)
             with self._lock:
                 # validate and canonicalise paths
                 _src_path, _dst_path = self._check_copy(src_path, dst_path, overwrite)
@@ -461,8 +462,9 @@ class OSFS(FS):
 
     else:
 
-        def copy(self, src_path, dst_path, overwrite=False):
-            # type: (Text, Text, bool) -> None
+        def copy(self, src_path, dst_path, overwrite=False, preserve_time=False):
+            # type: (Text, Text, bool, bool) -> None
+            # TODO(preserve_time)
             with self._lock:
                 _src_path, _dst_path = self._check_copy(src_path, dst_path, overwrite)
                 shutil.copy2(self.getsyspath(_src_path), self.getsyspath(_dst_path))

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -49,6 +49,7 @@ from .error_tools import convert_os_errors
 from .mode import Mode, validate_open_mode
 from .errors import FileExpected, NoURL
 from ._url_tools import url_quote
+from .copy import copy_mtime
 
 if typing.TYPE_CHECKING:
     from typing import (
@@ -452,6 +453,8 @@ class OSFS(FS):
                             while sent > 0:
                                 sent = sendfile(fd_dst, fd_src, offset, maxsize)
                                 offset += sent
+                    if preserve_time:
+                        copy_mtime(self, src_path, self, dst_path)
                 except OSError as e:
                     # the error is not a simple "sendfile not supported" error
                     if e.errno not in self._sendfile_error_codes:

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -433,7 +433,6 @@ class OSFS(FS):
 
         def copy(self, src_path, dst_path, overwrite=False, preserve_time=False):
             # type: (Text, Text, bool, bool) -> None
-            # TODO(preserve_time)
             with self._lock:
                 # validate and canonicalise paths
                 _src_path, _dst_path = self._check_copy(src_path, dst_path, overwrite)
@@ -464,7 +463,6 @@ class OSFS(FS):
 
         def copy(self, src_path, dst_path, overwrite=False, preserve_time=False):
             # type: (Text, Text, bool, bool) -> None
-            # TODO(preserve_time)
             with self._lock:
                 _src_path, _dst_path = self._check_copy(src_path, dst_path, overwrite)
                 shutil.copy2(self.getsyspath(_src_path), self.getsyspath(_dst_path))

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -49,7 +49,7 @@ from .error_tools import convert_os_errors
 from .mode import Mode, validate_open_mode
 from .errors import FileExpected, NoURL
 from ._url_tools import url_quote
-from .copy import copy_mtime
+from .copy import copy_modified_time
 
 if typing.TYPE_CHECKING:
     from typing import (
@@ -454,7 +454,7 @@ class OSFS(FS):
                                 sent = sendfile(fd_dst, fd_src, offset, maxsize)
                                 offset += sent
                     if preserve_time:
-                        copy_mtime(self, src_path, self, dst_path)
+                        copy_modified_time(self, src_path, self, dst_path)
                 except OSError as e:
                     # the error is not a simple "sendfile not supported" error
                     if e.errno not in self._sendfile_error_codes:

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -225,8 +225,8 @@ class WrapReadOnly(WrapFS[_F], typing.Generic[_F]):
         self.check()
         raise ResourceReadOnly(path)
 
-    def copy(self, src_path, dst_path, overwrite=False):
-        # type: (Text, Text, bool) -> None
+    def copy(self, src_path, dst_path, overwrite=False, preserve_time=False):
+        # type: (Text, Text, bool, bool) -> None
         self.check()
         raise ResourceReadOnly(dst_path)
 

--- a/fs/wrap.py
+++ b/fs/wrap.py
@@ -181,8 +181,8 @@ class WrapReadOnly(WrapFS[_F], typing.Generic[_F]):
         self.check()
         raise ResourceReadOnly(path)
 
-    def move(self, src_path, dst_path, overwrite=False):
-        # type: (Text, Text, bool) -> None
+    def move(self, src_path, dst_path, overwrite=False, preserve_time=False):
+        # type: (Text, Text, bool, bool) -> None
         self.check()
         raise ResourceReadOnly(dst_path)
 

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -167,15 +167,15 @@ class WrapFS(FS, typing.Generic[_F]):
         with unwrap_errors(path):
             return _fs.makedir(_path, permissions=permissions, recreate=recreate)
 
-    def move(self, src_path, dst_path, overwrite=False):
-        # type: (Text, Text, bool) -> None
+    def move(self, src_path, dst_path, overwrite=False, preserve_time=False):
+        # type: (Text, Text, bool, bool) -> None
         # A custom move permits a potentially optimized code path
         src_fs, _src_path = self.delegate_path(src_path)
         dst_fs, _dst_path = self.delegate_path(dst_path)
         with unwrap_errors({_src_path: src_path, _dst_path: dst_path}):
             if not overwrite and dst_fs.exists(_dst_path):
                 raise errors.DestinationExists(_dst_path)
-            move_file(src_fs, _src_path, dst_fs, _dst_path)
+            move_file(src_fs, _src_path, dst_fs, _dst_path, preserve_time=preserve_time)
 
     def movedir(self, src_path, dst_path, create=False):
         # type: (Text, Text, bool) -> None

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -177,8 +177,8 @@ class WrapFS(FS, typing.Generic[_F]):
                 raise errors.DestinationExists(_dst_path)
             move_file(src_fs, _src_path, dst_fs, _dst_path, preserve_time=preserve_time)
 
-    def movedir(self, src_path, dst_path, create=False):
-        # type: (Text, Text, bool) -> None
+    def movedir(self, src_path, dst_path, create=False, preserve_time=False):
+        # type: (Text, Text, bool, bool) -> None
         src_fs, _src_path = self.delegate_path(src_path)
         dst_fs, _dst_path = self.delegate_path(dst_path)
         with unwrap_errors({_src_path: src_path, _dst_path: dst_path}):

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -256,17 +256,17 @@ class WrapFS(FS, typing.Generic[_F]):
         with unwrap_errors(path):
             _fs.touch(_path)
 
-    def copy(self, src_path, dst_path, overwrite=False):
-        # type: (Text, Text, bool) -> None
+    def copy(self, src_path, dst_path, overwrite=False, preserve_time=False):
+        # type: (Text, Text, bool, bool) -> None
         src_fs, _src_path = self.delegate_path(src_path)
         dst_fs, _dst_path = self.delegate_path(dst_path)
         with unwrap_errors({_src_path: src_path, _dst_path: dst_path}):
             if not overwrite and dst_fs.exists(_dst_path):
                 raise errors.DestinationExists(_dst_path)
-            copy_file(src_fs, _src_path, dst_fs, _dst_path)
+            copy_file(src_fs, _src_path, dst_fs, _dst_path, preserve_time=preserve_time)
 
-    def copydir(self, src_path, dst_path, create=False):
-        # type: (Text, Text, bool) -> None
+    def copydir(self, src_path, dst_path, create=False, preserve_time=False):
+        # type: (Text, Text, bool, bool) -> None
         src_fs, _src_path = self.delegate_path(src_path)
         dst_fs, _dst_path = self.delegate_path(dst_path)
         with unwrap_errors({_src_path: src_path, _dst_path: dst_path}):
@@ -274,7 +274,7 @@ class WrapFS(FS, typing.Generic[_F]):
                 raise errors.ResourceNotFound(dst_path)
             if not src_fs.getinfo(_src_path).is_dir:
                 raise errors.DirectoryExpected(src_path)
-            copy_dir(src_fs, _src_path, dst_fs, _dst_path)
+            copy_dir(src_fs, _src_path, dst_fs, _dst_path, preserve_time=preserve_time)
 
     def create(self, path, wipe=False):
         # type: (Text, bool) -> bool

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -186,7 +186,7 @@ class WrapFS(FS, typing.Generic[_F]):
                 raise errors.ResourceNotFound(dst_path)
             if not src_fs.getinfo(_src_path).is_dir:
                 raise errors.DirectoryExpected(src_path)
-            move_dir(src_fs, _src_path, dst_fs, _dst_path)
+            move_dir(src_fs, _src_path, dst_fs, _dst_path, preserve_time=preserve_time)
 
     def openbin(self, path, mode="r", buffering=-1, **options):
         # type: (Text, Text, int, **Any) -> BinaryIO

--- a/setup.cfg
+++ b/setup.cfg
@@ -133,6 +133,7 @@ sitepackages = false
 skip_missing_interpreters = true
 requires =
   setuptools >=38.3.0
+  parameterized ~=0.8
 
 [testenv]
 commands = pytest --cov={toxinidir}/fs {posargs} {toxinidir}/tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -133,7 +133,6 @@ sitepackages = false
 skip_missing_interpreters = true
 requires =
   setuptools >=38.3.0
-  parameterized ~=0.8
 
 [testenv]
 commands = pytest --cov={toxinidir}/fs {posargs} {toxinidir}/tests

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -14,3 +14,5 @@ pysendfile ~=2.0 ; python_version <= "3.3"
 # mock v4+ doesn't support Python 2.7 anymore
 mock ~=3.0 ; python_version < "3.3"
 
+# parametrized to prevent code duplication in tests.
+parameterized ~=0.8

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -17,7 +17,7 @@ from fs import open_fs
 class TestCopy(unittest.TestCase):
     @parameterized.expand([(0,), (1,), (2,), (4,)])
     def test_copy_fs(self, workers):
-        namespaces = ("details", "accessed", "metadata_changed", "modified")
+        namespaces = ("details", "modified")
 
         src_fs = open_fs("mem://")
         src_fs.makedirs("foo/bar")
@@ -37,13 +37,7 @@ class TestCopy(unittest.TestCase):
         dst_file1_info = dst_fs.getinfo("test.txt", namespaces)
         dst_file2_info = dst_fs.getinfo("foo/bar/baz.txt", namespaces)
         self.assertEqual(dst_file1_info.modified, src_file1_info.modified)
-        self.assertEqual(
-            dst_file1_info.metadata_changed, src_file1_info.metadata_changed
-        )
         self.assertEqual(dst_file2_info.modified, src_file2_info.modified)
-        self.assertEqual(
-            dst_file2_info.metadata_changed, src_file2_info.metadata_changed
-        )
 
     def test_copy_value_error(self):
         src_fs = open_fs("mem://")
@@ -52,7 +46,7 @@ class TestCopy(unittest.TestCase):
             fs.copy.copy_fs(src_fs, dst_fs, workers=-1)
 
     def test_copy_dir0(self):
-        namespaces = ("details", "accessed", "metadata_changed", "modified")
+        namespaces = ("details", "modified")
 
         src_fs = open_fs("mem://")
         src_fs.makedirs("foo/bar")
@@ -69,13 +63,10 @@ class TestCopy(unittest.TestCase):
 
             dst_file2_info = dst_fs.getinfo("bar/baz.txt", namespaces)
             self.assertEqual(dst_file2_info.modified, src_file2_info.modified)
-            self.assertEqual(
-                dst_file2_info.metadata_changed, src_file2_info.metadata_changed
-            )
 
     @parameterized.expand([(0,), (1,), (2,), (4,)])
     def test_copy_dir(self, workers):
-        namespaces = ("details", "accessed", "metadata_changed", "modified")
+        namespaces = ("details", "modified")
 
         src_fs = open_fs("mem://")
         src_fs.makedirs("foo/bar")
@@ -94,9 +85,6 @@ class TestCopy(unittest.TestCase):
 
             dst_file2_info = dst_fs.getinfo("bar/baz.txt", namespaces)
             self.assertEqual(dst_file2_info.modified, src_file2_info.modified)
-            self.assertEqual(
-                dst_file2_info.metadata_changed, src_file2_info.metadata_changed
-            )
 
     def test_copy_large(self):
         data1 = b"foo" * 512 * 1024

--- a/tests/test_memoryfs.py
+++ b/tests/test_memoryfs.py
@@ -80,5 +80,4 @@ class TestMemoryFS(FSTestCases, unittest.TestCase):
 
         dst_info = self.fs.getinfo("bar/file.txt", namespaces)
         self.assertEqual(dst_info.modified, src_info.modified)
-        self.assertEqual(dst_info.accessed, src_info.accessed)
         self.assertEqual(dst_info.metadata_changed, src_info.metadata_changed)

--- a/tests/test_memoryfs.py
+++ b/tests/test_memoryfs.py
@@ -72,7 +72,7 @@ class TestMemoryFS(FSTestCases, unittest.TestCase):
         self.fs.makedir("bar")
         self.fs.touch("foo/file.txt")
 
-        namespaces = ("details", "accessed", "metadata_changed", "modified")
+        namespaces = ("details", "modified")
         src_info = self.fs.getinfo("foo/file.txt", namespaces)
 
         self.fs.copy("foo/file.txt", "bar/file.txt", preserve_time=True)
@@ -80,11 +80,9 @@ class TestMemoryFS(FSTestCases, unittest.TestCase):
 
         dst_info = self.fs.getinfo("bar/file.txt", namespaces)
         self.assertEqual(dst_info.modified, src_info.modified)
-        self.assertEqual(dst_info.metadata_changed, src_info.metadata_changed)
 
-        
+
 class TestMemoryFile(unittest.TestCase):
-
     def setUp(self):
         self.fs = memoryfs.MemoryFS()
 

--- a/tests/test_memoryfs.py
+++ b/tests/test_memoryfs.py
@@ -66,3 +66,19 @@ class TestMemoryFS(FSTestCases, unittest.TestCase):
             "Memory usage increased after closing the file system; diff is %0.2f KiB."
             % (diff_close.size_diff / 1024.0),
         )
+
+    def test_copy_preserve_time(self):
+        self.fs.makedir("foo")
+        self.fs.makedir("bar")
+        self.fs.touch("foo/file.txt")
+
+        namespaces = ("details", "accessed", "metadata_changed", "modified")
+        src_info = self.fs.getinfo("foo/file.txt", namespaces)
+
+        self.fs.copy("foo/file.txt", "bar/file.txt", preserve_time=True)
+        self.assertTrue(self.fs.exists("bar/file.txt"))
+
+        dst_info = self.fs.getinfo("bar/file.txt", namespaces)
+        self.assertEqual(dst_info.modified, src_info.modified)
+        self.assertEqual(dst_info.accessed, src_info.accessed)
+        self.assertEqual(dst_info.metadata_changed, src_info.metadata_changed)

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -2,15 +2,17 @@ from __future__ import unicode_literals
 
 import unittest
 
+from parameterized import parameterized_class
+
 from fs.mirror import mirror
 from fs import open_fs
 
 
+@parameterized_class(("WORKERS",), [(0,), (1,), (2,), (4,)])
 class TestMirror(unittest.TestCase):
-    WORKERS = 0  # Single threaded
-
     def _contents(self, fs):
         """Extract an FS in to a simple data structure."""
+        namespaces = ("details", "accessed", "metadata_changed", "modified")
         contents = []
         for path, dirs, files in fs.walk():
             for info in dirs:
@@ -18,7 +20,18 @@ class TestMirror(unittest.TestCase):
                 contents.append((_path, "dir", b""))
             for info in files:
                 _path = info.make_path(path)
-                contents.append((_path, "file", fs.readbytes(_path)))
+                _bytes = fs.readbytes(_path)
+                _info = fs.getinfo(_path, namespaces)
+                contents.append(
+                    (
+                        _path,
+                        "file",
+                        _bytes,
+                        _info.modified,
+                        _info.accessed,
+                        _info.metadata_changed,
+                    )
+                )
         return sorted(contents)
 
     def assert_compare_fs(self, fs1, fs2):
@@ -28,14 +41,14 @@ class TestMirror(unittest.TestCase):
     def test_empty_mirror(self):
         m1 = open_fs("mem://")
         m2 = open_fs("mem://")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
 
     def test_mirror_one_file(self):
         m1 = open_fs("mem://")
         m1.writetext("foo", "hello")
         m2 = open_fs("mem://")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
 
     def test_mirror_one_file_one_dir(self):
@@ -43,7 +56,7 @@ class TestMirror(unittest.TestCase):
         m1.writetext("foo", "hello")
         m1.makedir("bar")
         m2 = open_fs("mem://")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
 
     def test_mirror_delete_replace(self):
@@ -51,13 +64,13 @@ class TestMirror(unittest.TestCase):
         m1.writetext("foo", "hello")
         m1.makedir("bar")
         m2 = open_fs("mem://")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
         m2.remove("foo")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
         m2.removedir("bar")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
 
     def test_mirror_extra_dir(self):
@@ -66,7 +79,7 @@ class TestMirror(unittest.TestCase):
         m1.makedir("bar")
         m2 = open_fs("mem://")
         m2.makedir("baz")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
 
     def test_mirror_extra_file(self):
@@ -76,7 +89,7 @@ class TestMirror(unittest.TestCase):
         m2 = open_fs("mem://")
         m2.makedir("baz")
         m2.touch("egg")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
 
     def test_mirror_wrong_type(self):
@@ -86,7 +99,7 @@ class TestMirror(unittest.TestCase):
         m2 = open_fs("mem://")
         m2.makedir("foo")
         m2.touch("bar")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
 
     def test_mirror_update(self):
@@ -94,20 +107,8 @@ class TestMirror(unittest.TestCase):
         m1.writetext("foo", "hello")
         m1.makedir("bar")
         m2 = open_fs("mem://")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
         m2.appendtext("foo", " world!")
-        mirror(m1, m2, workers=self.WORKERS)
+        mirror(m1, m2, workers=self.WORKERS, preserve_time=True)
         self.assert_compare_fs(m1, m2)
-
-
-class TestMirrorWorkers1(TestMirror):
-    WORKERS = 1
-
-
-class TestMirrorWorkers2(TestMirror):
-    WORKERS = 2
-
-
-class TestMirrorWorkers4(TestMirror):
-    WORKERS = 4

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -12,7 +12,7 @@ from fs import open_fs
 class TestMirror(unittest.TestCase):
     def _contents(self, fs):
         """Extract an FS in to a simple data structure."""
-        namespaces = ("details", "accessed", "metadata_changed", "modified")
+        namespaces = ("details", "metadata_changed", "modified")
         contents = []
         for path, dirs, files in fs.walk():
             for info in dirs:
@@ -28,7 +28,6 @@ class TestMirror(unittest.TestCase):
                         "file",
                         _bytes,
                         _info.modified,
-                        _info.accessed,
                         _info.metadata_changed,
                     )
                 )

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -21,7 +21,7 @@ class TestMove(unittest.TestCase):
         src_file2_info = src_fs.getinfo("foo/bar/baz.txt", namespaces)
 
         dst_fs = open_fs("mem://")
-        fs.move.move_fs(src_fs, dst_fs)
+        fs.move.move_fs(src_fs, dst_fs, preserve_time=self.preserve_time)
 
         self.assertTrue(dst_fs.isdir("foo/bar"))
         self.assertTrue(dst_fs.isfile("test.txt"))
@@ -44,7 +44,7 @@ class TestMove(unittest.TestCase):
         src_file2_info = src_fs.getinfo("foo/bar/baz.txt", namespaces)
 
         dst_fs = open_fs("mem://")
-        fs.move.move_dir(src_fs, "/foo", dst_fs, "/")
+        fs.move.move_dir(src_fs, "/foo", dst_fs, "/", preserve_time=self.preserve_time)
 
         self.assertTrue(dst_fs.isdir("bar"))
         self.assertTrue(dst_fs.isfile("bar/baz.txt"))

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -11,7 +11,7 @@ from fs import open_fs
 @parameterized_class(("preserve_time",), [(True,), (False,)])
 class TestMove(unittest.TestCase):
     def test_move_fs(self):
-        namespaces = ("details", "accessed", "metadata_changed", "modified")
+        namespaces = ("details", "modified")
 
         src_fs = open_fs("mem://")
         src_fs.makedirs("foo/bar")
@@ -32,16 +32,10 @@ class TestMove(unittest.TestCase):
             dst_file1_info = dst_fs.getinfo("test.txt", namespaces)
             dst_file2_info = dst_fs.getinfo("foo/bar/baz.txt", namespaces)
             self.assertEqual(dst_file1_info.modified, src_file1_info.modified)
-            self.assertEqual(
-                dst_file1_info.metadata_changed, src_file1_info.metadata_changed
-            )
             self.assertEqual(dst_file2_info.modified, src_file2_info.modified)
-            self.assertEqual(
-                dst_file2_info.metadata_changed, src_file2_info.metadata_changed
-            )
 
     def test_move_dir(self):
-        namespaces = ("details", "accessed", "metadata_changed", "modified")
+        namespaces = ("details", "modified")
 
         src_fs = open_fs("mem://")
         src_fs.makedirs("foo/bar")
@@ -60,6 +54,3 @@ class TestMove(unittest.TestCase):
         if self.preserve_time:
             dst_file2_info = dst_fs.getinfo("bar/baz.txt", namespaces)
             self.assertEqual(dst_file2_info.modified, src_file2_info.modified)
-            self.assertEqual(
-                dst_file2_info.metadata_changed, src_file2_info.metadata_changed
-            )

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -32,12 +32,10 @@ class TestMove(unittest.TestCase):
             dst_file1_info = dst_fs.getinfo("test.txt", namespaces)
             dst_file2_info = dst_fs.getinfo("foo/bar/baz.txt", namespaces)
             self.assertEqual(dst_file1_info.modified, src_file1_info.modified)
-            self.assertEqual(dst_file1_info.accessed, src_file1_info.accessed)
             self.assertEqual(
                 dst_file1_info.metadata_changed, src_file1_info.metadata_changed
             )
             self.assertEqual(dst_file2_info.modified, src_file2_info.modified)
-            self.assertEqual(dst_file2_info.accessed, src_file2_info.accessed)
             self.assertEqual(
                 dst_file2_info.metadata_changed, src_file2_info.metadata_changed
             )
@@ -62,7 +60,6 @@ class TestMove(unittest.TestCase):
         if self.preserve_time:
             dst_file2_info = dst_fs.getinfo("bar/baz.txt", namespaces)
             self.assertEqual(dst_file2_info.modified, src_file2_info.modified)
-            self.assertEqual(dst_file2_info.accessed, src_file2_info.accessed)
             self.assertEqual(
                 dst_file2_info.metadata_changed, src_file2_info.metadata_changed
             )

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -21,6 +21,9 @@ class TestMove(unittest.TestCase):
         src_file2_info = src_fs.getinfo("foo/bar/baz.txt", namespaces)
 
         dst_fs = open_fs("mem://")
+        dst_fs.create("test.txt")
+        dst_fs.setinfo("test.txt", {"details": {"modified": 1000000}})
+
         fs.move.move_fs(src_fs, dst_fs, preserve_time=self.preserve_time)
 
         self.assertTrue(dst_fs.isdir("foo/bar"))
@@ -44,6 +47,9 @@ class TestMove(unittest.TestCase):
         src_file2_info = src_fs.getinfo("foo/bar/baz.txt", namespaces)
 
         dst_fs = open_fs("mem://")
+        dst_fs.create("test.txt")
+        dst_fs.setinfo("test.txt", {"details": {"modified": 1000000}})
+
         fs.move.move_dir(src_fs, "/foo", dst_fs, "/", preserve_time=self.preserve_time)
 
         self.assertTrue(dst_fs.isdir("bar"))

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -2,29 +2,54 @@ from __future__ import unicode_literals
 
 import unittest
 
+from parameterized import parameterized_class
+
 import fs.move
 from fs import open_fs
 
 
+@parameterized_class(("preserve_time",), [(True,), (False,)])
 class TestMove(unittest.TestCase):
     def test_move_fs(self):
+        namespaces = ("details", "accessed", "metadata_changed", "modified")
+
         src_fs = open_fs("mem://")
         src_fs.makedirs("foo/bar")
         src_fs.touch("test.txt")
         src_fs.touch("foo/bar/baz.txt")
+        src_file1_info = src_fs.getinfo("test.txt", namespaces)
+        src_file2_info = src_fs.getinfo("foo/bar/baz.txt", namespaces)
 
         dst_fs = open_fs("mem://")
         fs.move.move_fs(src_fs, dst_fs)
 
         self.assertTrue(dst_fs.isdir("foo/bar"))
         self.assertTrue(dst_fs.isfile("test.txt"))
+        self.assertTrue(dst_fs.isfile("foo/bar/baz.txt"))
         self.assertTrue(src_fs.isempty("/"))
 
-    def test_copy_dir(self):
+        if self.preserve_time:
+            dst_file1_info = dst_fs.getinfo("test.txt", namespaces)
+            dst_file2_info = dst_fs.getinfo("foo/bar/baz.txt", namespaces)
+            self.assertEqual(dst_file1_info.modified, src_file1_info.modified)
+            self.assertEqual(dst_file1_info.accessed, src_file1_info.accessed)
+            self.assertEqual(
+                dst_file1_info.metadata_changed, src_file1_info.metadata_changed
+            )
+            self.assertEqual(dst_file2_info.modified, src_file2_info.modified)
+            self.assertEqual(dst_file2_info.accessed, src_file2_info.accessed)
+            self.assertEqual(
+                dst_file2_info.metadata_changed, src_file2_info.metadata_changed
+            )
+
+    def test_move_dir(self):
+        namespaces = ("details", "accessed", "metadata_changed", "modified")
+
         src_fs = open_fs("mem://")
         src_fs.makedirs("foo/bar")
         src_fs.touch("test.txt")
         src_fs.touch("foo/bar/baz.txt")
+        src_file2_info = src_fs.getinfo("foo/bar/baz.txt", namespaces)
 
         dst_fs = open_fs("mem://")
         fs.move.move_dir(src_fs, "/foo", dst_fs, "/")
@@ -32,3 +57,12 @@ class TestMove(unittest.TestCase):
         self.assertTrue(dst_fs.isdir("bar"))
         self.assertTrue(dst_fs.isfile("bar/baz.txt"))
         self.assertFalse(src_fs.exists("foo"))
+        self.assertTrue(src_fs.isfile("test.txt"))
+
+        if self.preserve_time:
+            dst_file2_info = dst_fs.getinfo("bar/baz.txt", namespaces)
+            self.assertEqual(dst_file2_info.modified, src_file2_info.modified)
+            self.assertEqual(dst_file2_info.accessed, src_file2_info.accessed)
+            self.assertEqual(
+                dst_file2_info.metadata_changed, src_file2_info.metadata_changed
+            )

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -300,14 +300,26 @@ class TestOpeners(unittest.TestCase):
     def test_open_ftp(self, mock_FTPFS):
         open_fs("ftp://foo:bar@ftp.example.org")
         mock_FTPFS.assert_called_once_with(
-            "ftp.example.org", passwd="bar", port=21, user="foo", proxy=None, timeout=10, tls=False
+            "ftp.example.org",
+            passwd="bar",
+            port=21,
+            user="foo",
+            proxy=None,
+            timeout=10,
+            tls=False,
         )
 
     @mock.patch("fs.ftpfs.FTPFS")
     def test_open_ftps(self, mock_FTPFS):
         open_fs("ftps://foo:bar@ftp.example.org")
         mock_FTPFS.assert_called_once_with(
-            "ftp.example.org", passwd="bar", port=21, user="foo", proxy=None, timeout=10, tls=True
+            "ftp.example.org",
+            passwd="bar",
+            port=21,
+            user="foo",
+            proxy=None,
+            timeout=10,
+            tls=True,
         )
 
     @mock.patch("fs.ftpfs.FTPFS")

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -100,10 +100,9 @@ class TestOSFS(FSTestCases, unittest.TestCase):
     def test_copy_preserve_time(self):
         self.fs.makedir("foo")
         self.fs.makedir("bar")
-        now = time.time() - 10000
-        if not self.fs.create("foo/file.txt"):
-            raw_info = {"details": {"accessed": now, "modified": now}}
-            self.fs.setinfo("foo/file.txt", raw_info)
+        self.fs.create("foo/file.txt")
+        raw_info = {"details": {"modified": time.time() - 10000}}
+        self.fs.setinfo("foo/file.txt", raw_info)
 
         namespaces = ("details", "modified")
         src_info = self.fs.getinfo("foo/file.txt", namespaces)

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import tempfile
 import sys
+import time
 import unittest
 
 from fs import osfs, open_fs
@@ -86,6 +87,25 @@ class TestOSFS(FSTestCases, unittest.TestCase):
         fs2 = osfs.OSFS(path, expand_vars=False)
         self.assertIn("TYRIONLANISTER", fs1.getsyspath("/"))
         self.assertNotIn("TYRIONLANISTER", fs2.getsyspath("/"))
+
+    def test_copy_preserve_time(self):
+        self.fs.makedir("foo")
+        self.fs.makedir("bar")
+        now = time.time() - 10000
+        if not self.fs.create("foo/file.txt"):
+            raw_info = {"details": {"accessed": now, "modified": now}}
+            self.fs.setinfo("foo/file.txt", raw_info)
+
+        namespaces = ("details", "accessed", "metadata_changed", "modified")
+        src_info = self.fs.getinfo("foo/file.txt", namespaces)
+
+        self.fs.copy("foo/file.txt", "bar/file.txt", preserve_time=True)
+        self.assertTrue(self.fs.exists("bar/file.txt"))
+
+        dst_info = self.fs.getinfo("bar/file.txt", namespaces)
+        self.assertEqual(dst_info.modified, src_info.modified)
+        self.assertEqual(dst_info.accessed, src_info.accessed)
+        self.assertEqual(dst_info.metadata_changed, src_info.metadata_changed)
 
     @unittest.skipUnless(osfs.sendfile, "sendfile not supported")
     @unittest.skipIf(

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -113,7 +113,6 @@ class TestOSFS(FSTestCases, unittest.TestCase):
 
         dst_info = self.fs.getinfo("bar/file.txt", namespaces)
         self.assertEqual(dst_info.modified, src_info.modified)
-        self.assertEqual(dst_info.accessed, src_info.accessed)
         self.assertEqual(dst_info.metadata_changed, src_info.metadata_changed)
 
     @unittest.skipUnless(osfs.sendfile, "sendfile not supported")

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -105,7 +105,7 @@ class TestOSFS(FSTestCases, unittest.TestCase):
             raw_info = {"details": {"accessed": now, "modified": now}}
             self.fs.setinfo("foo/file.txt", raw_info)
 
-        namespaces = ("details", "accessed", "metadata_changed", "modified")
+        namespaces = ("details", "modified")
         src_info = self.fs.getinfo("foo/file.txt", namespaces)
 
         self.fs.copy("foo/file.txt", "bar/file.txt", preserve_time=True)
@@ -113,7 +113,6 @@ class TestOSFS(FSTestCases, unittest.TestCase):
 
         dst_info = self.fs.getinfo("bar/file.txt", namespaces)
         self.assertEqual(dst_info.modified, src_info.modified)
-        self.assertEqual(dst_info.metadata_changed, src_info.metadata_changed)
 
     @unittest.skipUnless(osfs.sendfile, "sendfile not supported")
     @unittest.skipIf(

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -177,7 +177,7 @@ class TestWrapCachedDir(unittest.TestCase):
         ]
         with mock.patch.object(self.fs, "scandir", wraps=self.fs.scandir) as scandir:
             self.assertEqual(sorted(self.cached.scandir("/"), key=key), expected)
-            scandir.assert_has_calls([mock.call('/', namespaces=None, page=None)])
+            scandir.assert_has_calls([mock.call("/", namespaces=None, page=None)])
         with mock.patch.object(self.fs, "scandir", wraps=self.fs.scandir) as scandir:
             self.assertEqual(sorted(self.cached.scandir("/"), key=key), expected)
             scandir.assert_not_called()
@@ -187,7 +187,7 @@ class TestWrapCachedDir(unittest.TestCase):
             self.assertTrue(self.cached.isdir("foo"))
             self.assertFalse(self.cached.isdir("egg"))  # is file
             self.assertFalse(self.cached.isdir("spam"))  # doesn't exist
-            scandir.assert_has_calls([mock.call('/', namespaces=None, page=None)])
+            scandir.assert_has_calls([mock.call("/", namespaces=None, page=None)])
         with mock.patch.object(self.fs, "scandir", wraps=self.fs.scandir) as scandir:
             self.assertTrue(self.cached.isdir("foo"))
             self.assertFalse(self.cached.isdir("egg"))
@@ -199,7 +199,7 @@ class TestWrapCachedDir(unittest.TestCase):
             self.assertTrue(self.cached.isfile("egg"))
             self.assertFalse(self.cached.isfile("foo"))  # is dir
             self.assertFalse(self.cached.isfile("spam"))  # doesn't exist
-            scandir.assert_has_calls([mock.call('/', namespaces=None, page=None)])
+            scandir.assert_has_calls([mock.call("/", namespaces=None, page=None)])
         with mock.patch.object(self.fs, "scandir", wraps=self.fs.scandir) as scandir:
             self.assertTrue(self.cached.isfile("egg"))
             self.assertFalse(self.cached.isfile("foo"))
@@ -211,7 +211,7 @@ class TestWrapCachedDir(unittest.TestCase):
             self.assertEqual(self.cached.getinfo("foo"), self.fs.getinfo("foo"))
             self.assertEqual(self.cached.getinfo("/"), self.fs.getinfo("/"))
             self.assertNotFound(self.cached.getinfo, "spam")
-            scandir.assert_has_calls([mock.call('/', namespaces=None, page=None)])
+            scandir.assert_has_calls([mock.call("/", namespaces=None, page=None)])
         with mock.patch.object(self.fs, "scandir", wraps=self.fs.scandir) as scandir:
             self.assertEqual(self.cached.getinfo("foo"), self.fs.getinfo("foo"))
             self.assertEqual(self.cached.getinfo("/"), self.fs.getinfo("/"))


### PR DESCRIPTION
## Type of changes

- New feature

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Fixes #450 by adding a `preserve_time` parameter to all relevant functions. The parameter is `False` by default to retain previous behaviour. However, it could be argued that the default should be `True` to mimic more common behavior found in operating systems.
