### PR TITLE
Github Actions Timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Type of changes

<!-- Remove unrelated categories -->

- Other

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

As discussed in #547, the tests should time out faster than the default 6h. I looked at some previous test runs and they all finish in 1:30 to 3:00 minutes. So I guess a 10:00 minute timeout should be fine.