### PR TITLE
#556 Fallback to alternate mtime depending correctly

### DIFF
--- a/fs/compress.py
+++ b/fs/compress.py
@@ -65,17 +65,15 @@ def write_zip(
                 # Python2 expects bytes filenames
                 zip_name = zip_name.encode(encoding, "replace")
 
-            if info.has_namespace("stat"):
-                # If the file has a stat namespace, get the
-                # zip time directory from the stat structure
-                st_mtime = info.get("stat", "st_mtime", None)
-                _mtime = time.localtime(st_mtime)
-                zip_time = _mtime[0:6]  # type: ZipTime
-            else:
-                # Otherwise, use the modified time from details
-                # namespace.
-                mt = info.modified or datetime.utcnow()
-                zip_time = (mt.year, mt.month, mt.day, mt.hour, mt.minute, mt.second)
+            # If the file has a stat namespace, get the
+            # zip time directory from the stat structure
+            st_mtime = info.get("stat", "st_mtime")
+            # Otherwise, use the modified time from details namespace.
+            if st_mtime is None:
+                st_mtime = info.get("details", "modified")
+
+            # If st_mtime is still None this will default to current time
+            zip_time = time.localtime(st_mtime)[:6]  # type: ZipTime
 
             # NOTE(@althonos): typeshed's `zipfile.py` on declares
             #     ZipInfo.__init__ for Python < 3 ?!


### PR DESCRIPTION
This will check the `stat` and `details` namespaces before defaulting to the current time.

## Type of changes

- Bug fix

## Checklist

- [X] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [X] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

This addresses an issues where `write_zip()` assumed that the `details` namespace was always available. The `stat` namespace will be checked first, followed by `details`, and finally the current time will be used if `st_mtime` is still `None`.

I'm willing to author a test against this, but I'm only aware of this being an issue with the s3 filesystem (and only when it encounters a directory) and I'm not certain how best to test that here.
