### PR TITLE
Add missing `exc` argument to `PathError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added FTP over TLS (FTPS) support to FTPFS.
   Closes [#437](https://github.com/PyFilesystem/pyfilesystem2/issues/437),
   [#449](https://github.com/PyFilesystem/pyfilesystem2/pull/449).
+- `PathError` now supports wrapping an exception using the `exc` argument.
+  Closes [#453](https://github.com/PyFilesystem/pyfilesystem2/issues/453).
 
 ### Changed
 

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -139,13 +139,14 @@ class PathError(FSError):
 
     default_message = "path '{path}' is invalid"
 
-    def __init__(self, path, msg=None):  # noqa: D107
-        # type: (Text, Optional[Text]) -> None
+    def __init__(self, path, msg=None, exc=None):  # noqa: D107
+        # type: (Text, Optional[Text], Optional[Exception]) -> None
         self.path = path
+        self.exc = exc
         super(PathError, self).__init__(msg=msg)
 
     def __reduce__(self):
-        return type(self), (self.path, self._msg)
+        return type(self), (self.path, self._msg, self.exc)
 
 
 class NoSysPath(PathError):

--- a/tests/test_error_tools.py
+++ b/tests/test_error_tools.py
@@ -3,13 +3,23 @@ from __future__ import unicode_literals
 import errno
 import unittest
 
+import fs.errors
 from fs.error_tools import convert_os_errors
-from fs import errors as fserrors
 
 
 class TestErrorTools(unittest.TestCase):
-    def assert_convert_os_errors(self):
+    def test_convert_enoent(self):
+        exception = OSError(errno.ENOENT, "resource not found")
+        with self.assertRaises(fs.errors.ResourceNotFound) as ctx:
+            with convert_os_errors("stat", "/tmp/test"):
+                raise exception
+        self.assertEqual(ctx.exception.exc, exception)
+        self.assertEqual(ctx.exception.path, "/tmp/test")
 
-        with self.assertRaises(fserrors.ResourceNotFound):
-            with convert_os_errors("foo", "test"):
-                raise OSError(errno.ENOENT)
+    def test_convert_enametoolong(self):
+        exception = OSError(errno.ENAMETOOLONG, "File name too long: test")
+        with self.assertRaises(fs.errors.PathError) as ctx:
+            with convert_os_errors("stat", "/tmp/test"):
+                raise exception
+        self.assertEqual(ctx.exception.exc, exception)
+        self.assertEqual(ctx.exception.path, "/tmp/test")


### PR DESCRIPTION
## Type of changes

- Bug fix

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

`fs.errors.PathError` was missing an `exc` argument, so it couldn't be used in `fs.error_tools.convert_os_errors`. This prevented the conversion of `OSError(errno.ENAMETOOLONG)` errors to `PathError`. Closes #453.
