### PR TITLE
tests: fix deprecated and removed aliases to assertEqual

### DIFF
--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -167,7 +167,7 @@ class TestMove(unittest.TestCase):
             self.assertFalse(src.exists("target.txt"))
             self.assertFalse(dst.exists("file.txt"))
             self.assertTrue(dst.exists("target.txt"))
-            self.assertEquals(dst.readtext("target.txt"), "source content")
+            self.assertEqual(dst.readtext("target.txt"), "source content")
 
     @parameterized.expand([("temp", "temp://"), ("mem", "mem://")])
     def test_move_file_overwrite_itself(self, _, fs_url):
@@ -177,7 +177,7 @@ class TestMove(unittest.TestCase):
             tmp.writetext("file.txt", "content")
             fs.move.move_file(tmp, "file.txt", tmp, "file.txt")
             self.assertTrue(tmp.exists("file.txt"))
-            self.assertEquals(tmp.readtext("file.txt"), "content")
+            self.assertEqual(tmp.readtext("file.txt"), "content")
 
     @parameterized.expand([("temp", "temp://"), ("mem", "mem://")])
     def test_move_file_overwrite_itself_relpath(self, _, fs_url):
@@ -188,7 +188,7 @@ class TestMove(unittest.TestCase):
             new_dir.writetext("file.txt", "content")
             fs.move.move_file(tmp, "dir/../dir/file.txt", tmp, "dir/file.txt")
             self.assertTrue(tmp.exists("dir/file.txt"))
-            self.assertEquals(tmp.readtext("dir/file.txt"), "content")
+            self.assertEqual(tmp.readtext("dir/file.txt"), "content")
 
     @parameterized.expand([(True,), (False,)])
     def test_move_file_cleanup_on_error(self, cleanup):


### PR DESCRIPTION
This file already uses the "correct" name a bunch of times. Both names have been around for the same amount of time but the version with an "s" at the end was deprecated in 3.2 and removed in 3.12.