### PR TITLE
errors: make FSError inherit from OSError

### DIFF
--- a/fs/errors.py
+++ b/fs/errors.py
@@ -68,7 +68,7 @@ class MissingInfoNamespace(AttributeError):
 
 
 @six.python_2_unicode_compatible
-class FSError(Exception):
+class FSError(OSError):
     """Base exception for the `fs` module."""
 
     default_message = "Unspecified error"


### PR DESCRIPTION

## Type of changes

- Bug fix

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [😄] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description
Hi,

`FSError` has the same semantics than python's base `OSError`. By making
it inherit from it we enable a better transparency between python "raw"
FS methods and PyFS ones (no need to catch both).

Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>