### PR TITLE
Make all self-move operations raise `IllegalDestination` error

### DIFF
--- a/fs/base.py
+++ b/fs/base.py
@@ -1091,6 +1091,8 @@ class FS(object):
                 and ``create`` is `False`.
             fs.errors.DirectoryExpected: if ``src_path`` or one of its
                 ancestors is not a directory.
+            fs.errors.IllegalDestination: when attempting to move the
+                folder at ``src_path`` to itself or one of its subfolders.
 
         """
         from .move import move_dir
@@ -1169,6 +1171,8 @@ class FS(object):
                 and ``overwrite`` is `False`.
             fs.errors.ResourceNotFound: If a parent directory of
                 ``dst_path`` does not exist.
+            fs.errors.IllegalDestination: If ``src_path`` and ``dst_path``
+                refer to the same resource, and ``overwrite`` is `True`.
 
         """
         _src_path = self.validatepath(src_path)
@@ -1179,7 +1183,7 @@ class FS(object):
             raise errors.FileExpected(src_path)
         if _src_path == _dst_path:
             # early exit when moving a file onto itself
-            raise errors.IllegalDestination(dst_path)            
+            raise errors.IllegalDestination(dst_path)
         if self.getmeta().get("supports_rename", False):
             try:
                 src_sys_path = self.getsyspath(_src_path)

--- a/fs/base.py
+++ b/fs/base.py
@@ -1100,8 +1100,6 @@ class FS(object):
         with self._lock:
             _src_path = self.validatepath(src_path)
             _dst_path = self.validatepath(dst_path)
-            if _src_path == _dst_path:
-                raise errors.IllegalDestination(dst_path)
             if isbase(_src_path, _dst_path):
                 raise errors.IllegalDestination(dst_path)
             if not create and not self.exists(dst_path):

--- a/fs/base.py
+++ b/fs/base.py
@@ -1099,7 +1099,7 @@ class FS(object):
             _src_path = self.validatepath(src_path)
             _dst_path = self.validatepath(dst_path)
             if _src_path == _dst_path:
-                return
+                raise errors.IllegalDestination(dst_path)
             if isbase(_src_path, _dst_path):
                 raise errors.IllegalDestination(dst_path)
             if not create and not self.exists(dst_path):
@@ -1179,7 +1179,7 @@ class FS(object):
             raise errors.FileExpected(src_path)
         if _src_path == _dst_path:
             # early exit when moving a file onto itself
-            return
+            raise errors.IllegalDestination(dst_path)            
         if self.getmeta().get("supports_rename", False):
             try:
                 src_sys_path = self.getsyspath(_src_path)

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -485,7 +485,7 @@ class MemoryFS(FS):
         src_dir, src_name = split(_src_path)
 
         # move a dir onto or into itself
-        if _src_path == _dst_path or isbase(_src_path, _dst_path):
+        if isbase(_src_path, _dst_path):
             raise errors.IllegalDestination(dst_path)
 
         with self._lock:

--- a/fs/memoryfs.py
+++ b/fs/memoryfs.py
@@ -465,8 +465,9 @@ class MemoryFS(FS):
             # handle moving a file onto itself
             if src_dir == dst_dir and src_name == dst_name:
                 if overwrite:
-                    return
-                raise errors.DestinationExists(dst_path)
+                    raise errors.IllegalDestination(dst_path)
+                else:
+                    raise errors.DestinationExists(dst_path)
 
             # move the entry from the src folder to the dst folder
             dst_dir_entry.set_entry(dst_name, src_entry)
@@ -483,11 +484,8 @@ class MemoryFS(FS):
         dst_dir, dst_name = split(_dst_path)
         src_dir, src_name = split(_src_path)
 
-        # move a dir onto itself
-        if _src_path == _dst_path:
-            return
-        # move a dir into itself
-        if isbase(_src_path, _dst_path):
+        # move a dir onto or into itself
+        if _src_path == _dst_path or isbase(_src_path, _dst_path):
             raise errors.IllegalDestination(dst_path)
 
         with self._lock:

--- a/fs/test.py
+++ b/fs/test.py
@@ -1813,20 +1813,20 @@ class FSTestCases(object):
 
     def test_move_file_onto_itself(self):
         self.fs.writetext("file.txt", "Hello")
-        self.fs.move("file.txt", "file.txt", overwrite=True)
-        self.assert_text("file.txt", "Hello")
-
+        with self.assertRaises(errors.IllegalDestination):
+            self.fs.move("file.txt", "file.txt", overwrite=True)
         with self.assertRaises(errors.DestinationExists):
             self.fs.move("file.txt", "file.txt", overwrite=False)
+        self.assert_text("file.txt", "Hello")
 
     def test_move_file_onto_itself_relpath(self):
         subdir = self.fs.makedir("sub")
         subdir.writetext("file.txt", "Hello")
-        self.fs.move("sub/file.txt", "sub/../sub/file.txt", overwrite=True)
-        self.assert_text("sub/file.txt", "Hello")
-
+        with self.assertRaises(errors.IllegalDestination):
+            self.fs.move("sub/file.txt", "sub/../sub/file.txt", overwrite=True)
         with self.assertRaises(errors.DestinationExists):
             self.fs.move("sub/file.txt", "sub/../sub/file.txt", overwrite=False)
+        self.assert_text("sub/file.txt", "Hello")
 
     def test_copy_file_onto_itself(self):
         self.fs.writetext("file.txt", "Hello")
@@ -1911,8 +1911,8 @@ class FSTestCases(object):
         folder.writetext("file1.txt", "Hello1")
         sub = folder.makedir("sub")
         sub.writetext("file2.txt", "Hello2")
-
-        self.fs.movedir("folder", "folder")
+        with self.assertRaises(errors.IllegalDestination):
+            self.fs.movedir("folder", "folder")
         self.assert_text("folder/file1.txt", "Hello1")
         self.assert_text("folder/sub/file2.txt", "Hello2")
 

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -11,7 +11,7 @@ from parameterized import parameterized, parameterized_class
 
 import fs.move
 from fs import open_fs
-from fs.errors import FSError, ResourceReadOnly
+from fs.errors import FSError, ResourceReadOnly, IllegalDestination
 from fs.path import join
 from fs.wrap import read_only
 
@@ -175,7 +175,8 @@ class TestMove(unittest.TestCase):
         # behaves like the regular one (TempFS tests the optmized code path).
         with open_fs(fs_url) as tmp:
             tmp.writetext("file.txt", "content")
-            fs.move.move_file(tmp, "file.txt", tmp, "file.txt")
+            with self.assertRaises(IllegalDestination):
+                fs.move.move_file(tmp, "file.txt", tmp, "file.txt")
             self.assertTrue(tmp.exists("file.txt"))
             self.assertEquals(tmp.readtext("file.txt"), "content")
 
@@ -186,7 +187,8 @@ class TestMove(unittest.TestCase):
         with open_fs(fs_url) as tmp:
             new_dir = tmp.makedir("dir")
             new_dir.writetext("file.txt", "content")
-            fs.move.move_file(tmp, "dir/../dir/file.txt", tmp, "dir/file.txt")
+            with self.assertRaises(IllegalDestination):
+                fs.move.move_file(tmp, "dir/../dir/file.txt", tmp, "dir/file.txt")
             self.assertTrue(tmp.exists("dir/file.txt"))
             self.assertEquals(tmp.readtext("dir/file.txt"), "content")
 


### PR DESCRIPTION
## Type of changes

- Bug fix
- New feature
- Tests

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've ~~added~~ updated tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

As discussed with @lurch in #547, this PR makes all self-move operations raise `IllegalDestination` instead of being silent. In `fs.move.move_file`, `DestinationExists` takes priority if `overwrite` is `False`.
