### PR TITLE
fix imports in extension.rst

### DIFF
--- a/docs/source/extension.rst
+++ b/docs/source/extension.rst
@@ -29,7 +29,8 @@ Here's an example taken from an Amazon S3 Filesystem::
 
   __all__ = ['S3FSOpener']
 
-  from fs.opener import Opener, OpenerError
+  from fs.opener import Opener
+  from fs.opener.errors import OpenerError
 
   from ._s3fs import S3FS
 


### PR DESCRIPTION
## Type of changes
- Documentation / docstrings

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Add a new import statement for `OpenerError` which was moved to a separate module (and isn't imported as part of the package's [\_\_init\_\_.py](https://github.com/PyFilesystem/pyfilesystem2/blob/master/fs/opener/__init__.py)).
