### PR TITLE
Some setinfo fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed performance bugs in `fs.copy.copy_dir_if_newer`. Test cases were adapted to catch those bugs in the future.
+- Fixed precision bug for timestamps in `fs.OSFS.setinfo`.
 
 
 ## [2.4.13] - 2021-03-27

--- a/fs/info.py
+++ b/fs/info.py
@@ -135,6 +135,9 @@ class Info(object):
         When creating an `Info` object, you can add a ``_write`` key to
         each raw namespace that lists which keys are writable or not.
 
+        In general, this means they are compatible with the `setinfo`
+        function of filesystem objects.
+
         Arguments:
             namespace (str): A namespace identifier.
             key (str): A key within the namespace.

--- a/fs/osfs.py
+++ b/fs/osfs.py
@@ -665,10 +665,10 @@ class OSFS(FS):
         if "details" in info:
             details = info["details"]
             if "accessed" in details or "modified" in details:
-                _accessed = typing.cast(int, details.get("accessed"))
-                _modified = typing.cast(int, details.get("modified", _accessed))
-                accessed = int(_modified if _accessed is None else _accessed)
-                modified = int(_modified)
+                _accessed = typing.cast(float, details.get("accessed"))
+                _modified = typing.cast(float, details.get("modified", _accessed))
+                accessed = float(_modified if _accessed is None else _accessed)
+                modified = float(_modified)
                 if accessed is not None or modified is not None:
                     with convert_os_errors("setinfo", path):
                         os.utime(sys_path, (accessed, modified))

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -111,7 +111,8 @@ class TestOSFS(FSTestCases, unittest.TestCase):
         self.assertTrue(self.fs.exists("bar/file.txt"))
 
         dst_info = self.fs.getinfo("bar/file.txt", namespaces)
-        self.assertAlmostEqual(dst_info.modified, src_info.modified, places=2)
+        delta = dst_info.modified - src_info.modified
+        self.assertAlmostEqual(delta.total_seconds(), 0, places=2)
 
     @unittest.skipUnless(osfs.sendfile, "sendfile not supported")
     @unittest.skipIf(

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -111,7 +111,7 @@ class TestOSFS(FSTestCases, unittest.TestCase):
         self.assertTrue(self.fs.exists("bar/file.txt"))
 
         dst_info = self.fs.getinfo("bar/file.txt", namespaces)
-        self.assertEqual(dst_info.modified, src_info.modified)
+        self.assertAlmostEqual(dst_info.modified, src_info.modified, places=2)
 
     @unittest.skipUnless(osfs.sendfile, "sendfile not supported")
     @unittest.skipIf(


### PR DESCRIPTION

## Type of changes

- Bug fix

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description
Unit tests for `FS.setinfo` now function correctly, whereas they basically did nothing before. Also, a bug in OSFS was fixed which caused timestamps to lose precision with `setinfo`.
