### PR TITLE
Remove pytz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support more lenient usernames and group names in FTP servers
   ([#507](https://github.com/PyFilesystem/pyfilesystem2/pull/507)).
   Closes [#506](https://github.com/PyFilesystem/pyfilesystem2/issues/506).
+- Removed dependency on pytz ([#518](https://github.com/PyFilesystem/pyfilesystem2/pull/518)).
+  Closes [#516](https://github.com/PyFilesystem/pyfilesystem2/issues/518).
 
 ### Fixed
 

--- a/fs/_ftp_parse.py
+++ b/fs/_ftp_parse.py
@@ -5,7 +5,12 @@ from __future__ import unicode_literals
 import unicodedata
 import re
 import time
-from datetime import datetime, timezone
+from datetime import datetime
+
+try:
+    from datetime import timezone
+except ImportError:
+    from ._tzcompat import timezone  # type: ignore
 
 from .enums import ResourceType
 from .permissions import Permissions

--- a/fs/_ftp_parse.py
+++ b/fs/_ftp_parse.py
@@ -3,17 +3,15 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import unicodedata
-import datetime
 import re
 import time
-
-from pytz import UTC
+from datetime import datetime, timezone
 
 from .enums import ResourceType
 from .permissions import Permissions
 
 
-EPOCH_DT = datetime.datetime.fromtimestamp(0, UTC)
+EPOCH_DT = datetime.fromtimestamp(0, timezone.utc)
 
 
 RE_LINUX = re.compile(
@@ -98,7 +96,7 @@ def _parse_time(t, formats):
     day = _t.tm_mday
     hour = _t.tm_hour
     minutes = _t.tm_min
-    dt = datetime.datetime(year, month, day, hour, minutes, tzinfo=UTC)
+    dt = datetime(year, month, day, hour, minutes, tzinfo=timezone.utc)
 
     epoch_time = (dt - EPOCH_DT).total_seconds()
     return epoch_time

--- a/fs/_tzcompat.py
+++ b/fs/_tzcompat.py
@@ -1,0 +1,30 @@
+"""Compatibility shim for python2's lack of datetime.timezone.
+
+This is the example code from the Python 2 documentation:
+https://docs.python.org/2.7/library/datetime.html#tzinfo-objects
+"""
+
+from datetime import tzinfo, timedelta
+
+
+ZERO = timedelta(0)
+
+
+class UTC(tzinfo):
+    """UTC"""
+
+    def utcoffset(self, dt):
+        return ZERO
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return ZERO
+
+
+utc = UTC()
+
+
+class timezone:
+    utc = utc

--- a/fs/test.py
+++ b/fs/test.py
@@ -8,7 +8,7 @@ All Filesystems should be able to pass these.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from datetime import datetime, timezone
+from datetime import datetime
 import io
 import itertools
 import json
@@ -33,6 +33,11 @@ if six.PY2:
     import collections as collections_abc
 else:
     import collections.abc as collections_abc
+
+try:
+    from datetime import timezone
+except ImportError:
+    from ._tzcompat import timezone  # type: ignore
 
 
 UNICODE_TEXT = """

--- a/fs/test.py
+++ b/fs/test.py
@@ -8,7 +8,7 @@ All Filesystems should be able to pass these.
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from datetime import datetime
+from datetime import datetime, timezone
 import io
 import itertools
 import json
@@ -26,7 +26,6 @@ from fs import glob
 from fs.opener import open_fs
 from fs.subfs import ClosingSubFS, SubFS
 
-import pytz
 import six
 from six import text_type
 
@@ -1196,9 +1195,9 @@ class FSTestCases(object):
         can_write_acccess = info.is_writeable("details", "accessed")
         can_write_modified = info.is_writeable("details", "modified")
         if can_write_acccess:
-            self.assertEqual(info.accessed, datetime(2016, 7, 5, tzinfo=pytz.UTC))
+            self.assertEqual(info.accessed, datetime(2016, 7, 5, tzinfo=timezone.utc))
         if can_write_modified:
-            self.assertEqual(info.modified, datetime(2016, 7, 5, tzinfo=pytz.UTC))
+            self.assertEqual(info.modified, datetime(2016, 7, 5, tzinfo=timezone.utc))
 
     def test_touch(self):
         self.fs.touch("new.txt")
@@ -1206,7 +1205,7 @@ class FSTestCases(object):
         self.fs.settimes("new.txt", datetime(2016, 7, 5))
         info = self.fs.getinfo("new.txt", namespaces=["details"])
         if info.is_writeable("details", "accessed"):
-            self.assertEqual(info.accessed, datetime(2016, 7, 5, tzinfo=pytz.UTC))
+            self.assertEqual(info.accessed, datetime(2016, 7, 5, tzinfo=timezone.utc))
             now = time.time()
             self.fs.touch("new.txt")
             accessed = self.fs.getinfo("new.txt", namespaces=["details"]).raw[

--- a/fs/time.py
+++ b/fs/time.py
@@ -6,7 +6,12 @@ from __future__ import unicode_literals
 
 import typing
 from calendar import timegm
-from datetime import datetime, timezone
+from datetime import datetime
+
+try:
+    from datetime import timezone
+except ImportError:
+    from ._tzcompat import timezone  # type: ignore
 
 if typing.TYPE_CHECKING:
     from typing import Optional

--- a/fs/time.py
+++ b/fs/time.py
@@ -6,16 +6,10 @@ from __future__ import unicode_literals
 
 import typing
 from calendar import timegm
-from datetime import datetime
-from pytz import UTC, timezone
+from datetime import datetime, timezone
 
 if typing.TYPE_CHECKING:
     from typing import Optional
-
-
-utcfromtimestamp = datetime.utcfromtimestamp
-utclocalize = UTC.localize
-GMT = timezone("GMT")
 
 
 def datetime_to_epoch(d):
@@ -39,4 +33,6 @@ def epoch_to_datetime(t):  # noqa: D103
 def epoch_to_datetime(t):
     # type: (Optional[int]) -> Optional[datetime]
     """Convert epoch time to a UTC datetime."""
-    return utclocalize(utcfromtimestamp(t)) if t is not None else None
+    if t is None:
+        return None
+    return datetime.fromtimestamp(t, tz=timezone.utc)

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ setup_requires =
     setuptools >=38.3.0
 install_requires =
     appdirs~=1.4.3
-    pytz
     setuptools
     six ~=1.10
     enum34 ~=1.1.6      ;  python_version < '3.4'

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,12 +1,17 @@
 from __future__ import unicode_literals
 
-from datetime import datetime, timezone
+from datetime import datetime
 import unittest
 
 from fs.enums import ResourceType
 from fs.info import Info
 from fs.permissions import Permissions
 from fs.time import datetime_to_epoch
+
+try:
+    from datetime import timezone
+except ImportError:
+    from fs._tzcompat import timezone  # type: ignore
 
 
 class TestInfo(unittest.TestCase):

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,9 +1,7 @@
 from __future__ import unicode_literals
 
-import datetime
+from datetime import datetime, timezone
 import unittest
-
-import pytz
 
 from fs.enums import ResourceType
 from fs.info import Info
@@ -71,10 +69,10 @@ class TestInfo(unittest.TestCase):
 
     def test_details(self):
         dates = [
-            datetime.datetime(2016, 7, 5, tzinfo=pytz.UTC),
-            datetime.datetime(2016, 7, 6, tzinfo=pytz.UTC),
-            datetime.datetime(2016, 7, 7, tzinfo=pytz.UTC),
-            datetime.datetime(2016, 7, 8, tzinfo=pytz.UTC),
+            datetime(2016, 7, 5, tzinfo=timezone.utc),
+            datetime(2016, 7, 6, tzinfo=timezone.utc),
+            datetime(2016, 7, 7, tzinfo=timezone.utc),
+            datetime(2016, 7, 8, tzinfo=timezone.utc),
         ]
         epochs = [datetime_to_epoch(d) for d in dates]
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,9 +1,14 @@
 from __future__ import unicode_literals, print_function
 
-from datetime import datetime, timezone
+from datetime import datetime
 import unittest
 
 from fs.time import datetime_to_epoch, epoch_to_datetime
+
+try:
+    from datetime import timezone
+except ImportError:
+    from fs._tzcompat import timezone  # type: ignore
 
 
 class TestEpoch(unittest.TestCase):

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,9 +1,7 @@
 from __future__ import unicode_literals, print_function
 
-from datetime import datetime
+from datetime import datetime, timezone
 import unittest
-
-import pytz
 
 from fs.time import datetime_to_epoch, epoch_to_datetime
 
@@ -11,10 +9,10 @@ from fs.time import datetime_to_epoch, epoch_to_datetime
 class TestEpoch(unittest.TestCase):
     def test_epoch_to_datetime(self):
         self.assertEqual(
-            epoch_to_datetime(142214400), datetime(1974, 7, 5, tzinfo=pytz.UTC)
+            epoch_to_datetime(142214400), datetime(1974, 7, 5, tzinfo=timezone.utc)
         )
 
     def test_datetime_to_epoch(self):
         self.assertEqual(
-            datetime_to_epoch(datetime(1974, 7, 5, tzinfo=pytz.UTC)), 142214400
+            datetime_to_epoch(datetime(1974, 7, 5, tzinfo=timezone.utc)), 142214400
         )


### PR DESCRIPTION
## Type of changes

- Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Everything that pytz was being utilised for can be serviced perfectly
fine by the standard library. Meanwhile, pytz is known as a footgun:

https://blog.ganssle.io/articles/2018/03/pytz-fastest-footgun.html

Fixes #516 