### PR TITLE
Add `open_parent_fs()` method

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ Many thanks to the following developers for contributing to this project:
 - [Andrew Scheller](https://github.com/lurch)
 - [Andrey Serov](https://github.com/zmej-serow)
 - [Ben Lindsay](https://github.com/benlindsay)
+- [Bruno Grande](https://github.com/BrunoGrandePhD)
 - [Bernhard M. Wiedemann](https://github.com/bmwiedemann)
 - [@chfw](https://github.com/chfw)
 - [Dafna Hirschfeld](https://github.com/kamomil)

--- a/docs/source/openers.rst
+++ b/docs/source/openers.rst
@@ -52,10 +52,15 @@ Query strings are used to provide additional filesystem-specific information use
 Opening FS URLS
 ---------------
 
-To open a filesysem with a FS URL, you can use :meth:`~fs.opener.registry.Registry.open_fs`, which may be imported and used as follows::
+To open a filesystem with a FS URL referring to a directory, you can use :meth:`~fs.opener.registry.Registry.open_fs`, which may be imported and used as follows::
 
     from fs import open_fs
     projects_fs = open_fs('osfs://~/projects')
+
+To open a filesysem with a FS URL referring to a file, you can use :meth:`~fs.opener.registry.Registry.open_parent_fs`, which may be imported and used as follows::
+
+    from fs.opener import open_parent_fs
+    projects_fs, path = open_parent_fs('osfs://~/projects/test.txt')
 
 
 Manually registering Openers

--- a/fs/opener/__init__.py
+++ b/fs/opener/__init__.py
@@ -15,8 +15,17 @@ from .registry import registry
 
 # Alias functions defined as Registry methods
 open_fs = registry.open_fs
+open_parent_fs = registry.open_parent_fs
 open = registry.open
 manage_fs = registry.manage_fs
 
 # __all__ with aliases and classes
-__all__ = ["registry", "Opener", "open_fs", "open", "manage_fs", "parse"]
+__all__ = [
+    "registry",
+    "Opener",
+    "open_fs",
+    "open_parent_fs",
+    "open",
+    "manage_fs",
+    "parse",
+]

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -265,6 +265,13 @@ class TestOpeners(unittest.TestCase):
         mem_fs_2 = opener.open_fs(mem_fs)
         self.assertEqual(mem_fs, mem_fs_2)
 
+    def test_open_parent_fs(self):
+        mem_fs, path = opener.open_parent_fs("mem://dir/test.txt")
+        mem_fs.writetext(path, "foo")
+        contents = mem_fs.readtext(path)
+        self.assertEqual(path, "test.txt")
+        self.assertEqual(contents, "foo")
+
     @mock.patch("appdirs.{}".format(UserDataFS.app_dir), autospec=True, spec_set=True)
     def test_open_userdata(self, app_dir):
         app_dir.return_value = self.tmpdir


### PR DESCRIPTION
## Type of changes

- New feature
- Documentation / docstrings
- Tests

## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [x] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

One of my use cases for PyFileSystem2 is that I want to perform operations (read/write) on file URLs. Unfortunately, you can only use `open_fs()` with a directory URL. So, `open_parent_fs()` addresses this gap. I noticed the `open()` method, which has a similar return tuple, but based on my tests, it doesn't seem to work the same way. Feel free to tell me otherwise. 

Here's the docstring for the new `open_parent_fs()` method: 

> Open a filesystem for the top-most directory in a FS URL.
> 
> Compared to `~Registry.open_fs`, this function is useful for
> handling URLs that point to files instead of directories.
> 
> The top-most directory is used as the root of the file system
> because it doesn't assume that the intermediate directories
> exist at the time of creating the file system. The user can
> opt to run `~FS.makedirs` to "fill in" the directories prior
> to performing operations on the file indicated by the URL.
> 
> After determining the top-most directory, the remainder of the
> given FS URL is provided as the second return value as a path
> to be used in downstream FS operations.