### PR TITLE
Enable comparing filesystems with `==`

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,6 +38,7 @@ Many thanks to the following developers for contributing to this project:
 - [Silvan Spross](https://github.com/sspross)
 - [@sqwishy](https://github.com/sqwishy)
 - [Sven Schliesing](https://github.com/muffl0n)
+- [Thomas Feldmann](https://github.com/tfeldmann)
 - [Tim Gates](https://github.com/timgates42/)
 - [@tkossak](https://github.com/tkossak)
 - [Todd Levi](https://github.com/televi)

--- a/fs/base.py
+++ b/fs/base.py
@@ -130,6 +130,18 @@ class FS(object):
         """Close filesystem on exit."""
         self.close()
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            try:
+                return self.getsyspath("/") == other.getsyspath("/")
+            except errors.NoSysPath:
+                pass
+            try:
+                return self.geturl("/") == other.geturl("/")
+            except errors.NoURL:
+                pass
+        return False
+
     @property
     def glob(self):
         """`~fs.glob.BoundGlobber`: a globber object.."""

--- a/fs/tarfs.py
+++ b/fs/tarfs.py
@@ -185,6 +185,9 @@ class WriteTarFS(WrapFS):
         # type: () -> Text
         return "<TarFS-write '{}'>".format(self._file)
 
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self._file == other._file
+
     def delegate_path(self, path):
         # type: (Text) -> Tuple[FS, Text]
         return self._temp_fs, path
@@ -302,6 +305,9 @@ class ReadTarFS(FS):
     def __str__(self):
         # type: () -> Text
         return "<TarFS '{}'>".format(self._file)
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self._file == other._file
 
     if six.PY2:
 

--- a/fs/zipfs.py
+++ b/fs/zipfs.py
@@ -226,6 +226,9 @@ class WriteZipFS(WrapFS):
         # type: () -> Text
         return "<zipfs-write '{}'>".format(self._file)
 
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self._file == other._file
+
     def delegate_path(self, path):
         # type: (Text) -> Tuple[FS, Text]
         return self._temp_fs, path
@@ -304,6 +307,9 @@ class ReadZipFS(FS):
     def __str__(self):
         # type: () -> Text
         return "<zipfs '{}'>".format(self._file)
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self._file == other._file
 
     def _path_to_zip_name(self, path):
         # type: (Text) -> str

--- a/tests/test_osfs.py
+++ b/tests/test_osfs.py
@@ -229,3 +229,16 @@ class TestOSFS(FSTestCases, unittest.TestCase):
 
     def test_geturl_return_no_url(self):
         self.assertRaises(errors.NoURL, self.fs.geturl, "test/path", "upload")
+
+    def test_equality(self):
+        dir_path = tempfile.mkdtemp()
+        t1 = open_fs(dir_path, create=True)
+        t2 = open_fs(dir_path, create=True)
+        self.assertEqual(t1, t2)
+
+        another_dir_path = tempfile.mkdtemp()
+        t3 = open_fs(another_dir_path, create=True)
+        self.assertNotEqual(t1, t3)
+
+        another_fs = open_fs("mem://")
+        self.assertNotEqual(t1, another_fs)

--- a/tests/test_tarfs.py
+++ b/tests/test_tarfs.py
@@ -306,6 +306,32 @@ class TestImplicitDirectories(unittest.TestCase):
         self.assertIs(info.type, ResourceType.directory)
 
 
+class TestEquality(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpfs = open_fs("temp://")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmpfs.close()
+
+    def test_equality(self):
+        p1 = self.tmpfs.getospath("test.tar")
+        p2 = self.tmpfs.getospath("other.tar")
+
+        with tarfs.TarFS("test.tar", write=True) as fw, tarfs.TarFS(
+            "test.tar"
+        ) as fr, tarfs.TarFS("test.tar") as fr2, tarfs.TarFS(
+            "other.tar"
+        ) as other, open_fs(
+            "mem://"
+        ) as mem:
+            self.assertEqual(fr, fr2)
+            self.assertNotEqual(fw, fr)
+            self.assertNotEqual(fr, mem)
+            self.assertNotEqual(fw, mem)
+
+
 class TestReadTarFSMem(TestReadTarFS):
     def make_source_fs(self):
         return open_fs("mem://")


### PR DESCRIPTION
## Type of changes

- Other

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

This PR enables comparing filesystems with the `==` operator. Based on the discussion in #515.