### PR TITLE
tests: remove test that doesn't seem to make a lot of sense

### DIFF
--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -215,12 +215,6 @@ class TestOpeners(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
-    def test_repr(self):
-        # Check __repr__ works
-        for entry_point in pkg_resources.iter_entry_points("fs.opener"):
-            _opener = entry_point.load()
-            repr(_opener())
-
     def test_open_osfs(self):
         fs = opener.open_fs("osfs://.")
         self.assertIsInstance(fs, OSFS)


### PR DESCRIPTION
It claims to be testing that a `__repr__()` "works", but this doesn't make any sense as everything eventually gets one from `object()`. It also makes use of the deprecated pkg_resources interface, so simply ditch this code entirely.