### PR TITLE
Make tests compatible with pyftpdlib 2.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,14 +1,10 @@
 # the bare requirements for running tests
 
 # pyftpdlib is needed to spawn a FTP server for the
-# FTPFS test suite
-pyftpdlib ~=1.5
-
-# these are optional dependencies for pyftpdlib that
-# are not explicitly listed, we need to install these
-# ourselves
-psutil ~=5.0
-pysendfile ~=2.0 ; python_version <= "3.3"
+# FTPFS test suite; we import from pyftpdlib.test, so
+# we need (at least some of) pyftpdlib's test
+# dependencies
+pyftpdlib[test] ~=2.0
 
 # mock is only available from Python 3.3 onward, and 
 # mock v4+ doesn't support Python 2.7 anymore

--- a/tests/test_ftpfs.py
+++ b/tests/test_ftpfs.py
@@ -146,7 +146,7 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        from pyftpdlib.test import ThreadedTestFTPd
+        from pyftpdlib.test import FtpdThreadWrapper
 
         super(TestFTPFS, cls).setUpClass()
 
@@ -154,7 +154,7 @@ class TestFTPFS(FSTestCases, unittest.TestCase):
         cls._temp_path = os.path.join(cls._temp_dir, text_type(uuid.uuid4()))
         os.mkdir(cls._temp_path)
 
-        cls.server = ThreadedTestFTPd()
+        cls.server = FtpdThreadWrapper()
         cls.server.shutdown_after = -1
         cls.server.handler.authorizer = DummyAuthorizer()
         cls.server.handler.authorizer.add_user(
@@ -336,7 +336,7 @@ class TestAnonFTPFS(FSTestCases, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        from pyftpdlib.test import ThreadedTestFTPd
+        from pyftpdlib.test import FtpdThreadWrapper
 
         super(TestAnonFTPFS, cls).setUpClass()
 
@@ -344,7 +344,7 @@ class TestAnonFTPFS(FSTestCases, unittest.TestCase):
         cls._temp_path = os.path.join(cls._temp_dir, text_type(uuid.uuid4()))
         os.mkdir(cls._temp_path)
 
-        cls.server = ThreadedTestFTPd()
+        cls.server = FtpdThreadWrapper()
         cls.server.shutdown_after = -1
         cls.server.handler.authorizer = DummyAuthorizer()
         cls.server.handler.authorizer.add_anonymous(cls._temp_path, perm="elradfmw")


### PR DESCRIPTION
## Type of changes

<!-- Remove unrelated categories -->

- Tests
## Checklist

- [x] I've run the latest [black](https://github.com/ambv/black) with default args on new code.
- [x] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate. **Is this needed?**
- [x] I've added tests for new code. **N/A, testing fixes**
- [x] I accept that @PyFilesystem/maintainers may be pedantic in the code review.

## Description

Inspired by @mweinelt via https://github.com/PyFilesystem/pyfilesystem2/pull/591.

- Updates the `pyftpdlib` test dependency from `~=1.5` to `~=2.0`
- Uses `pyftpdlib`’s `test` extra (introduced in 2.0) to bring in dependencies for `pyftpdlib.test`, rather than naming them and maintaining their version bounds manually.
- Follow the renaming of `ThreadedTestFTPd` to `FtpdThreadWrapper`

----

I tested this locally in a Python 3.13 virtualenv, first applying https://github.com/PyFilesystem/pyfilesystem2/pull/570 and https://github.com/PyFilesystem/pyfilesystem2/pull/587. I do find that I can sometimes get all the tests to pass, but there are almost always some flaky failures where it seems like the test FTP server is not ready, like:

```
====================================== short test summary info =======================================
FAILED tests/test_ftpfs.py::TestFTPFS::test_download_4 - fs.errors.RemoteConnectionError: unable to connect to 127.0.0.1
FAILED tests/test_ftpfs.py::TestFTPFSNoMLSD::test_download_0 - fs.errors.RemoteConnectionError: unable to connect to 127.0.0.1
====================== 2 failed, 2652 passed, 26 skipped, 46 warnings in 38.61s ======================
```

I have not tried to understand or fix that.