### PR TITLE
Optimize `move.move_file` for moving files between different OSFS instances.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,6 +38,7 @@ Many thanks to the following developers for contributing to this project:
 - [Silvan Spross](https://github.com/sspross)
 - [@sqwishy](https://github.com/sqwishy)
 - [Sven Schliesing](https://github.com/muffl0n)
+- [Thomas Feldmann](https://github.com/tfeldmann)
 - [Tim Gates](https://github.com/timgates42/)
 - [@tkossak](https://github.com/tkossak)
 - [Todd Levi](https://github.com/televi)

--- a/fs/move.py
+++ b/fs/move.py
@@ -4,11 +4,15 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from os.path import commonpath
 import typing
 
+from . import open_fs, errors
 from .copy import copy_dir
 from .copy import copy_file
 from .opener import manage_fs
+from .osfs import OSFS
+from .path import frombase
 
 if typing.TYPE_CHECKING:
     from .base import FS
@@ -55,6 +59,21 @@ def move_file(
             resources (defaults to `False`).
 
     """
+    # optimization for moving files between different OSFS instances
+    if isinstance(src_fs, OSFS) and isinstance(dst_fs, OSFS):
+        try:
+            src_syspath = src_fs.getsyspath(src_path)
+            dst_syspath = dst_fs.getsyspath(dst_path)
+            common = commonpath([src_syspath, dst_syspath])
+            rel_src = frombase(common, src_syspath)
+            rel_dst = frombase(common, dst_syspath)
+            with open_fs(common, writeable=True) as base:
+                base.move(rel_src, rel_dst, preserve_time=preserve_time)
+            return
+        except (ValueError, errors.NoSysPath):
+            # optimization cannot be applied
+            pass
+
     with manage_fs(src_fs) as _src_fs:
         with manage_fs(dst_fs, create=True) as _dst_fs:
             if _src_fs is _dst_fs:

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -6,6 +6,7 @@ from parameterized import parameterized_class
 
 import fs.move
 from fs import open_fs
+from fs.path import join
 
 
 @parameterized_class(("preserve_time",), [(True,), (False,)])
@@ -36,6 +37,17 @@ class TestMove(unittest.TestCase):
             dst_file2_info = dst_fs.getinfo("foo/bar/baz.txt", namespaces)
             self.assertEqual(dst_file1_info.modified, src_file1_info.modified)
             self.assertEqual(dst_file2_info.modified, src_file2_info.modified)
+
+    def test_move_file(self):
+        with open_fs("temp://") as temp:
+            syspath = temp.getsyspath("/")
+            a = open_fs(syspath)
+            a.makedir("dir")
+            b = open_fs(join(syspath, "dir"))
+            b.writetext("file.txt", "Content")
+            fs.move.move_file(b, "file.txt", a, "here.txt")
+            self.assertEqual(a.readtext("here.txt"), "Content")
+            self.assertFalse(b.exists("file.txt"))
 
     def test_move_dir(self):
         namespaces = ("details", "modified")


### PR DESCRIPTION
## Type of changes

- New feature

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Using `move.move_file` to move a file between different OSFS instances is extremely slow because it first copies the file to the destination and then deletes the source.
This PR adds an optimization for this use case.