### PR TITLE
MountFS fixes

### DIFF
--- a/tests/test_mountfs.py
+++ b/tests/test_mountfs.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import unittest
 
+from fs.errors import ResourceNotFound
 from fs.mountfs import MountError, MountFS
 from fs.memoryfs import MemoryFS
 from fs.tempfs import TempFS
@@ -9,16 +10,6 @@ from fs.test import FSTestCases
 
 
 class TestMountFS(FSTestCases, unittest.TestCase):
-    """Test OSFS implementation."""
-
-    def make_fs(self):
-        fs = MountFS()
-        mem_fs = MemoryFS()
-        fs.mount("/", mem_fs)
-        return fs
-
-
-class TestMountFS2(FSTestCases, unittest.TestCase):
     """Test OSFS implementation."""
 
     def make_fs(self):
@@ -35,6 +26,11 @@ class TestMountFSBehaviours(unittest.TestCase):
             mount_fs.mount("foo", 5)
         with self.assertRaises(TypeError):
             mount_fs.mount("foo", b"bar")
+        m1 = MemoryFS()
+        with self.assertRaises(MountError):
+            mount_fs.mount("", m1)
+        with self.assertRaises(MountError):
+            mount_fs.mount("/", m1)
 
     def test_listdir(self):
         mount_fs = MountFS()
@@ -42,14 +38,32 @@ class TestMountFSBehaviours(unittest.TestCase):
         m1 = MemoryFS()
         m3 = MemoryFS()
         m4 = TempFS()
+        m5 = MemoryFS()
         mount_fs.mount("/m1", m1)
         mount_fs.mount("/m2", "temp://")
         mount_fs.mount("/m3", m3)
         with self.assertRaises(MountError):
             mount_fs.mount("/m3/foo", m4)
         self.assertEqual(sorted(mount_fs.listdir("/")), ["m1", "m2", "m3"])
+        mount_fs.makedir("/m2/foo")
+        self.assertEqual(sorted(mount_fs.listdir("/m2")), ["foo"])
         m3.makedir("foo")
         self.assertEqual(sorted(mount_fs.listdir("/m3")), ["foo"])
+        mount_fs.mount("/subdir/m4", m4)
+        self.assertEqual(sorted(mount_fs.listdir("/")), ["m1", "m2", "m3", "subdir"])
+        self.assertEqual(mount_fs.listdir("/subdir"), ["m4"])
+        self.assertEqual(mount_fs.listdir("/subdir/m4"), [])
+        mount_fs.mount("/subdir/m5", m5)
+        self.assertEqual(sorted(mount_fs.listdir("/subdir")), ["m4", "m5"])
+        self.assertEqual(mount_fs.listdir("/subdir/m5"), [])
+        mount_fs.makedir("/subdir/m4/foo")
+        mount_fs.makedir("/subdir/m5/bar")
+        self.assertEqual(mount_fs.listdir("/subdir/m4"), ["foo"])
+        self.assertEqual(mount_fs.listdir("/subdir/m5"), ["bar"])
+        self.assertEqual(m4.listdir("/"), ["foo"])
+        self.assertEqual(m5.listdir("/"), ["bar"])
+        m5.removedir("/bar")
+        self.assertEqual(mount_fs.listdir("/subdir/m5"), [])
 
     def test_auto_close(self):
         """Test MountFS auto close is working"""
@@ -85,8 +99,60 @@ class TestMountFSBehaviours(unittest.TestCase):
     def test_mount_self(self):
         mount_fs = MountFS()
         with self.assertRaises(ValueError):
-            mount_fs.mount("/", mount_fs)
+            mount_fs.mount("/m1", mount_fs)
 
     def test_desc(self):
         mount_fs = MountFS()
         mount_fs.desc("/")
+
+    def test_makedirs(self):
+        mount_fs = MountFS()
+        with self.assertRaises(ResourceNotFound):
+            mount_fs.makedir("empty")
+        m1 = MemoryFS()
+        m2 = MemoryFS()
+        with self.assertRaises(ResourceNotFound):
+            mount_fs.makedirs("/m1/foo/bar", recreate=True)
+        mount_fs.mount("/m1", m1)
+        mount_fs.makedirs("/m1/foo/bar", recreate=True)
+        self.assertEqual(m1.listdir("foo"), ["bar"])
+        with self.assertRaises(ResourceNotFound):
+            mount_fs.makedirs("/subdir/m2/bar/foo", recreate=True)
+        mount_fs.mount("/subdir/m2", m2)
+        mount_fs.makedirs("/subdir/m2/bar/foo", recreate=True)
+        self.assertEqual(m2.listdir("bar"), ["foo"])
+        with self.assertRaises(ResourceNotFound):
+            mount_fs.makedir("/subdir/m3", recreate=True)
+
+    def test_unmount(self):
+        mount_fs = MountFS()
+        m1 = MemoryFS()
+        m2 = MemoryFS()
+        m3 = MemoryFS()
+        m4 = MemoryFS()
+        mount_fs.mount("/m1", m1)
+        with self.assertRaises(ValueError):
+            mount_fs.unmount("/m2")
+        mount_fs.mount("/m2", m2)
+        self.assertEqual(sorted(mount_fs.listdir("/")), ["m1", "m2"])
+        mount_fs.unmount("/m1")
+        with self.assertRaises(ResourceNotFound):
+            mount_fs.listdir("/m1")
+        self.assertEqual(mount_fs.listdir("/"), ["m2"])
+        with self.assertRaises(ValueError):
+            mount_fs.unmount("/m1")
+        mount_fs.mount("/subdir/m3", m3)
+        with self.assertRaises(ValueError):
+            mount_fs.unmount("/subdir")
+        mount_fs.mount("/subdir/m4", m4)
+        self.assertEqual(sorted(mount_fs.listdir("/")), ["m2", "subdir"])
+        mount_fs.makedir("/subdir/m4/foo")
+        with self.assertRaises(ValueError):
+            mount_fs.unmount("/subdir/m4/foo")
+        mount_fs.unmount("/subdir/m4")
+        self.assertEqual(sorted(mount_fs.listdir("/")), ["m2", "subdir"])
+        self.assertEqual(mount_fs.listdir("/subdir"), ["m3"])
+        mount_fs.unmount("/subdir/m3")
+        self.assertEqual(mount_fs.listdir("/"), ["m2"])
+        with self.assertRaises(ResourceNotFound):
+            mount_fs.listdir("/subdir")


### PR DESCRIPTION
## Type of changes

- Bug fix
- Tests

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Addresses issues outlined #486 
* Don't allow MountFS to have an empty mount-path
* Don't allow files/dirs to be created inside MountFS's internal MemoryFS
* Change MountFS's .mounts attribute to a dict instead of a list of tuples
* Add a MountFS.unmount method
* Add associated unit-tests

It's a long time since I've done any PyFilesystem development, so this should should be considered "WIP code", comments welcome...  (e.g. I'm not sure if the `unmount` method is actually useful?)

This should be reviewed with care as the "bugfixes" this includes (the first two bullet-points above) subtly change the API of MountFS.