### PR TITLE
Use platformdirs instead of appdirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Replaced `appdirs` with `platformdirs` dependency 
+  ([#489](https://github.com/PyFilesystem/pyfilesystem2/pull/489)).
+
 
 ## [2.4.15] - 2022-02-07
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ Many thanks to the following developers for contributing to this project:
 - [Diego Argueta](https://github.com/dargueta)
 - [Eelke van den Bos](https://github.com/eelkevdbos)
 - [Egor Namakonov](https://github.com/fresheed)
+- [Felix Yan](https://github.com/felixonmars)
 - [@FooBarQuaxx](https://github.com/FooBarQuaxx)
 - [Geoff Jukes](https://github.com/geoffjukes)
 - [George Macon](https://github.com/gmacon)

--- a/fs/appfs.py
+++ b/fs/appfs.py
@@ -5,7 +5,7 @@ across platforms, which vary in their conventions. They are all
 subclasses of `~fs.osfs.OSFS`.
 
 """
-# Thanks to authors of https://pypi.org/project/appdirs
+# Thanks to authors of https://pypi.org/project/platformdirs
 
 # see http://technet.microsoft.com/en-us/library/cc766489(WS.10).aspx
 
@@ -16,7 +16,7 @@ import six
 
 from .osfs import OSFS
 from ._repr import make_repr
-from appdirs import AppDirs
+from platformdirs import PlatformDirs
 
 if typing.TYPE_CHECKING:
     from typing import Optional, Text
@@ -78,7 +78,7 @@ class _AppFS(OSFS):
                 will be created if it does not exist.
 
         """
-        self.app_dirs = AppDirs(appname, author, version, roaming)
+        self.app_dirs = PlatformDirs(appname, author, version, roaming)
         self._create = create
         super(_AppFS, self).__init__(
             getattr(self.app_dirs, self.app_dir), create=create

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ packages = find:
 setup_requires =
     setuptools >=38.3.0
 install_requires =
-    appdirs~=1.4.3
+    platformdirs~=2.0.2
     pytz
     setuptools
     six ~=1.10

--- a/tests/test_appfs.py
+++ b/tests/test_appfs.py
@@ -30,7 +30,7 @@ class _TestAppFS(fs.test.FSTestCases):
 
     def make_fs(self):
         with mock.patch(
-            "appdirs.{}".format(self.AppFS.app_dir),
+            "platformdirs.{}".format(self.AppFS.app_dir),
             autospec=True,
             spec_set=True,
             return_value=tempfile.mkdtemp(dir=self.tmpdir),

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -264,7 +264,7 @@ class TestOpeners(unittest.TestCase):
         mem_fs_2 = opener.open_fs(mem_fs)
         self.assertEqual(mem_fs, mem_fs_2)
 
-    @mock.patch("appdirs.{}".format(UserDataFS.app_dir), autospec=True, spec_set=True)
+    @mock.patch("platformdirs.{}".format(UserDataFS.app_dir), autospec=True, spec_set=True)
     def test_open_userdata(self, app_dir):
         app_dir.return_value = self.tmpdir
 
@@ -276,7 +276,7 @@ class TestOpeners(unittest.TestCase):
         self.assertEqual(app_fs.app_dirs.appauthor, "willmcgugan")
         self.assertEqual(app_fs.app_dirs.version, "1.0")
 
-    @mock.patch("appdirs.{}".format(UserDataFS.app_dir), autospec=True, spec_set=True)
+    @mock.patch("platformdirs.{}".format(UserDataFS.app_dir), autospec=True, spec_set=True)
     def test_open_userdata_no_version(self, app_dir):
         app_dir.return_value = self.tmpdir
 
@@ -285,7 +285,7 @@ class TestOpeners(unittest.TestCase):
         self.assertEqual(app_fs.app_dirs.appauthor, "willmcgugan")
         self.assertEqual(app_fs.app_dirs.version, None)
 
-    @mock.patch("appdirs.{}".format(UserDataFS.app_dir), autospec=True, spec_set=True)
+    @mock.patch("platformdirs.{}".format(UserDataFS.app_dir), autospec=True, spec_set=True)
     def test_user_data_opener(self, app_dir):
         app_dir.return_value = self.tmpdir
 


### PR DESCRIPTION
## Type of changes

- Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Use the better maintained `platformdirs` instead of `appdirs`.