### PR TITLE
docs: fix simple typo, fileystem -> filesystem

### DIFF
--- a/docs/source/info.rst
+++ b/docs/source/info.rst
@@ -46,7 +46,7 @@ file::
 
     resource_info = fs.getinfo('myfile.txt', namespaces=['details', 'access'])
 
-In addition to the specified namespaces, the fileystem will also return
+In addition to the specified namespaces, the filesystem will also return
 the ``basic`` namespace, which contains the name of the resource, and a
 flag which indicates if the resource is a directory.
 


### PR DESCRIPTION
There is a small typo in docs/source/info.rst.

Should read `filesystem` rather than `fileystem`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md