### PR TITLE
drop the final remaining use of the deprecated pkg_resources module

### DIFF
--- a/fs/__init__.py
+++ b/fs/__init__.py
@@ -1,7 +1,7 @@
 """Python filesystem abstraction layer.
 """
 
-__import__("pkg_resources").declare_namespace(__name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 from . import path
 from ._fscompat import fsdecode, fsencode

--- a/fs/opener/__init__.py
+++ b/fs/opener/__init__.py
@@ -3,7 +3,7 @@
 """
 
 # Declare fs.opener as a namespace package
-__import__("pkg_resources").declare_namespace(__name__)  # type: ignore
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 # Import opener modules so that `registry.install` if called on each opener
 from . import appfs, ftpfs, memoryfs, osfs, tarfs, tempfs, zipfs

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ setup_requires =
     setuptools >=38.3.0
 install_requires =
     appdirs~=1.4.3
-    setuptools
+    setuptools          ; python_version < '3.8'
     six ~=1.10
     enum34 ~=1.1.6      ;  python_version < '3.4'
     typing ~=3.6        ;  python_version < '3.6'


### PR DESCRIPTION
Declaring a namespace package has gone through a few revisions. pkg_resources has a version that is heavily deprecated. pkgutil provides a python2/python3 compatible version that is also compatible with native python3 namespaces.

https://packaging.python.org/en/latest/guides/packaging-namespace-packages/

pkg_resources is very very deprecated and importing or using it results in deprecation warnings. It's time to move off of it entirely.

Fixes: https://github.com/PyFilesystem/pyfilesystem2/issues/577

Depends on: https://github.com/PyFilesystem/pyfilesystem2/pull/589