### PR TITLE
Update test compat with pyftpdlib>=1.5.10

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@
 
 # pyftpdlib is needed to spawn a FTP server for the
 # FTPFS test suite
-pyftpdlib ~=1.5
+pyftpdlib ~=1.5.10
 
 # these are optional dependencies for pyftpdlib that
 # are not explicitly listed, we need to install these

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -146,7 +146,7 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        from pyftpdlib.test import ThreadedTestFTPd
+        from pyftpdlib.test import FtpdThreadWrapper
 
         super(TestFTPFS, cls).setUpClass()
 
@@ -154,7 +154,7 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
         cls._temp_path = os.path.join(cls._temp_dir, text_type(uuid.uuid4()))
         os.mkdir(cls._temp_path)
 
-        cls.server = ThreadedTestFTPd()
+        cls.server = FtpThreadWrapper()
         cls.server.shutdown_after = -1
         cls.server.handler.authorizer = DummyAuthorizer()
         cls.server.handler.authorizer.add_user(


### PR DESCRIPTION
## Type of changes

- Bug fix

## Checklist

- [ ] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

The pyftpdlib library in version 1.5.10 renamed the `ThreadedTestFTPd` to `FtpdThreadWrapper`. I've updated that reference and ran the tests. I also updated the version requirement to my best knowledge.