### PR TITLE
Fix backward incompatibility introduced in 2.4.16 (#535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Fixes a backward incompatibility where `fs.move.move_file` raises `DestinationExists`
+  ([#535](https://github.com/PyFilesystem/pyfilesystem2/issues/535)).
+
 
 ## [2.4.16] - 2022-05-02
 

--- a/fs/move.py
+++ b/fs/move.py
@@ -82,7 +82,12 @@ def move_file(
                         rel_dst = frombase(common, dst_syspath)
                         with _src_fs.lock(), _dst_fs.lock():
                             with OSFS(common) as base:
-                                base.move(rel_src, rel_dst, preserve_time=preserve_time)
+                                base.move(
+                                    rel_src,
+                                    rel_dst,
+                                    overwrite=True,
+                                    preserve_time=preserve_time,
+                                )
                                 return  # optimization worked, exit early
                 except ValueError:
                     # This is raised if we cannot find a common base folder.

--- a/fs/move.py
+++ b/fs/move.py
@@ -10,7 +10,7 @@ from .copy import copy_dir, copy_file
 from .errors import FSError
 from .opener import manage_fs
 from .osfs import OSFS
-from .path import frombase
+from .path import frombase, normpath
 
 if typing.TYPE_CHECKING:
     from typing import Text, Union
@@ -64,7 +64,8 @@ def move_file(
     with manage_fs(src_fs, writeable=True) as _src_fs:
         with manage_fs(dst_fs, writeable=True, create=True) as _dst_fs:
             if _src_fs is _dst_fs:
-                if src_path == dst_path:
+                # Exit early if source and destination are the same file
+                if normpath(src_path) == normpath(dst_path):
                     return
 
                 # Same filesystem, may be optimized

--- a/fs/move.py
+++ b/fs/move.py
@@ -10,7 +10,7 @@ from .copy import copy_dir, copy_file
 from .errors import FSError
 from .opener import manage_fs
 from .osfs import OSFS
-from .path import frombase, normpath
+from .path import frombase
 
 if typing.TYPE_CHECKING:
     from typing import Text, Union

--- a/fs/move.py
+++ b/fs/move.py
@@ -64,6 +64,9 @@ def move_file(
     with manage_fs(src_fs, writeable=True) as _src_fs:
         with manage_fs(dst_fs, writeable=True, create=True) as _dst_fs:
             if _src_fs is _dst_fs:
+                if src_path == dst_path:
+                    return
+
                 # Same filesystem, may be optimized
                 _src_fs.move(
                     src_path, dst_path, overwrite=True, preserve_time=preserve_time

--- a/fs/move.py
+++ b/fs/move.py
@@ -64,10 +64,6 @@ def move_file(
     with manage_fs(src_fs, writeable=True) as _src_fs:
         with manage_fs(dst_fs, writeable=True, create=True) as _dst_fs:
             if _src_fs is _dst_fs:
-                # Exit early if source and destination are the same file
-                if normpath(src_path) == normpath(dst_path):
-                    return
-
                 # Same filesystem, may be optimized
                 _src_fs.move(
                     src_path, dst_path, overwrite=True, preserve_time=preserve_time

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -151,6 +151,14 @@ class TestMove(unittest.TestCase):
                 dst_ro.exists("target.txt"), "file should not have been copied over"
             )
 
+    def test_overwrite(self):
+        with open_fs("temp://") as src, open_fs("temp://") as dst:
+            src.writetext("file.txt", "Content")
+            dst.writetext("target.txt", "Content")
+            fs.move.move_file(src, "file.txt", dst, "target.txt")
+            self.assertFalse(src.exists("file.txt"))
+            self.assertTrue(dst.exists("target.txt"))
+
     @parameterized.expand([(True,), (False,)])
     def test_move_file_cleanup_on_error(self, cleanup):
         with open_fs("mem://") as src, open_fs("mem://") as dst:

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -151,13 +151,17 @@ class TestMove(unittest.TestCase):
                 dst_ro.exists("target.txt"), "file should not have been copied over"
             )
 
-    @parameterized.expand([("temp://",), ("mem://",)])
-    def test_move_file_overwrite(self, fs_url):
-        # we use TempFS and MemoryFS in order to make sure the optimised code path
-        # behaves like the regular one
+    @parameterized.expand([("temp", "temp://"), ("mem", "mem://")])
+    def test_move_file_overwrite(self, _, fs_url):
+        # we use TempFS and MemoryFS in order to make sure the optimized code path
+        # behaves like the regular one (TempFS tests the optmized code path).
         with open_fs(fs_url) as src, open_fs(fs_url) as dst:
             src.writetext("file.txt", "source content")
             dst.writetext("target.txt", "target content")
+            self.assertTrue(src.exists("file.txt"))
+            self.assertFalse(src.exists("target.txt"))
+            self.assertFalse(dst.exists("file.txt"))
+            self.assertTrue(dst.exists("target.txt"))
             fs.move.move_file(src, "file.txt", dst, "target.txt")
             self.assertFalse(src.exists("file.txt"))
             self.assertFalse(src.exists("target.txt"))
@@ -165,15 +169,26 @@ class TestMove(unittest.TestCase):
             self.assertTrue(dst.exists("target.txt"))
             self.assertEquals(dst.readtext("target.txt"), "source content")
 
-    @parameterized.expand([("temp://",), ("mem://",)])
-    def test_move_file_overwrite_itself(self, fs_url):
-        # we use TempFS and MemoryFS in order to make sure the optimised code path
-        # behaves like the regular one
+    @parameterized.expand([("temp", "temp://"), ("mem", "mem://")])
+    def test_move_file_overwrite_itself(self, _, fs_url):
+        # we use TempFS and MemoryFS in order to make sure the optimized code path
+        # behaves like the regular one (TempFS tests the optmized code path).
         with open_fs(fs_url) as tmp:
             tmp.writetext("file.txt", "content")
             fs.move.move_file(tmp, "file.txt", tmp, "file.txt")
             self.assertTrue(tmp.exists("file.txt"))
             self.assertEquals(tmp.readtext("file.txt"), "content")
+
+    @parameterized.expand([("temp", "temp://"), ("mem", "mem://")])
+    def test_move_file_overwrite_itself_relpath(self, _, fs_url):
+        # we use TempFS and MemoryFS in order to make sure the optimized code path
+        # behaves like the regular one (TempFS tests the optmized code path).
+        with open_fs(fs_url) as tmp:
+            new_dir = tmp.makedir("dir")
+            new_dir.writetext("file.txt", "content")
+            fs.move.move_file(tmp, "dir/../dir/file.txt", tmp, "dir/file.txt")
+            self.assertTrue(tmp.exists("dir/file.txt"))
+            self.assertEquals(tmp.readtext("dir/file.txt"), "content")
 
     @parameterized.expand([(True,), (False,)])
     def test_move_file_cleanup_on_error(self, cleanup):


### PR DESCRIPTION
## Type of changes

<!-- Remove unrelated categories -->

- Bug fix
- Tests

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Added `overwrite=True` to the optimized path in `fs.move.move_file`. `move_file` now behaves like in versions <2.4.16.
