### PR TITLE
Add WalkerBase

### DIFF
--- a/fs/compress.py
+++ b/fs/compress.py
@@ -20,7 +20,7 @@ from .enums import ResourceType
 from .path import relpath
 from .time import datetime_to_epoch
 from .errors import NoSysPath, MissingInfoNamespace
-from .walk import Walker
+from .walk import Walker, WalkerBase
 
 if typing.TYPE_CHECKING:
     from typing import BinaryIO, Optional, Text, Tuple, Union
@@ -34,7 +34,7 @@ def write_zip(
     file,  # type: Union[Text, BinaryIO]
     compression=zipfile.ZIP_DEFLATED,  # type: int
     encoding="utf-8",  # type: Text
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
 ):
     # type: (...) -> None
     """Write the contents of a filesystem to a zip file.
@@ -110,7 +110,7 @@ def write_tar(
     file,  # type: Union[Text, BinaryIO]
     compression=None,  # type: Optional[Text]
     encoding="utf-8",  # type: Text
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
 ):
     # type: (...) -> None
     """Write the contents of a filesystem to a tar file.

--- a/fs/copy.py
+++ b/fs/copy.py
@@ -10,7 +10,7 @@ from .errors import ResourceNotFound
 from .opener import manage_fs
 from .path import abspath, combine, frombase, normpath
 from .tools import is_thread_safe
-from .walk import Walker
+from .walk import Walker, WalkerBase
 
 if typing.TYPE_CHECKING:
     from typing import Callable, Optional, Text, Union
@@ -22,7 +22,7 @@ if typing.TYPE_CHECKING:
 def copy_fs(
     src_fs,  # type: Union[FS, Text]
     dst_fs,  # type: Union[FS, Text]
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
     on_copy=None,  # type: Optional[_OnCopy]
     workers=0,  # type: int
     preserve_time=False,  # type: bool
@@ -53,7 +53,7 @@ def copy_fs(
 def copy_fs_if_newer(
     src_fs,  # type: Union[FS, Text]
     dst_fs,  # type: Union[FS, Text]
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
     on_copy=None,  # type: Optional[_OnCopy]
     workers=0,  # type: int
     preserve_time=False,  # type: bool
@@ -77,7 +77,7 @@ def copy_fs_if(
     src_fs,  # type: Union[FS, Text]
     dst_fs,  # type: Union[FS, Text]
     condition="always",  # type: Text
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
     on_copy=None,  # type: Optional[_OnCopy]
     workers=0,  # type: int
     preserve_time=False,  # type: bool
@@ -282,7 +282,7 @@ def copy_file_internal(
 def copy_structure(
     src_fs,  # type: Union[FS, Text]
     dst_fs,  # type: Union[FS, Text]
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
     src_root="/",  # type: Text
     dst_root="/",  # type: Text
 ):
@@ -316,7 +316,7 @@ def copy_dir(
     src_path,  # type: Text
     dst_fs,  # type: Union[FS, Text]
     dst_path,  # type: Text
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
     on_copy=None,  # type: Optional[_OnCopy]
     workers=0,  # type: int
     preserve_time=False,  # type: bool
@@ -359,7 +359,7 @@ def copy_dir_if_newer(
     src_path,  # type: Text
     dst_fs,  # type: Union[FS, Text]
     dst_path,  # type: Text
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
     on_copy=None,  # type: Optional[_OnCopy]
     workers=0,  # type: int
     preserve_time=False,  # type: bool
@@ -393,7 +393,7 @@ def copy_dir_if(
     dst_fs,  # type: Union[FS, Text]
     dst_path,  # type: Text
     condition,  # type: Text
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
     on_copy=None,  # type: Optional[_OnCopy]
     workers=0,  # type: int
     preserve_time=False,  # type: bool
@@ -407,7 +407,7 @@ def copy_dir_if(
         dst_fs (FS or str): Destination filesystem (instance or URL).
         dst_path (str): Path to a directory on the destination filesystem.
         condition (str): Name of the condition to check for each file.
-        walker (~fs.walk.Walker, optional): A walker object that will be
+        walker (~fs.walk.WalkerBase, optional): A walker object that will be
             used to scan for files in ``src_fs``. Set this if you only want
             to consider a sub-set of the resources in ``src_fs``.
         on_copy (callable):A function callback called after a single file copy

--- a/fs/mirror.py
+++ b/fs/mirror.py
@@ -26,7 +26,7 @@ from .copy import copy_file_internal
 from .errors import ResourceNotFound
 from .opener import manage_fs
 from .tools import is_thread_safe
-from .walk import Walker
+from .walk import Walker, WalkerBase
 
 if typing.TYPE_CHECKING:
     from typing import Callable, Optional, Text, Union
@@ -54,7 +54,7 @@ def _compare(info1, info2):
 def mirror(
     src_fs,  # type: Union[FS, Text]
     dst_fs,  # type: Union[FS, Text]
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
     copy_if_newer=True,  # type: bool
     workers=0,  # type: int
     preserve_time=False,  # type: bool
@@ -104,7 +104,7 @@ def mirror(
 def _mirror(
     src_fs,  # type: FS
     dst_fs,  # type: FS
-    walker=None,  # type: Optional[Walker]
+    walker=None,  # type: Optional[WalkerBase]
     copy_if_newer=True,  # type: bool
     copy_file=copy_file_internal,  # type: Callable[[FS, str, FS, str, bool], None]
     preserve_time=False,  # type: bool


### PR DESCRIPTION
## Type of changes

<!-- Remove unrelated categories -->

- New feature
- Refactoring


## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

I've been cleaning up the huge mess my personal files have become over the years, and I needed a way to list every file in every archive across all my various drives.

To that end, I'm working on a new walker class that uses https://github.com/althonos/fs.archive to recursively list nested archives.

I noticed a [TODO](https://github.com/PyFilesystem/pyfilesystem2/blob/a6ea045e766c76bae2e2fde19294c8275773ffde/fs/walk.py#L48-L49) from @althonos, along with references to a missing [`WalkerBase`](https://github.com/PyFilesystem/pyfilesystem2/blob/a6ea045e766c76bae2e2fde19294c8275773ffde/fs/walk.py#L515) class, and figured I'd go ahead and implement it, since I was looking around for an abstract base class anyway.

I'm keeping this open, since there are a couple of things that still need attention (and some reading into how Python implemented generics):

- [ ] `fs.walk.BoundWalker` is still coupled with `fs.walk.Walker` specifically.
- [ ] `fs.base.FS:` is still coupled with `fs.walk.Walker` specifically.
