### PR TITLE
Drop usage of `pkg_resources`

### DIFF
--- a/fs/__init__.py
+++ b/fs/__init__.py
@@ -1,7 +1,7 @@
 """Python filesystem abstraction layer.
 """
 
-__import__("pkg_resources").declare_namespace(__name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
 
 from . import path
 from ._fscompat import fsdecode, fsencode

--- a/fs/opener/__init__.py
+++ b/fs/opener/__init__.py
@@ -3,7 +3,7 @@
 """
 
 # Declare fs.opener as a namespace package
-__import__("pkg_resources").declare_namespace(__name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
 
 # Import opener modules so that `registry.install` if called on each opener
 from . import appfs, ftpfs, memoryfs, osfs, tarfs, tempfs, zipfs

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,9 +45,10 @@ install_requires =
     appdirs~=1.4.3
     setuptools
     six ~=1.10
-    enum34 ~=1.1.6      ;  python_version < '3.4'
-    typing ~=3.6        ;  python_version < '3.6'
-    backports.os ~=0.1  ;  python_version < '3.0'
+    enum34 ~=1.1.6            ;  python_version < '3.4'
+    typing ~=3.6              ;  python_version < '3.6'
+    backports.os ~=0.1        ;  python_version < '3.0'
+    importlib-metadata ~=2.0  ;  python_version < '3.8'
 
 [options.extras_require]
 scandir =


### PR DESCRIPTION
## Type of changes

<!-- Remove unrelated categories -->

- Bug fix

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Drop `pkg_resources` in favor of the `importlib.metadata` API.

Closes https://github.com/PyFilesystem/pyfilesystem2/issues/356