### PR TITLE
Add optimized implementations of several `MemoryFS` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Closes [#445](https://github.com/PyFilesystem/pyfilesystem2/pull/445).
 - Migrate continuous integration from Travis-CI to GitHub Actions and introduce several linters
   again in the build steps ([#448](https://github.com/PyFilesystem/pyfilesystem2/pull/448)).
-  Closes [#446](https://github.com/PyFilesystem/pyfilesystem2/pull/446).
+  Closes [#446](https://github.com/PyFilesystem/pyfilesystem2/issues/446).
 - Stop requiring `pytest` to run tests, allowing any test runner supporting `unittest`-style
   test suites.
 - `FSTestCases` now builds the large data required for `upload` and `download` tests only
   once in order to reduce the total testing time.
+- `MemoryFS.move` and `MemoryFS.movedir` will now avoid copying data. 
+   Closes [#452](https://github.com/PyFilesystem/pyfilesystem2/issues/452).
 
 ### Fixed
 

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import contextlib
 import io
-import itertools
 import os
 import time
 import typing
@@ -39,6 +38,7 @@ if typing.TYPE_CHECKING:
         SupportsInt,
         Union,
         Text,
+        Tuple,
     )
     from .base import _OpendirFactory
     from .info import RawInfo
@@ -608,7 +608,8 @@ class MemoryFS(FS):
                 filenames = filenames[start:end]
             # yield info with the right namespaces
             for name in filenames:
-                yield dir_entry.get_entry(name).to_info(namespaces=namespaces)
+                entry = typing.cast(_DirEntry, dir_entry.get_entry(name))
+                yield entry.to_info(namespaces=namespaces)
 
     def setinfo(self, path, info):
         # type: (Text, RawInfo) -> None

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import contextlib
 import io
+import itertools
 import os
 import time
 import typing
@@ -298,6 +299,21 @@ class _DirEntry(object):
         # type: (_MemoryFile) -> None
         self._open_files.remove(memory_file)
 
+    def to_info(self, namespaces=None):
+        # type: (Optional[Collection[Text]]) -> Info
+        namespaces = namespaces or ()
+        info = {"basic": {"name": self.name, "is_dir": self.is_dir}}
+        if "details" in namespaces:
+            info["details"] = {
+                "_write": ["accessed", "modified"],
+                "type": int(self.resource_type),
+                "size": self.size,
+                "accessed": self.accessed_time,
+                "modified": self.modified_time,
+                "created": self.created_time,
+            }
+        return Info(info)
+
 
 @six.python_2_unicode_compatible
 class MemoryFS(FS):
@@ -372,33 +388,24 @@ class MemoryFS(FS):
 
     def getinfo(self, path, namespaces=None):
         # type: (Text, Optional[Collection[Text]]) -> Info
-        namespaces = namespaces or ()
         _path = self.validatepath(path)
         dir_entry = self._get_dir_entry(_path)
         if dir_entry is None:
             raise errors.ResourceNotFound(path)
-        info = {"basic": {"name": dir_entry.name, "is_dir": dir_entry.is_dir}}
-        if "details" in namespaces:
-            info["details"] = {
-                "_write": ["accessed", "modified"],
-                "type": int(dir_entry.resource_type),
-                "size": dir_entry.size,
-                "accessed": dir_entry.accessed_time,
-                "modified": dir_entry.modified_time,
-                "created": dir_entry.created_time,
-            }
-        return Info(info)
+        return dir_entry.to_info(namespaces=namespaces)
 
     def listdir(self, path):
         # type: (Text) -> List[Text]
         self.check()
         _path = self.validatepath(path)
         with self._lock:
+            # locate and validate the entry corresponding to the given path
             dir_entry = self._get_dir_entry(_path)
             if dir_entry is None:
                 raise errors.ResourceNotFound(path)
             if not dir_entry.is_dir:
                 raise errors.DirectoryExpected(path)
+            # return the filenames in the order they were created
             return dir_entry.list()
 
     if typing.TYPE_CHECKING:
@@ -503,13 +510,13 @@ class MemoryFS(FS):
 
     def removedir(self, path):
         # type: (Text) -> None
-        # make sure the directory is empty
-        if not self.isempty(path):
-            return DirectoryNotEmpty(path)
         # make sure we are not removing root
         _path = self.validatepath(path)
         if _path == "/":
             raise errors.RemoveRootError()
+        # make sure the directory is empty
+        if not self.isempty(path):
+            raise errors.DirectoryNotEmpty(path)
         # we can now delegate to removetree since we confirmed that
         # * path exists (isempty)
         # * path is a folder (isempty)
@@ -537,6 +544,31 @@ class MemoryFS(FS):
                 raise errors.DirectoryExpected(path)
 
             parent_dir_entry.remove_entry(file_name)
+
+    def scandir(
+        self,
+        path,  # type: Text
+        namespaces=None,  # type: Optional[Collection[Text]]
+        page=None,  # type: Optional[Tuple[int, int]]
+    ):
+        # type: (...) -> Iterator[Info]
+        self.check()
+        _path = self.validatepath(path)
+        with self._lock:
+            # locate and validate the entry corresponding to the given path
+            dir_entry = self._get_dir_entry(_path)
+            if dir_entry is None:
+                raise errors.ResourceNotFound(path)
+            if not dir_entry.is_dir:
+                raise errors.DirectoryExpected(path)
+            # if paging was requested, slice the filenames
+            filenames = dir_entry.list()
+            if page is not None:
+                start, end = page
+                filenames = filenames[start:end]
+            # yield info with the right namespaces
+            for name in filenames:
+                yield dir_entry.get_entry(name).to_info(namespaces=namespaces)
 
     def setinfo(self, path, info):
         # type: (Text, RawInfo) -> None

--- a/fs/test.py
+++ b/fs/test.py
@@ -1115,6 +1115,15 @@ class FSTestCases(object):
         self.fs.removetree("foo")
         self.assert_not_exists("foo")
 
+        # Errors on files
+        self.fs.create("bar")
+        with self.assertRaises(errors.DirectoryExpected):
+            self.fs.removetree("bar")
+
+        # Errors on non-existing path
+        with self.assertRaises(errors.ResourceNotFound):
+            self.fs.removetree("foofoo")
+
     def test_setinfo(self):
         self.fs.create("birthday.txt")
         now = math.floor(time.time())

--- a/tests/test_memoryfs.py
+++ b/tests/test_memoryfs.py
@@ -66,3 +66,20 @@ class TestMemoryFS(FSTestCases, unittest.TestCase):
             "Memory usage increased after closing the file system; diff is %0.2f KiB."
             % (diff_close.size_diff / 1024.0),
         )
+
+
+class TestMemoryFile(unittest.TestCase):
+
+    def setUp(self):
+        self.fs = memoryfs.MemoryFS()
+
+    def tearDown(self):
+        self.fs.close()
+
+    def test_readline_writing(self):
+        with self.fs.openbin("test.txt", "w") as f:
+            self.assertRaises(IOError, f.readline)
+
+    def test_readinto_writing(self):
+        with self.fs.openbin("test.txt", "w") as f:
+            self.assertRaises(IOError, f.readinto, bytearray(10))


### PR DESCRIPTION
## Type of changes

- New feature

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] ~~I've added tests for new code.~~
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

This PR adds dedicated implementations for some `MemoryFS` methods that were still using the base `FS` code. This includes:

- `move` and `movedir`: the right directory entry is simply moved between folder, avoiding useless copy. Closes #452 .
- `removetree`: the entry is simply removed from its parents (in the case of `removetree("/")`, the entry is kept, but cleared)
- `scandir`: the entry being scanned is now kept in memory in a dedicated method (the base implementation uses `listdir` + `getinfo`, which caused `MemoryFS` to lookup for the parent folder over and over).
