### PR TITLE
Fix minor issues in `OSFS.scandir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `WrapCachedDir.isdir` and `WrapCachedDir.isfile` raising a `ResourceNotFound` error on non-existing path ([#470](https://github.com/PyFilesystem/pyfilesystem2/pull/470)).
 - `FTPFS` not listing certain entries with sticky/SUID/SGID permissions set by Linux server ([#473](https://github.com/PyFilesystem/pyfilesystem2/pull/473)).
   Closes [#451](https://github.com/PyFilesystem/pyfilesystem2/issues/451).
+- `scandir` iterator not being closed explicitly in `OSFS.scandir`, occasionally causing a `ResourceWarning` 
+  to be thrown. Closes [#311](https://github.com/PyFilesystem/pyfilesystem2/issues/311).
 
 
 ## [2.4.12] - 2021-01-14

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -496,7 +496,9 @@ class OSFS(FS):
                         if requires_stat:
                             stat_result = dir_entry.stat()
                             if "details" in namespaces:
-                                info["details"] = self._make_details_from_stat(stat_result)
+                                info["details"] = self._make_details_from_stat(
+                                    stat_result
+                                )
                             if "stat" in namespaces:
                                 info["stat"] = {
                                     k: getattr(stat_result, k)
@@ -504,7 +506,9 @@ class OSFS(FS):
                                     if k.startswith("st_")
                                 }
                             if "access" in namespaces:
-                                info["access"] = self._make_access_from_stat(stat_result)
+                                info["access"] = self._make_access_from_stat(
+                                    stat_result
+                                )
                         if "lstat" in namespaces:
                             lstat_result = dir_entry.stat(follow_symlinks=False)
                             info["lstat"] = {

--- a/fs/test.py
+++ b/fs/test.py
@@ -16,6 +16,7 @@ import math
 import os
 import time
 import unittest
+import warnings
 
 import fs.copy
 import fs.move
@@ -884,8 +885,9 @@ class FSTestCases(object):
             self.assertFalse(f.closed)
         self.assertTrue(f.closed)
 
-        iter_lines = iter(self.fs.open("text"))
-        self.assertEqual(next(iter_lines), "Hello\n")
+        with self.fs.open("text") as f:
+            iter_lines = iter(f)
+            self.assertEqual(next(iter_lines), "Hello\n")
 
         with self.fs.open("unicode", "w") as f:
             self.assertEqual(12, f.write("Héllo\nWörld\n"))
@@ -1594,8 +1596,10 @@ class FSTestCases(object):
         self.assert_bytes("foo2", b"help")
 
         # Test __del__ doesn't throw traceback
-        f = self.fs.open("foo2", "r")
-        del f
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            f = self.fs.open("foo2", "r")
+            del f
 
         with self.assertRaises(IOError):
             with self.fs.open("foo2", "r") as f:

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -8,6 +8,7 @@ import shutil
 import tempfile
 import sys
 import unittest
+import warnings
 
 from fs import osfs, open_fs
 from fs.path import relpath, dirname
@@ -24,6 +25,14 @@ except ImportError:
 
 class TestOSFS(FSTestCases, unittest.TestCase):
     """Test OSFS implementation."""
+
+    @classmethod
+    def setUpClass(cls):
+        warnings.simplefilter("error")
+
+    @classmethod
+    def tearDownClass(cls):
+        warnings.simplefilter(warnings.defaultaction)
 
     def make_fs(self):
         temp_dir = tempfile.mkdtemp("fstestosfs")


### PR DESCRIPTION
## Type of changes

- Bug fix

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Since Python 3.6, `os.scandir` returns an object that must be explicitly closed if the iteration stops before the iterator is exhausted. This PR does that, which should suppress `ResourceWarning` that were occasionally raised by an unclosed iterator in `OSFS.scandir`. I also changed the current `OSFS.scandir` code so that it only calls `stat` when necessary. Closes #311 .

I made it so `tests.test_osfs.TestOSFS` now treats warnings as errors, but it's still not 100% feasible to test this kind of warnings, because they are thrown on garbage collection, most of the time after our test case has finished running.
