### PR TITLE
Fix `move` and `movedir` methods of `MemoryFS` not renaming the entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-- Support more leniant usernames and group names in FTP servers [#507](https://github.com/PyFilesystem/pyfilesystem2/pull/507). Closes [#506](https://github.com/PyFilesystem/pyfilesystem2/pull/506).
+### Changed
+
+- Support more lenient usernames and group names in FTP servers
+  ([#507](https://github.com/PyFilesystem/pyfilesystem2/pull/507)).
+  Closes [#506](https://github.com/PyFilesystem/pyfilesystem2/issues/506).
+
+### Fixed
+
+- Fixed `MemoryFS.move` and `MemoryFS.movedir` not updating the name of moved
+  resources, causing `MemoryFS.scandir` to use the old name.
+  ([#510](https://github.com/PyFilesystem/pyfilesystem2/pull/510)).
+  Closes [#509](https://github.com/PyFilesystem/pyfilesystem2/issues/509).
+
 
 ## [2.4.14] - 2021-11-16
 

--- a/fs/errors.py
+++ b/fs/errors.py
@@ -51,6 +51,7 @@ __all__ = [
     "ResourceNotFound",
     "ResourceReadOnly",
     "Unsupported",
+    "UnsupportedHash",
 ]
 
 

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -463,8 +463,11 @@ class MemoryFS(FS):
             elif not overwrite and dst_name in dst_dir_entry:
                 raise errors.DestinationExists(dst_path)
 
+            # move the entry from the src folder to the dst folder
             dst_dir_entry.set_entry(dst_name, src_entry)
             src_dir_entry.remove_entry(src_name)
+            # make sure to update the entry name itself (see #509)
+            src_entry.name = dst_name
 
             if preserve_time:
                 copy_modified_time(self, src_path, self, dst_path)
@@ -481,12 +484,16 @@ class MemoryFS(FS):
             if not src_entry.is_dir:
                 raise errors.DirectoryExpected(src_path)
 
+            # move the entry from the src folder to the dst folder
             dst_dir_entry = self._get_dir_entry(dst_dir)
             if dst_dir_entry is None or (not create and dst_name not in dst_dir_entry):
                 raise errors.ResourceNotFound(dst_path)
 
+            # move the entry from the src folder to the dst folder
             dst_dir_entry.set_entry(dst_name, src_entry)
             src_dir_entry.remove_entry(src_name)
+            # make sure to update the entry name itself (see #509)
+            src_entry.name = dst_name
 
             if preserve_time:
                 copy_modified_time(self, src_path, self, dst_path)

--- a/fs/test.py
+++ b/fs/test.py
@@ -1738,6 +1738,22 @@ class FSTestCases(object):
         self._test_copy_dir("temp://")
         self._test_copy_dir_write("temp://")
 
+    def test_move_dir_same_fs(self):
+        self.fs.makedirs("foo/bar/baz")
+        self.fs.makedir("egg")
+        self.fs.writetext("top.txt", "Hello, World")
+        self.fs.writetext("/foo/bar/baz/test.txt", "Goodbye, World")
+
+        fs.move.move_dir(self.fs, "foo", self.fs, "foo2")
+
+        expected = {"/egg", "/foo2", "/foo2/bar", "/foo2/bar/baz"}
+        self.assertEqual(set(walk.walk_dirs(self.fs)), expected)
+        self.assert_text("top.txt", "Hello, World")
+        self.assert_text("/foo2/bar/baz/test.txt", "Goodbye, World")
+
+        self.assertEqual(sorted(self.fs.listdir("/")), ["egg", "foo2", "top.txt"])
+        self.assertEqual(sorted(x.name for x in self.fs.scandir("/")), ["egg", "foo2", "top.txt"])
+
     def _test_move_dir_write(self, protocol):
         # Test moving to this filesystem from another.
         other_fs = open_fs(protocol)
@@ -1760,19 +1776,6 @@ class FSTestCases(object):
     def test_move_dir_temp(self):
         self._test_move_dir_write("temp://")
 
-    def test_move_same_fs(self):
-        self.fs.makedirs("foo/bar/baz")
-        self.fs.makedir("egg")
-        self.fs.writetext("top.txt", "Hello, World")
-        self.fs.writetext("/foo/bar/baz/test.txt", "Goodbye, World")
-
-        fs.move.move_dir(self.fs, "foo", self.fs, "foo2")
-
-        expected = {"/egg", "/foo2", "/foo2/bar", "/foo2/bar/baz"}
-        self.assertEqual(set(walk.walk_dirs(self.fs)), expected)
-        self.assert_text("top.txt", "Hello, World")
-        self.assert_text("/foo2/bar/baz/test.txt", "Goodbye, World")
-
     def test_move_file_same_fs(self):
         text = "Hello, World"
         self.fs.makedir("foo").writetext("test.txt", text)
@@ -1781,6 +1784,9 @@ class FSTestCases(object):
         fs.move.move_file(self.fs, "foo/test.txt", self.fs, "foo/test2.txt")
         self.assert_not_exists("foo/test.txt")
         self.assert_text("foo/test2.txt", text)
+
+        self.assertEqual(self.fs.listdir("foo"), ["test2.txt"])
+        self.assertEqual(next(self.fs.scandir("foo")).name, "test2.txt")
 
     def _test_move_file(self, protocol):
         other_fs = open_fs(protocol)

--- a/fs/test.py
+++ b/fs/test.py
@@ -1752,7 +1752,9 @@ class FSTestCases(object):
         self.assert_text("/foo2/bar/baz/test.txt", "Goodbye, World")
 
         self.assertEqual(sorted(self.fs.listdir("/")), ["egg", "foo2", "top.txt"])
-        self.assertEqual(sorted(x.name for x in self.fs.scandir("/")), ["egg", "foo2", "top.txt"])
+        self.assertEqual(
+            sorted(x.name for x in self.fs.scandir("/")), ["egg", "foo2", "top.txt"]
+        )
 
     def _test_move_dir_write(self, protocol):
         # Test moving to this filesystem from another.


### PR DESCRIPTION
## Type of changes

- Bug fix

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Fix `MemoryFS.move` and `MemoryFS.movedir` not renaming the entry that gets moved, which is causing issues with `scandir` (#509). This was not being picked by current tests, so I updated the `test_move_file_same_fs` and `test_move_dir_same_fs` test cases to detect the issue before fixing it.
