### PR TITLE
fix: carry filesize suffix when mantissa rounds up to base

### DIFF
--- a/fs/filesize.py
+++ b/fs/filesize.py
@@ -33,12 +33,20 @@ def _to_str(size, suffixes, base):
     elif size < base:
         return "{:,} bytes".format(size)
 
-    # TODO (dargueta): Don't rely on unit or suffix being defined in the loop.
+    suffixes = list(suffixes)
     for i, suffix in enumerate(suffixes, 2):  # noqa: B007
         unit = base**i
         if size < unit:
             break
-    return "{:,.1f} {}".format((base * size / unit), suffix)
+
+    mantissa = base * size / unit
+    # Rounding can push the mantissa to `base` (e.g. 999,999 B is 999.999 kB,
+    # which formats as "1,000.0 kB"). Carry into the next suffix instead.
+    if round(mantissa, 1) >= base and i - 1 < len(suffixes):
+        suffix = suffixes[i - 1]
+        mantissa = size / unit
+
+    return "{:,.1f} {}".format(mantissa, suffix)
 
 
 def traditional(size):

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -60,6 +60,15 @@ class TestFilesize(unittest.TestCase):
         self.assertEqual(filesize.binary(1024**2 - 1), "1.0 MiB")
         self.assertEqual(filesize.binary(1024**3 - 1), "1.0 GiB")
 
+    def test_rounding_boundaries(self):
+        # Within-unit rounding boundaries (no suffix change), per review on #600
+        self.assertEqual(filesize.traditional(1996), "1.9 KB")
+        self.assertEqual(filesize.traditional(1997), "2.0 KB")
+        self.assertEqual(filesize.decimal(1950), "1.9 kB")
+        self.assertEqual(filesize.decimal(1951), "2.0 kB")
+        self.assertEqual(filesize.binary(1996), "1.9 KiB")
+        self.assertEqual(filesize.binary(1997), "2.0 KiB")
+
     def test_errors(self):
 
         with self.assertRaises(TypeError):

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -45,6 +45,21 @@ class TestFilesize(unittest.TestCase):
 
         self.assertEqual(filesize.decimal(1200 * 1000), "1.2 MB")
 
+    def test_rollover_decimal(self):
+        # Mantissa rounds up to base — must carry to the next suffix
+        self.assertEqual(filesize.decimal(999_999), "1.0 MB")
+        self.assertEqual(filesize.decimal(999_999_999), "1.0 GB")
+        self.assertEqual(filesize.decimal(999_999_999_999), "1.0 TB")
+
+    def test_rollover_traditional(self):
+        # 1024**2 - 1 bytes is 1023.999 KB, which rounds to 1,024.0 KB
+        self.assertEqual(filesize.traditional(1024**2 - 1), "1.0 MB")
+        self.assertEqual(filesize.traditional(1024**3 - 1), "1.0 GB")
+
+    def test_rollover_binary(self):
+        self.assertEqual(filesize.binary(1024**2 - 1), "1.0 MiB")
+        self.assertEqual(filesize.binary(1024**3 - 1), "1.0 GiB")
+
     def test_errors(self):
 
         with self.assertRaises(TypeError):

--- a/tests/test_filesize.py
+++ b/tests/test_filesize.py
@@ -46,17 +46,26 @@ class TestFilesize(unittest.TestCase):
         self.assertEqual(filesize.decimal(1200 * 1000), "1.2 MB")
 
     def test_rollover_decimal(self):
+        # First value whose mantissa rounds up to base — the carry boundary
+        self.assertEqual(filesize.decimal(999_949), "999.9 kB")
+        self.assertEqual(filesize.decimal(999_950), "1.0 MB")
         # Mantissa rounds up to base — must carry to the next suffix
         self.assertEqual(filesize.decimal(999_999), "1.0 MB")
         self.assertEqual(filesize.decimal(999_999_999), "1.0 GB")
         self.assertEqual(filesize.decimal(999_999_999_999), "1.0 TB")
 
     def test_rollover_traditional(self):
+        # First-flip carry boundary: 1,023.95 KB rounds up to 1,024.0 KB -> 1.0 MB
+        self.assertEqual(filesize.traditional(1_048_524), "1,023.9 KB")
+        self.assertEqual(filesize.traditional(1_048_525), "1.0 MB")
         # 1024**2 - 1 bytes is 1023.999 KB, which rounds to 1,024.0 KB
         self.assertEqual(filesize.traditional(1024**2 - 1), "1.0 MB")
         self.assertEqual(filesize.traditional(1024**3 - 1), "1.0 GB")
 
     def test_rollover_binary(self):
+        # First-flip carry boundary: 1,023.95 KiB rounds up to 1,024.0 KiB -> 1.0 MiB
+        self.assertEqual(filesize.binary(1_048_524), "1,023.9 KiB")
+        self.assertEqual(filesize.binary(1_048_525), "1.0 MiB")
         self.assertEqual(filesize.binary(1024**2 - 1), "1.0 MiB")
         self.assertEqual(filesize.binary(1024**3 - 1), "1.0 GiB")
 


### PR DESCRIPTION
## Problem

All three public functions (`traditional`, `binary`, `decimal`) can produce impossible output like `"1,024.0 KB"` instead of `"1.0 MB"` for values just below a unit boundary.

Root cause: `_to_str` picks the suffix from the *unrounded* value, then formats the mantissa — which can round up to `base`, producing an impossible result.

```python
filesize.decimal(999_999)        # '1,000.0 kB'  ← should be '1.0 MB'
filesize.traditional(1024**2-1)  # '1,024.0 KB'  ← should be '1.0 MB'
filesize.binary(1024**2-1)       # '1,024.0 KiB' ← should be '1.0 MiB'
```

## Fix

Convert `suffixes` to a list before the loop. After computing the mantissa, round and compare against `base`. If the rounded value hits `base`, step up one suffix and recompute:

```python
mantissa = base * size / unit
if round(mantissa, 1) >= base and i - 1 < len(suffixes):
    suffix = suffixes[i - 1]
    mantissa = size / unit
```

Math: when the current unit is `base**i`, dividing `size` by that same `unit` gives the value in the next suffix (whose denominator is `base**(i+1)`, which divides into `base * size / base**(i+1) = size / base**i = size / unit`).

Also removes the existing TODO comment that flagged this exact issue.

## Tests

Added `test_rollover_decimal`, `test_rollover_traditional`, and `test_rollover_binary` covering the unit boundaries for all three functions.