### PR TITLE
Update `movedir` methods of `WrapFS` to use the delegate FS method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   resources, causing `MemoryFS.scandir` to use the old name.
   ([#510](https://github.com/PyFilesystem/pyfilesystem2/pull/510)).
   Closes [#509](https://github.com/PyFilesystem/pyfilesystem2/issues/509).
+- Make `WrapFS.move` and `WrapFS.movedir` use the delegate FS methods instead
+  of `fs.move` functions, which was causing optimized implementation of 
+  `movedir` to be always skipped.
+  ([#511](https://github.com/PyFilesystem/pyfilesystem2/pull/511)).
 
 
 ## [2.4.14] - 2021-11-16

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -11,7 +11,6 @@ from . import errors
 from .base import FS
 from .copy import copy_file, copy_dir
 from .info import Info
-from .move import move_file, move_dir
 from .path import abspath, join, normpath
 from .error_tools import unwrap_errors
 

--- a/fs/wrapfs.py
+++ b/fs/wrapfs.py
@@ -169,24 +169,21 @@ class WrapFS(FS, typing.Generic[_F]):
 
     def move(self, src_path, dst_path, overwrite=False, preserve_time=False):
         # type: (Text, Text, bool, bool) -> None
-        # A custom move permits a potentially optimized code path
-        src_fs, _src_path = self.delegate_path(src_path)
-        dst_fs, _dst_path = self.delegate_path(dst_path)
+        _fs, _src_path = self.delegate_path(src_path)
+        _, _dst_path = self.delegate_path(dst_path)
         with unwrap_errors({_src_path: src_path, _dst_path: dst_path}):
-            if not overwrite and dst_fs.exists(_dst_path):
-                raise errors.DestinationExists(_dst_path)
-            move_file(src_fs, _src_path, dst_fs, _dst_path, preserve_time=preserve_time)
+            _fs.move(
+                _src_path, _dst_path, overwrite=overwrite, preserve_time=preserve_time
+            )
 
     def movedir(self, src_path, dst_path, create=False, preserve_time=False):
         # type: (Text, Text, bool, bool) -> None
-        src_fs, _src_path = self.delegate_path(src_path)
-        dst_fs, _dst_path = self.delegate_path(dst_path)
+        _fs, _src_path = self.delegate_path(src_path)
+        _, _dst_path = self.delegate_path(dst_path)
         with unwrap_errors({_src_path: src_path, _dst_path: dst_path}):
-            if not create and not dst_fs.exists(_dst_path):
-                raise errors.ResourceNotFound(dst_path)
-            if not src_fs.getinfo(_src_path).is_dir:
-                raise errors.DirectoryExpected(src_path)
-            move_dir(src_fs, _src_path, dst_fs, _dst_path, preserve_time=preserve_time)
+            _fs.movedir(
+                _src_path, _dst_path, create=create, preserve_time=preserve_time
+            )
 
     def openbin(self, path, mode="r", buffering=-1, **options):
         # type: (Text, Text, int, **Any) -> BinaryIO


### PR DESCRIPTION
## Type of changes

<!-- Remove unrelated categories -->

- Bug fix

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

The current implementation of `WrapFS.move` and `WrapFS.movedir` was always going through the `fs.move` functions. For `move`, this was just causing one extra call (`WrapFS.move -> fs.move.move_file -> WrapFS.delegate_fs().move`). But for `movedir`, this was never the case (`fs.move.move_dir` is always copying/removing the files, and never tries to call `movedir` because of recursivity issues, **this should be fixed too at some point**):

```python
home_fs = open_fs("~")
pics_fs = home_fs.opendir("Pictures")
pics_fs.movedir("My kid", "My kids")  # this was never using `home_fs.movedir`, always copying files
```


